### PR TITLE
Add syntax highlighting and sitemap plugins

### DIFF
--- a/ARACA_REPORT_20250731-032950.md
+++ b/ARACA_REPORT_20250731-032950.md
@@ -1,0 +1,27 @@
+# ARACA Report (2025-07-31T03:29:50Z)
+
+## Objectives and Constraints
+- Introduce emergent improvements while keeping Eleventy, Nunjucks and Tailwind.
+- Maintain modular structure and run existing tests.
+
+## Summary of Changes
+- Added syntax highlighting via `@11ty/eleventy-plugin-syntaxhighlight` and imported its CSS.
+- Integrated `@quasibit/eleventy-plugin-sitemap` to generate `/sitemap.xml`.
+- Implemented new `slugify` filter with unit tests.
+- Updated README with new plugin information and sitemap section.
+
+## Validation Results
+- `npm install` succeeded with no vulnerabilities.
+- `npm test` ran 6 passing tests.
+
+## Files Touched
+- `lib/plugins.js` – registered new plugins.
+- `lib/filters.js` – added `slugify`.
+- `test/filters.test.js` – tests for new filter.
+- `src/assets/css/tailwind.css` – imported Prism theme.
+- `package.json`, `package-lock.json` – dependency updates.
+- `README.md` – documented new features.
+
+## Next Steps
+- Review sitemap output for completeness.
+- Consider custom Prism theme for better dark-mode contrast.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The site supports bidirectional linking, knowledge-graph visualisation, and cont
 * **Site generator**: Eleventy  
 * **Bidirectional linking**: [`@photogabble/eleventy-plugin-interlinker`](https://github.com/photogabble/eleventy-plugin-interlinker)  
 * **Styling**: Tailwind CSS via [`eleventy-plugin-tailwindcss-4`  ](https://github.com/dwkns/eleventy-plugin-tailwindcss-4)
+* **Syntax highlighting**: [`@11ty/eleventy-plugin-syntaxhighlight`](https://github.com/11ty/eleventy-plugin-syntaxhighlight)
+* **Sitemap generation**: [`@quasibit/eleventy-plugin-sitemap`](https://github.com/quasibit/eleventy-plugin-sitemap)
 * **Graph view**: [`vis-network`](https://visjs.org/)
 
 ---
@@ -84,6 +86,12 @@ Opening `/map/` reveals how Sparks, Concepts, Projects, and Meta documents inter
 ## RSS feed
 
 A site-wide feed is available at `/feed.xml` for following updates in your preferred reader.
+
+---
+
+## Sitemap
+
+An automatically generated sitemap is produced at `/sitemap.xml` to help search engines discover content.
 
 ---
 

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -32,6 +32,19 @@ function readingTime(text = '', wordsPerMinute = 200) {
   return `${minutes} min read`;
 }
 
+/**
+ * Convert a string into a URL friendly slug.
+ * @param {string} str
+ * @returns {string}
+ */
+function slugify(str = '') {
+  return String(str)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+}
+
 /** Limit an array to n items */
 function limit(arr = [], n = 5) {
   return Array.isArray(arr) ? arr.slice(0, n) : [];
@@ -69,4 +82,4 @@ function jsonify(data) {
   );
 }
 
-module.exports = { readableDate, htmlDateString, limit, jsonify, readingTime };
+module.exports = { readableDate, htmlDateString, limit, jsonify, readingTime, slugify };

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -2,6 +2,8 @@ const interlinker = require('@photogabble/eleventy-plugin-interlinker');
 const navigation = require('@11ty/eleventy-navigation');
 const tailwind = require('eleventy-plugin-tailwindcss-4');
 const rss = require('@11ty/eleventy-plugin-rss');
+const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
+const sitemap = require('@quasibit/eleventy-plugin-sitemap');
 
 /**
  * Return the plugin configuration list for Eleventy.
@@ -23,6 +25,7 @@ function getPlugins() {
       }
     ],
     [navigation],
+    [syntaxHighlight, { preAttributes: { tabindex: 0 } }],
     [rss],
     [
       tailwind,
@@ -31,7 +34,8 @@ function getPlugins() {
         output: 'assets/main.css',
         minify: true
       }
-    ]
+    ],
+    [sitemap, { sitemap: { hostname: 'https://effusionlabs.com' } }]
   ];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "markdown-it-footnote": "^4.0.0"
       },
       "devDependencies": {
+        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
+        "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
         "@tailwindcss/typography": "^0.5.16",
         "autoprefixer": "^10.4.21",
         "daisyui": "^4.10.1",
@@ -171,6 +173,20 @@
         "@11ty/posthtml-urls": "^1.0.1",
         "debug": "^4.4.0",
         "posthtml": "^0.16.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.1.tgz",
+      "integrity": "sha512-xDPF3Ay38XlmWZe9ER0SLtMmNah7olUBlGORhUiCUkPh3jYGVCDTDayi4tbFI9Dxha8NwKlfBZ2FXM/s3aZzAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
       },
       "funding": {
         "type": "opencollective",
@@ -469,6 +485,20 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@quasibit/eleventy-plugin-sitemap": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@quasibit/eleventy-plugin-sitemap/-/eleventy-plugin-sitemap-2.2.0.tgz",
+      "integrity": "sha512-7YoU4jjipLjifBhZwttLWbAAkImmBfeMQ0+1ST6mJO45z2mFLHZcgnfHwGF2joNk74wiYNsNOB1ennouzQFZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-flat-polyfill": "^1.0.1",
+        "sitemap": "^6.3.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@sindresorhus/slugify": {
@@ -818,6 +848,23 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -897,6 +944,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -910,6 +964,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/array-union": {
@@ -3796,6 +3860,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -3864,6 +3938,13 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -3956,6 +4037,26 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sitemap": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-6.4.0.tgz",
+      "integrity": "sha512-DoPKNc2/apQZTUnfiOONWctwq7s6dZVspxAZe2VPMNtoqNq7HgXRvlRnbIpKjf+8+piQdWncwcy+YhhTGY5USQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.14.28",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=10.3.0",
+        "npm": ">=5.6.0"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "eleventy-plugin-tailwindcss-4": "^2.0.1",
     "markdown-it-attrs": "^4.3.1",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
+    "@quasibit/eleventy-plugin-sitemap": "^2.2.0"
   }
 }

--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -1,5 +1,6 @@
 @config "../../../tailwind.config.cjs";
 @import "tailwindcss";
+@import "@11ty/eleventy-plugin-syntaxhighlight/dist/prism.css";
 
 /* ═══════════════  Core Affordance & Meta Utilities  ═══════════════ */
 @layer components {

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -1,4 +1,4 @@
-const { readableDate, htmlDateString, limit, jsonify, readingTime } = require('../lib/filters');
+const { readableDate, htmlDateString, limit, jsonify, readingTime, slugify } = require('../lib/filters');
 const assert = require('node:assert');
 const { test } = require('node:test');
 
@@ -31,4 +31,9 @@ test('jsonify serializes pages', () => {
 test('readingTime estimates minutes', () => {
   const text = 'word '.repeat(450);
   assert.strictEqual(readingTime(text), '3 min read');
+});
+
+test('slugify generates URL-friendly strings', () => {
+  assert.strictEqual(slugify('Hello World!'), 'hello-world');
+  assert.strictEqual(slugify(' Multi   Space '), 'multi-space');
 });


### PR DESCRIPTION
## Summary
- integrate `@11ty/eleventy-plugin-syntaxhighlight`
- integrate `@quasibit/eleventy-plugin-sitemap`
- add new `slugify` filter with tests
- import Prism CSS through Tailwind pipeline
- document new features

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ae20609088330ab64cd204e5644ae