### PR TITLE
Improve Docker build and compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+_site
+.git

--- a/.portainer/Dockerfile
+++ b/.portainer/Dockerfile
@@ -1,3 +1,12 @@
+# Build stage
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npx @11ty/eleventy
+
+# Runtime stage
 FROM nginx:stable-alpine
-COPY _site/ /usr/share/nginx/html/
+COPY --from=builder /app/_site/ /usr/share/nginx/html/
 COPY .portainer/nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  effusion-labs:
+    image: ghcr.io/toxicwind/effusion-labs:latest
+    container_name: effusion
+    restart: unless-stopped
+    ports:
+      - "18400:80"


### PR DESCRIPTION
## Summary
- add docker-compose setup for running the published image
- update the Dockerfile used by CI to build the site within the container
- ignore build output and git folder during Docker builds

## Testing
- `npm install`
- `npx @11ty/eleventy`
- `npm test` *(fails: Error: no test specified)*
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f1bea8248330ab643a98c5f4ff3a