### PR TITLE
Upgrade Tailwind build with PostCSS v4

### DIFF
--- a/ARACA_REPORT_20250731-042333.md
+++ b/ARACA_REPORT_20250731-042333.md
@@ -1,0 +1,21 @@
+# ARACA Report (2025-07-31 04:23 UTC)
+
+## Summary
+- Upgraded styling pipeline to Tailwind CSS v4 with daisyUI v5 and autoprefixer.
+- Added `postcss.config.cjs` ensuring `@tailwindcss/postcss` and `autoprefixer` plugins.
+- Injected `@plugin` directives into `src/assets/css/tailwind.css` and linked compiled CSS in layout.
+- Introduced custom Eleventy plugin `lib/autoprefixer-plugin.js` to run autoprefixer after Tailwind build.
+- Updated dependencies in `package.json` and lockfile.
+
+## Validation
+- `npm test` – all tests passing.
+- `npm run build` – Eleventy generated site successfully.
+
+## Files Touched
+- `postcss.config.cjs`
+- `src/assets/css/tailwind.css`
+- `lib/autoprefixer-plugin.js`
+- `lib/plugins.js`
+- `package.json`, `package-lock.json`
+- `README.md`
+

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ The site supports bidirectional linking, knowledge-graph visualisation, and cont
 
 * **Site generator**: Eleventy  
 * **Bidirectional linking**: [`@photogabble/eleventy-plugin-interlinker`](https://github.com/photogabble/eleventy-plugin-interlinker)  
-* **Styling**: Tailwind CSS via [`eleventy-plugin-tailwindcss-4`  ](https://github.com/dwkns/eleventy-plugin-tailwindcss-4) with [daisyUI](https://daisyui.com) components
+* **Styling**: Tailwind CSS via [`eleventy-plugin-tailwindcss-4`  ](https://github.com/dwkns/eleventy-plugin-tailwindcss-4) with [daisyUI](https://daisyui.com) v5 components and an autoprefixed PostCSS pipeline
 * **Syntax highlighting**: [`@11ty/eleventy-plugin-syntaxhighlight`](https://github.com/11ty/eleventy-plugin-syntaxhighlight)
 * **Sitemap generation**: [`@quasibit/eleventy-plugin-sitemap`](https://github.com/quasibit/eleventy-plugin-sitemap)
 * **Graph view**: [`vis-network`](https://visjs.org/)
 
-The Tailwind setup includes [daisyUI](https://daisyui.com) with a custom theme defined in `tailwind.config.cjs`.
+The Tailwind setup includes [daisyUI](https://daisyui.com) v5 with a custom theme defined in `tailwind.config.cjs`.
 
 ---
 

--- a/lib/autoprefixer-plugin.js
+++ b/lib/autoprefixer-plugin.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('node:path');
+const postcss = require('postcss');
+const autoprefixer = require('autoprefixer');
+
+module.exports = function autoprefixerPlugin(options = {}) {
+  const cssPath = options.cssPath || 'assets/main.css';
+
+  return (eleventyConfig) => {
+    eleventyConfig.on('eleventy.after', async () => {
+      const outPath = path.join(eleventyConfig.dir.output, cssPath);
+      if (!fs.existsSync(outPath)) return;
+      const css = await fs.promises.readFile(outPath, 'utf8');
+      const result = await postcss([autoprefixer]).process(css, { from: outPath });
+      await fs.promises.writeFile(outPath, result.css);
+    });
+  };
+};

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,6 +1,7 @@
 const interlinker = require('@photogabble/eleventy-plugin-interlinker');
 const navigation = require('@11ty/eleventy-navigation');
 const tailwind = require('eleventy-plugin-tailwindcss-4');
+const autoprefixerPlugin = require('./autoprefixer-plugin');
 const rss = require('@11ty/eleventy-plugin-rss');
 const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const sitemap = require('@quasibit/eleventy-plugin-sitemap');
@@ -35,6 +36,7 @@ function getPlugins() {
         minify: true
       }
     ],
+    [autoprefixerPlugin],
     [sitemap, { sitemap: { hostname: 'https://effusionlabs.com' } }]
   ];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,10 @@
       "devDependencies": {
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
         "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
+        "@tailwindcss/postcss": "^4.1.11",
         "@tailwindcss/typography": "^0.5.16",
         "autoprefixer": "^10.4.21",
-        "daisyui": "^4.10.1",
+        "daisyui": "^5.0.50",
         "eleventy-plugin-tailwindcss-4": "^2.0.1",
         "markdown-it-attrs": "^4.3.1",
         "postcss": "^8.5.6",
@@ -1188,16 +1189,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/camelcase-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -1423,17 +1414,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/css-selector-tokenizer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
-      "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2"
-      }
-    },
     "node_modules/css-tree": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -1608,34 +1588,14 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "license": "MIT"
     },
-    "node_modules/culori": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/culori/-/culori-3.3.0.tgz",
-      "integrity": "sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/daisyui": {
-      "version": "4.12.24",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-4.12.24.tgz",
-      "integrity": "sha512-JYg9fhQHOfXyLadrBrEqCDM6D5dWCSSiM6eTNCRrBRzx/VlOCrLS8eDfIw9RVvs64v2mJdLooKXY8EwQzoszAA==",
+      "version": "5.0.50",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.50.tgz",
+      "integrity": "sha512-c1PweK5RI1C76q58FKvbS4jzgyNJSP6CGTQ+KkZYzADdJoERnOxFoeLfDHmQgxLpjEzlYhFMXCeodQNLCC9bow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "css-selector-tokenizer": "^0.8",
-        "culori": "^3",
-        "picocolors": "^1",
-        "postcss-js": "^4"
-      },
-      "engines": {
-        "node": ">=16.9.0"
-      },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/daisyui"
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
     },
     "node_modules/data-urls": {
@@ -1987,13 +1947,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/fastparse": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.4.6",
@@ -3438,26 +3391,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.32"
-      }
-    },
-    "node_modules/postcss-js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-css": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21"
       }
     },
     "node_modules/postcss-merge-longhand": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",
     "autoprefixer": "^10.4.21",
-    "daisyui": "^4.10.1",
+    "daisyui": "^5.0.50",
     "eleventy-plugin-tailwindcss-4": "^2.0.1",
     "markdown-it-attrs": "^4.3.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
-    "@quasibit/eleventy-plugin-sitemap": "^2.2.0"
+    "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
+    "@tailwindcss/postcss": "^4.1.11"
   }
 }

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+    autoprefixer: {}
+  }
+};

--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -1,5 +1,7 @@
 @config "../../../tailwind.config.cjs";
 @import "tailwindcss";
+@plugin "daisyui";
+@plugin "@tailwindcss/typography";
 @import "@11ty/eleventy-plugin-syntaxhighlight/dist/prism.css";
 
 /* ═══════════════  Core Affordance & Meta Utilities  ═══════════════ */


### PR DESCRIPTION
## Summary
- use daisyUI v5 and upgrade PostCSS pipeline
- create `postcss.config.cjs` with `@tailwindcss/postcss` and autoprefixer
- inject plugin directives into the Tailwind input CSS
- add custom Eleventy plugin to run autoprefixer
- update docs and dependencies

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aeea2f530833092218bfb6e7e1460