### PR TITLE
Refactor Eleventy config into modules

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,258 +1,34 @@
-const fs = require('fs');
-const { DateTime } = require('luxon');
-
-const interlinker = require('@photogabble/eleventy-plugin-interlinker');
-const navigation = require('@11ty/eleventy-navigation');
-const tailwind = require('eleventy-plugin-tailwindcss-4');
 const markdownItFootnote = require('markdown-it-footnote');
 const markdownItAttrs = require('markdown-it-attrs');
 
-/* ── Enhanced Footnote System ──────────────────────────────────────────────── */
-
-function hybridFootnoteDefinitions(md) {
-  // Store original renderers instead of nullifying them
-  const originalFootnoteOpen = md.renderer.rules.footnote_open || function(tokens, idx, options, env, slf) {
-    let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
-    if (tokens[idx].meta.subId > 0) id += `:${tokens[idx].meta.subId}`;
-    return `<li id="fn${id}" class="footnote-item">`;
-  };
-
-  const originalFootnoteClose = md.renderer.rules.footnote_close || function() {
-    return '</li>\n';
-  };
-
-  const originalFootnoteAnchor = md.renderer.rules.footnote_anchor || function(tokens, idx, options, env, slf) {
-    let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
-    if (tokens[idx].meta.subId > 0) id += `:${tokens[idx].meta.subId}`;
-    return ` <a href="#fnref${id}" class="footnote-backref">\u21a9\uFE0E</a>`;
-  };
-
-  // Override footnote definition rendering for local display
-  md.renderer.rules.footnote_reference_open = (tokens, idx, _opts, env) => {
-    const label = tokens[idx].meta?.label;
-    const id = label && env.footnotes?.refs?.hasOwnProperty(':' + label)
-      ? env.footnotes.refs[':' + label]
-      : 0;
-    const n = id + 1;
-    env.__currentFootnoteId = n;
-
-    // Create local footnote container
-    return `<div id="fn${n}" class="footnote-local"><div class="footnote-content">`;
-  };
-
-  md.renderer.rules.footnote_reference_close = (_t, _i, _o, env) =>
-    `</div> <a href="#fnref${env.__currentFootnoteId}" class="footnote-backref">↩︎</a></div>\n`;
-
-  // Preserve block structure but modify for hybrid display
-  md.renderer.rules.footnote_block_open = () => '<section class="footnotes-hybrid">\n';
-  md.renderer.rules.footnote_block_close = () => '</section>\n';
-
-  // Use original renderers for standard footnote items with enhanced styling
-  md.renderer.rules.footnote_open = function(tokens, idx, options, env, slf) {
-    const original = originalFootnoteOpen(tokens, idx, options, env, slf);
-    return original.replace('class="footnote-item"', 'class="footnote-item footnote-enhanced"');
-  };
-
-  md.renderer.rules.footnote_close = originalFootnoteClose;
-  md.renderer.rules.footnote_anchor = originalFootnoteAnchor;
-
-  // Postprocess content: detect "Source:" and auto-split
-  const originalRender = md.renderer.render.bind(md.renderer);
-  md.renderer.render = function(tokens, options, env) {
-    let html = originalRender(tokens, options, env);
-    
-    // Auto-split "Source:" in footnote content
-    html = html.replace(
-      /(<div class="footnote-content">[\s\S]*?)<p>\s*Source:/g,
-      '$1<p class="footnote-source">Source:'
-    );
-    
-    return html;
-  };
-}
-
-function footnotePopover(md) {
-  // Store the original footnote_ref renderer from markdown-it-footnote
-  const originalFootnoteRef = md.renderer.rules.footnote_ref;
-  
-  if (!originalFootnoteRef) {
-    console.warn('footnotePopover: No original footnote_ref renderer found');
-    return;
-  }
-
-  // Enhance the original renderer with popover functionality
-  md.renderer.rules.footnote_ref = function(tokens, idx, options, env, self) {
-    const { id, label = "" } = tokens[idx].meta || {};
-    const list = env.footnotes && env.footnotes.list;
-    
-    // If no footnote content available for popover, use original renderer
-    if (!Array.isArray(list) || !list[id]?.tokens) {
-      return originalFootnoteRef(tokens, idx, options, env, self);
-    }
-
-    const n = id + 1;
-    let defHtml = '';
-    
-    // Render footnote content for popover
-    try {
-      defHtml = md.renderer.render(list[id].tokens, options, env).trim();
-      // Clean up the HTML for popover display
-      defHtml = defHtml.replace(/<\/?p>/g, ''); // Remove paragraph tags for inline display
-    } catch (e) {
-      // Fallback to original renderer on error
-      return originalFootnoteRef(tokens, idx, options, env, self);
-    }
-
-    const refId = `fn${n}`;
-
-    return `<sup class="annotation-ref${label ? " " + label : ""}">
-      <a href="#fn${n}" id="fnref${n}" 
-         class="annotation-anchor"
-         aria-describedby="popup-${refId}">[${n}]</a>
-      <span id="popup-${refId}" role="tooltip" class="annotation-popup">${defHtml}</span>
-    </sup>`;
-  };
-}
-
-/* ── Inline Macro Extensions ───────────────────────────────────────────────── */
-
-const inlineMacro = (name, after, toHtml) => md => {
-  md.inline.ruler.after(after, name, (state, silent) => {
-    const m = state.src.slice(state.pos).match(new RegExp(`^@${name}\\(([^)]+)\\)`));
-    if (!m) return false;
-    if (!silent) state.push({ type: 'html_inline', content: toHtml(m[1]) });
-    state.pos += m[0].length;
-    return true;
-  });
-};
-
-const audioEmbed = inlineMacro('audio', 'emphasis', src => 
-  `<audio controls class="audio-embed" src="${src}"></audio>`
-);
-
-const qrEmbed = inlineMacro('qr', 'audio', s => {
-  const src = encodeURIComponent(s);
-  return `<img class="qr-code" src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${src}" alt="QR code">`;
-});
-
-function externalLinks(md) {
-  const base = md.renderer.rules.link_open ||
-    ((t, i, o, e, s) => s.renderToken(t, i, o));
-  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-    tokens[idx].attrJoin('class', 'external-link');
-    const nxt = tokens[idx + 1];
-    if (nxt?.type === 'text') nxt.content = '↗ source';
-    return base(tokens, idx, options, env, self);
-  };
-}
-
-const mdItExtensions = [
-  hybridFootnoteDefinitions,
-  footnotePopover,
-  audioEmbed,
-  qrEmbed,
-  externalLinks
-];
-
-/* ── Filters ───────────────────────────────────────────────────────────────── */
-
-const ord = n =>
-  n % 100 >= 11 && n % 100 <= 13 ? 'th' : ['th','st','nd','rd'][n%10] || 'th';
-
-const filters = {
-  readableDate: (d, zone='utc') => {
-    if (!(d instanceof Date)) return '';
-    const dt = DateTime.fromJSDate(d, { zone });
-    return `${dt.toFormat('MMMM d')}${ord(dt.day)}, ${dt.toFormat('yyyy')}`;
-  },
-  htmlDateString: d =>
-    d instanceof Date ? DateTime.fromJSDate(d, { zone:'utc' }).toFormat('yyyy-MM-dd') : '',
-  limit: (arr=[], n=5) => Array.isArray(arr) ? arr.slice(0, n) : [],
-  jsonify: data => {
-    if (!Array.isArray(data)) return '[]';
-    return JSON.stringify(data.map(page => {
-      const p = page?.inputPath; if (!p) return null;
-      let raw; 
-      try { 
-        raw = fs.readFileSync(p,'utf8'); 
-      } catch { 
-        raw = `Error loading ${p}`; 
-      }
-      return { 
-        url: page.url, 
-        fileSlug: page.fileSlug, 
-        inputContent: raw, 
-        data: { 
-          title: page.data?.title || '', 
-          aliases: page.data?.aliases || [] 
-        } 
-      };
-    }).filter(Boolean));
-  }
-};
-
-/* ── Collections / paths ───────────────────────────────────────────────────── */
+const getPlugins = require('./lib/plugins');
+const filters = require('./lib/filters');
+const { mdItExtensions } = require('./lib/markdown-extensions');
 
 const baseContent = 'src/content';
 const areas = ['sparks','concepts','projects','meta'];
 const glob = d => `${baseContent}/${d}/**/*.md`;
 
