### PR TITLE
Add daisyUI responsive navbar

### DIFF
--- a/ARACA_REPORT_20250731-034446.md
+++ b/ARACA_REPORT_20250731-034446.md
@@ -1,0 +1,30 @@
+# ARACA Report (2025-07-31T03:44:46Z)
+
+## Objectives and Constraints
+- Integrate daisyUI with Tailwind/Nunjucks project.
+- Fix mobile header with hamburger menu.
+- Maintain Eleventy stack and run existing tests.
+
+## Summary of Changes
+- Configured custom daisyUI theme in `tailwind.config.cjs`.
+- Extracted navigation links to `src/_data/nav.js`.
+- Added new `src/_includes/header.njk` implementing daisyUI responsive navbar with hamburger dropdown.
+- Updated `layout.njk` to include the header partial.
+- Documented daisyUI usage in `README.md`.
+- Added unit test `test/nav.test.js` for navigation data.
+
+## Validation Results
+- `npm test` – all 7 tests passing.
+- `npm run build` – Eleventy generated site successfully.
+
+## Files Touched
+- `tailwind.config.cjs`
+- `src/_data/nav.js`
+- `src/_includes/header.njk`
+- `src/_includes/layout.njk`
+- `README.md`
+- `test/nav.test.js`
+
+## Next Steps
+- Review styling of the new navbar across light/dark themes.
+- Consider adding a theme switcher using daisyUI utilities.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ The site supports bidirectional linking, knowledge-graph visualisation, and cont
 
 * **Site generator**: Eleventy  
 * **Bidirectional linking**: [`@photogabble/eleventy-plugin-interlinker`](https://github.com/photogabble/eleventy-plugin-interlinker)  
-* **Styling**: Tailwind CSS via [`eleventy-plugin-tailwindcss-4`  ](https://github.com/dwkns/eleventy-plugin-tailwindcss-4)
+* **Styling**: Tailwind CSS via [`eleventy-plugin-tailwindcss-4`  ](https://github.com/dwkns/eleventy-plugin-tailwindcss-4) with [daisyUI](https://daisyui.com) components
 * **Syntax highlighting**: [`@11ty/eleventy-plugin-syntaxhighlight`](https://github.com/11ty/eleventy-plugin-syntaxhighlight)
 * **Sitemap generation**: [`@quasibit/eleventy-plugin-sitemap`](https://github.com/quasibit/eleventy-plugin-sitemap)
 * **Graph view**: [`vis-network`](https://visjs.org/)
+
+The Tailwind setup includes [daisyUI](https://daisyui.com) with a custom theme defined in `tailwind.config.cjs`.
 
 ---
 

--- a/src/_data/nav.js
+++ b/src/_data/nav.js
@@ -1,0 +1,8 @@
+module.exports = [
+  { url: '/', label: 'Showcase' },
+  { url: '/projects/', label: 'Projects' },
+  { url: '/concepts/', label: 'Concepts' },
+  { url: '/sparks/', label: 'Sparks' },
+  { url: '/meta/', label: 'Meta' },
+  { url: '/map/', label: 'Map' }
+];

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,0 +1,28 @@
+<header class="sticky top-0 z-40 w-full bg-base-100/90 backdrop-blur shadow">
+  <div class="navbar mx-auto max-w-screen-2xl px-6">
+    <div class="flex-1">
+      <a href="/" class="flex items-center gap-2 font-heading text-3xl text-primary">
+        <i data-lucide="flask-conical"></i><span>Effusion Labs</span>
+      </a>
+    </div>
+    <div class="flex-none lg:hidden">
+      <div class="dropdown dropdown-end">
+        <label tabindex="0" class="btn btn-ghost btn-square">
+          <i data-lucide="menu"></i>
+        </label>
+        <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-40">
+          {% for n in nav %}
+          <li><a href="{{ n.url }}">{{ n.label }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+    <nav class="flex-none hidden lg:flex">
+      <ul class="menu menu-horizontal px-1">
+        {% for n in nav %}
+        <li><a href="{{ n.url }}" class="hover:text-malachite">{{ n.label }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -16,26 +16,7 @@
 
 <body class="bg-bg-dark text-text-light font-body leading-relaxed">
 
-  <header class="sticky top-0 z-40 w-full bg-text-dark/90 backdrop-blur">
-    <div class="mx-auto flex max-w-screen-2xl items-center justify-between px-6 py-4">
-      <a href="/" class="flex items-center gap-2 font-heading text-3xl text-cerulean">
-        <i data-lucide="flask-conical"></i><span>Effusion Labs</span>
-      </a>
-
-      <nav class="flex flex-wrap justify-center gap-4 text-sm font-bold sm:justify-end sm:gap-6">
-        {% for n in [
-          { url: '/', label: 'Showcase' },
-          { url: '/projects/', label: 'Projects' },
-          { url: '/concepts/', label: 'Concepts' },
-          { url: '/sparks/', label: 'Sparks' },
-          { url: '/meta/', label: 'Meta' },
-          { url: '/map/', label: 'Map' }
-        ] %}
-          <a href="{{ n.url }}" class="hover:text-malachite">{{ n.label }}</a>
-        {% endfor %}
-      </nav>
-    </div>
-  </header>
+  {% include 'header.njk' %}
 
   <div class="mx-auto max-w-screen-2xl px-6">
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -23,6 +23,17 @@ module.exports = {
     require("daisyui")
   ],
   daisyui: {
-    themes: ["light", "dark"]
+    themes: [
+      {
+        lab: {
+          primary: "#0698e0",
+          secondary: "#60a0cd",
+          accent: "#10ea30",
+          neutral: "#1a1a1a",
+          "base-100": "#0f0f0f"
+        }
+      },
+      "dark"
+    ]
   }
 };

--- a/test/nav.test.js
+++ b/test/nav.test.js
@@ -1,0 +1,11 @@
+const nav = require('../src/_data/nav');
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+test('navigation contains expected links', () => {
+  assert.ok(Array.isArray(nav), 'nav is an array');
+  assert.strictEqual(nav.length, 6);
+  for (const item of nav) {
+    assert.ok(item.url && item.label, 'item has url and label');
+  }
+});


### PR DESCRIPTION
## Summary
- add custom daisyUI theme
- extract navigation data
- implement new header.njk with responsive dropdown menu
- reference new header in layout
- document DaisyUI integration
- test navigation data

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ae5c29884833083a85bb4f8e2b72e