-/* ── Shortcodes ────────────────────────────────────────────────────────────── */
-
 function specnote(variant, content, tooltip) {
-  const cls = { 
-    soft: 'spec-note-soft', 
-    subtle: 'spec-note-subtle', 
-    liminal: 'spec-note-liminal', 
-    archival: 'spec-note-archival', 
-    ghost: 'spec-note-ghost' 
+  const cls = {
+    soft: 'spec-note-soft',
+    subtle: 'spec-note-subtle',
+    liminal: 'spec-note-liminal',
+    archival: 'spec-note-archival',
+    ghost: 'spec-note-ghost'
   }[variant] || 'spec-note-soft';
-  
+
   const safeTooltip = tooltip?.replace(/"/g,'&quot;') || '';
   return `<span class="${cls}" title="${safeTooltip}">${content}</span>`;
 }
 
-/* ── Eleventy Configuration ────────────────────────────────────────────────── */
-
 module.exports = function(eleventyConfig) {
-  // Plugin Configuration
-  const plugins = [
-    [ 
-      interlinker, 
-      { 
-        defaultLayout: 'layouts/embed.njk', 
-        resolvingFns: new Map([
-          ['default', link => { 
-            const href = link.href || link.link; 
-            const label = link.title || link.name; 
-            return `<a class="interlink" href="${href}">${label}</a>`;
-          }]
-        ]) 
-      } 
-    ],
-    [ navigation ],
-    [ 
-      tailwind, 
-      { 
-        input: 'assets/css/tailwind.css', 
-        output: 'assets/main.css', 
-        minify: true 
-      } 
-    ]
-  ];
-
+  const plugins = getPlugins();
   plugins.forEach(([plugin, opts = {}]) => eleventyConfig.addPlugin(plugin, opts));
 
-  // Markdown Configuration with Enhanced Footnotes
   eleventyConfig.amendLibrary('md', md => {
-    // Apply standard markdown-it plugins first
     md.use(markdownItFootnote);
     md.use(markdownItAttrs);
-    
-    // CRITICAL: Don't disable footnote_tail - it's essential for footnote processing
-    // The original issue was caused by: md.core.ruler.disable('footnote_tail');
-    
-    // Apply our enhanced footnote extensions
     mdItExtensions.forEach(fn => {
       try {
         fn(md);
@@ -260,53 +36,43 @@ module.exports = function(eleventyConfig) {
         console.error(`Error applying markdown extension: ${error.message}`);
       }
     });
-    
     return md;
   });
 
-  // Filter Registration
   Object.entries(filters).forEach(([key, value]) => {
     eleventyConfig.addFilter(key, value);
   });
 
-  // Collection Configuration
   areas.forEach(name => {
     eleventyConfig.addCollection(name, api => api.getFilteredByGlob(glob(name)));
   });
-  
-  eleventyConfig.addCollection('nodes', api => 
+  eleventyConfig.addCollection('nodes', api =>
     api.getFilteredByGlob(areas.map(glob))
   );
 
-  // Asset and File Handling
   eleventyConfig.addPassthroughCopy('src/assets');
   eleventyConfig.addPassthroughCopy({ 'src/favicon.ico': 'favicon.ico' });
 
-  // Browser Sync Configuration
-  eleventyConfig.setBrowserSyncConfig({ 
-    index: 'index.html', 
-    server: { baseDir: '_site' } 
+  eleventyConfig.setBrowserSyncConfig({
+    index: 'index.html',
+    server: { baseDir: '_site' }
   });
 
-  // Shortcode Registration
   eleventyConfig.addShortcode('specnote', specnote);
 
-  // Error Handling for Development
   eleventyConfig.on('eleventy.before', () => {
     console.log('🚀 Eleventy build starting with enhanced footnote system...');
   });
-
   eleventyConfig.on('eleventy.after', ({ results }) => {
     console.log(`✅ Eleventy build completed. Generated ${results.length} files.`);
   });
 
-  // Return Configuration Object
   return {
-    dir: { 
-      input: 'src', 
-      output: '_site', 
-      includes: '_includes', 
-      data: '_data' 
+    dir: {
+      input: 'src',
+      output: '_site',
+      includes: '_includes',
+      data: '_data'
     },
     markdownTemplateEngine: 'njk',
     htmlTemplateEngine: 'njk',

--- a/ARACA_REPORT_20250731-020453.md
+++ b/ARACA_REPORT_20250731-020453.md
@@ -1,0 +1,39 @@
+# ARACA Report (2025-07-31T02:04:53Z)
+
+## Objectives and Constraints
+- Perform structural improvements without replacing Eleventy, Nunjucks or Tailwind.
+- Reduce redundancy and clarify boundaries across the codebase.
+- Provide deterministic validation via tests.
+
+## Inventory of Changes
+- `lib/filters.js` – standalone utilities for date and collection formatting.
+- `lib/markdown-extensions.js` – modular markdown-it enhancements for footnotes and embeds.
+- `lib/plugins.js` – centralised Eleventy plugin configuration.
+- `.eleventy.js` – simplified by consuming the above modules.
+- `README.md` – updated snippet showing new configuration pattern.
+- `test/filters.test.js` – minimal Node.js test suite exercising filter behaviour.
+- `package.json` – `test` script uses Node's built‑in runner.
+
+## Refactor Summary
+- **Modularisation**: extracted large inline sections from `.eleventy.js` into focused modules for plugins, filters and markdown extensions.
+- **Configuration hygiene**: consolidated plugin setup via `getPlugins()` and registered filters programmatically.
+- **Type strengthening**: added JSDoc comments describing parameters and return values for exported utilities.
+- **Testing**: introduced `node:test` based checks ensuring filters behave deterministically.
+
+## Validation Results
+- `npm install` completed successfully.
+- `npm test` – all 4 tests pass.
+
+## Performance / Footprint
+- No runtime dependencies added; tests use existing packages only.
+
+## Citations
+- Filters module implementation【F:lib/filters.js†L1-L65】
+- Markdown extension module implementation【F:lib/markdown-extensions.js†L1-L40】
+- Plugin configuration module implementation【F:lib/plugins.js†L1-L36】
+- Updated Eleventy configuration utilising modules【F:.eleventy.js†L1-L40】
+- README excerpt showing new configuration usage【F:README.md†L60-L72】
+
+## Next Steps
+- Expand test coverage for remaining utilities and shortcodes.
+- Consider linting (ESLint) and formatting to ensure consistent style across modules.

--- a/README.md
+++ b/README.md
@@ -57,18 +57,12 @@ The bundled `nginx.conf` serves static assets with cache headers and falls back 
 Key customisation is in `.eleventy.js`:
 
 ```js
-const interlinker = require("@photogabble/eleventy-plugin-interlinker");
-const navigation  = require("@11ty/eleventy-navigation");
-const tailwind    = require("eleventy-plugin-tailwindcss-4");
+const getPlugins = require("./lib/plugins");
+const filters    = require("./lib/filters");
 
 module.exports = eleventyConfig => {
-  eleventyConfig.addPlugin(interlinker, { defaultLayout: "layouts/embed.njk" });
-  eleventyConfig.addPlugin(navigation);
-  eleventyConfig.addPlugin(tailwind, {
-    input : "assets/css/tailwind.css",
-    output: "assets/main.css",
-    minify: true
-  });
+  getPlugins().forEach(([plugin, opts]) => eleventyConfig.addPlugin(plugin, opts));
+  Object.entries(filters).forEach(([name, fn]) => eleventyConfig.addFilter(name, fn));
 
   ["sparks", "concepts", "projects", "meta"].forEach(group =>
     eleventyConfig.addCollection(group, api =>

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const { DateTime } = require('luxon');
+
+/** Append ordinal suffix to a given day number */
+const ord = n => (n % 100 >= 11 && n % 100 <= 13 ? 'th' : ['th','st','nd','rd'][n%10] || 'th');
+
+/**
+ * Format a Date into a human readable string.
+ * @param {Date} d
+ * @param {string} [zone='utc'] - timezone identifier
+ * @returns {string}
+ */
+function readableDate(d, zone = 'utc') {
+  if (!(d instanceof Date)) return '';
+  const dt = DateTime.fromJSDate(d, { zone });
+  return `${dt.toFormat('MMMM d')}${ord(dt.day)}, ${dt.toFormat('yyyy')}`;
+}
+
+/**
+ * Return a date formatted for HTML date attributes.
+ * @param {Date} d
+ * @returns {string}
+ */
+function htmlDateString(d) {
+  return d instanceof Date ? DateTime.fromJSDate(d, { zone: 'utc' }).toFormat('yyyy-MM-dd') : '';
+}
+
+/** Limit an array to n items */
+function limit(arr = [], n = 5) {
+  return Array.isArray(arr) ? arr.slice(0, n) : [];
+}
+
+/**
+ * Serialize collection data for graph visualisation.
+ * @param {Array<Object>} data - eleventy page objects
+ * @returns {string}
+ */
+function jsonify(data) {
+  if (!Array.isArray(data)) return '[]';
+  return JSON.stringify(
+    data
+      .map(page => {
+        const p = page?.inputPath;
+        if (!p) return null;
+        let raw;
+        try {
+          raw = fs.readFileSync(p, 'utf8');
+        } catch {
+          raw = `Error loading ${p}`;
+        }
+        return {
+          url: page.url,
+          fileSlug: page.fileSlug,
+          inputContent: raw,
+          data: {
+            title: page.data?.title || '',
+            aliases: page.data?.aliases || []
+          }
+        };
+      })
+      .filter(Boolean)
+  );
+}
+
+module.exports = { readableDate, htmlDateString, limit, jsonify };

--- a/lib/markdown-extensions.js
+++ b/lib/markdown-extensions.js
@@ -1,0 +1,132 @@
+// Custom markdown-it extensions used by Eleventy
+/**
+ * Collection of markdown-it extension functions for footnotes, embeds and links.
+ * @module markdownExtensions
+ */
+
+/**
+ * Enhance the default footnote output to support local display and hybrid blocks.
+ * @param {import('markdown-it')} md - markdown-it instance to mutate
+ */
+function hybridFootnoteDefinitions(md) {
+  const originalFootnoteOpen = md.renderer.rules.footnote_open || function(tokens, idx, options, env, slf) {
+    let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
+    if (tokens[idx].meta.subId > 0) id += `:${tokens[idx].meta.subId}`;
+    return `<li id="fn${id}" class="footnote-item">`;
+  };
+
+  const originalFootnoteClose = md.renderer.rules.footnote_close || function() {
+    return '</li>\n';
+  };
+
+  const originalFootnoteAnchor = md.renderer.rules.footnote_anchor || function(tokens, idx, options, env, slf) {
+    let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
+    if (tokens[idx].meta.subId > 0) id += `:${tokens[idx].meta.subId}`;
+    return ` <a href="#fnref${id}" class="footnote-backref">\u21a9\uFE0E</a>`;
+  };
+
+  md.renderer.rules.footnote_reference_open = (tokens, idx, _opts, env) => {
+    const label = tokens[idx].meta?.label;
+    const id = label && env.footnotes?.refs?.hasOwnProperty(':' + label)
+      ? env.footnotes.refs[':' + label]
+      : 0;
+    const n = id + 1;
+    env.__currentFootnoteId = n;
+    return `<div id="fn${n}" class="footnote-local"><div class="footnote-content">`;
+  };
+
+  md.renderer.rules.footnote_reference_close = (_t, _i, _o, env) =>
+    `</div> <a href="#fnref${env.__currentFootnoteId}" class="footnote-backref">↩︎</a></div>\n`;
+
+  md.renderer.rules.footnote_block_open = () => '<section class="footnotes-hybrid">\n';
+  md.renderer.rules.footnote_block_close = () => '</section>\n';
+
+  md.renderer.rules.footnote_open = function(tokens, idx, options, env, slf) {
+    const original = originalFootnoteOpen(tokens, idx, options, env, slf);
+    return original.replace('class="footnote-item"', 'class="footnote-item footnote-enhanced"');
+  };
+
+  md.renderer.rules.footnote_close = originalFootnoteClose;
+  md.renderer.rules.footnote_anchor = originalFootnoteAnchor;
+
+  const originalRender = md.renderer.render.bind(md.renderer);
+  md.renderer.render = function(tokens, options, env) {
+    let html = originalRender(tokens, options, env);
+    html = html.replace(/(<div class="footnote-content">[\s\S]*?)<p>\s*Source:/g, '$1<p class="footnote-source">Source:');
+    return html;
+  };
+}
+
+/**
+ * Replace footnote references with popover-enabled anchors.
+ * @param {import('markdown-it')} md - markdown-it instance to mutate
+ */
+function footnotePopover(md) {
+  const originalFootnoteRef = md.renderer.rules.footnote_ref;
+  if (!originalFootnoteRef) return;
+
+  md.renderer.rules.footnote_ref = function(tokens, idx, options, env, self) {
+    const { id, label = '' } = tokens[idx].meta || {};
+    const list = env.footnotes && env.footnotes.list;
+    if (!Array.isArray(list) || !list[id]?.tokens) {
+      return originalFootnoteRef(tokens, idx, options, env, self);
+    }
+
+    const n = id + 1;
+    let defHtml = '';
+    try {
+      defHtml = md.renderer.render(list[id].tokens, options, env).trim();
+      defHtml = defHtml.replace(/<\/?p>/g, '');
+    } catch {
+      return originalFootnoteRef(tokens, idx, options, env, self);
+    }
+    const refId = `fn${n}`;
+    return `<sup class="annotation-ref${label ? ' ' + label : ''}">` +
+           `<a href="#fn${n}" id="fnref${n}" class="annotation-anchor" aria-describedby="popup-${refId}">[${n}]</a>` +
+           `<span id="popup-${refId}" role="tooltip" class="annotation-popup">${defHtml}</span>` +
+           `</sup>`;
+  };
+}
+
+/**
+ * Helper to define simple inline macros.
+ * @param {string} name - macro name
+ * @param {string} after - rule to insert after
+ * @param {(value:string)=>string} toHtml - HTML generator
+ */
+const inlineMacro = (name, after, toHtml) => md => {
+  md.inline.ruler.after(after, name, (state, silent) => {
+    const m = state.src.slice(state.pos).match(new RegExp(`^@${name}\\(([^)]+)\\)`));
+    if (!m) return false;
+    if (!silent) state.push({ type: 'html_inline', content: toHtml(m[1]) });
+    state.pos += m[0].length;
+    return true;
+  });
+};
+
+/** Inline audio embedding macro */
+const audioEmbed = inlineMacro('audio', 'emphasis', src => `<audio controls class="audio-embed" src="${src}"></audio>`);
+
+/** Inline QR-code embedding macro */
+const qrEmbed = inlineMacro('qr', 'audio', s => {
+  const src = encodeURIComponent(s);
+  return `<img class="qr-code" src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${src}" alt="QR code">`;
+});
+
+/**
+ * Add an external-link class and arrow to outbound links.
+ * @param {import('markdown-it')} md - markdown-it instance
+ */
+function externalLinks(md) {
+  const base = md.renderer.rules.link_open || ((t, i, o, e, s) => s.renderToken(t, i, o));
+  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    tokens[idx].attrJoin('class', 'external-link');
+    const nxt = tokens[idx + 1];
+    if (nxt?.type === 'text') nxt.content = '↗ source';
+    return base(tokens, idx, options, env, self);
+  };
+}
+
+const mdItExtensions = [hybridFootnoteDefinitions, footnotePopover, audioEmbed, qrEmbed, externalLinks];
+
+module.exports = { hybridFootnoteDefinitions, footnotePopover, audioEmbed, qrEmbed, externalLinks, mdItExtensions };

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,0 +1,36 @@
+const interlinker = require('@photogabble/eleventy-plugin-interlinker');
+const navigation = require('@11ty/eleventy-navigation');
+const tailwind = require('eleventy-plugin-tailwindcss-4');
+
+/**
+ * Return the plugin configuration list for Eleventy.
+ * Each item is `[plugin, options]`.
+ */
+function getPlugins() {
+  return [
+    [
+      interlinker,
+      {
+        defaultLayout: 'layouts/embed.njk',
+        resolvingFns: new Map([
+          ['default', link => {
+            const href = link.href || link.link;
+            const label = link.title || link.name;
+            return `<a class="interlink" href="${href}">${label}</a>`;
+          }]
+        ])
+      }
+    ],
+    [navigation],
+    [
+      tailwind,
+      {
+        input: 'assets/css/tailwind.css',
+        output: 'assets/main.css',
+        minify: true
+      }
+    ]
+  ];
+}
+
+module.exports = getPlugins;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is a digital studio and knowledge base for Effusion Labs, built with Eleventy and the powerful `@photogabble/eleventy-plugin-interlinker`.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -1,0 +1,29 @@
+const { readableDate, htmlDateString, limit, jsonify } = require('../lib/filters');
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+test('readableDate formats correctly', () => {
+  const date = new Date('2023-01-15T00:00:00Z');
+  assert.strictEqual(readableDate(date), 'January 15th, 2023');
+});
+
+test('htmlDateString formats correctly', () => {
+  const date = new Date('2023-01-15T00:00:00Z');
+  assert.strictEqual(htmlDateString(date), '2023-01-15');
+});
+
+test('limit returns subset', () => {
+  assert.deepStrictEqual(limit([1,2,3,4],2), [1,2]);
+});
+
+test('jsonify serializes pages', () => {
+  const fake = [{
+    url: '/x',
+    fileSlug: 'x',
+    inputPath: __filename,
+    data: { title: 'X', aliases: [] }
+  }];
+  const json = JSON.parse(jsonify(fake));
+  assert.strictEqual(json[0].url, '/x');
+  assert.ok(json[0].inputContent.includes('jsonify'));
+});


### PR DESCRIPTION
## Summary
- split filters, plugins, and markdown extensions into `lib/` modules
- simplify `.eleventy.js` to consume new modules
- update README configuration example
- add node-based tests for filters
- document changes in ARACA report

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ace6214a8833084278973af9aacb1