### PR TITLE
Fix menu icon visibility and footnote popovers

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -55,6 +55,9 @@ module.exports = function(eleventyConfig) {
   // Copy raw Tailwind source for direct inspection
   eleventyConfig.addPassthroughCopy({ 'src/assets/css': 'assets/css' });
   eleventyConfig.addPassthroughCopy({ 'src/favicon.ico': 'favicon.ico' });
+  eleventyConfig.addPassthroughCopy({
+    'node_modules/lucide/dist/umd/lucide.min.js': 'assets/js/lucide.min.js'
+  });
 
   eleventyConfig.setBrowserSyncConfig({
     index: 'index.html',

--- a/ARACA_REPORT_20250731-061131.md
+++ b/ARACA_REPORT_20250731-061131.md
@@ -1,0 +1,35 @@
+# ARACA Report - 2025-07-31T06:11:31Z
+
+## Objectives and Constraints
+- Fix invisible hamburger menu by localizing icon assets.
+- Ensure custom footnote popover overrides apply site-wide.
+- Maintain Eleventy/Nunjucks/Tailwind baseline and run repository tests/build.
+
+## Inventory of Changes
+- `.eleventy.js` now copies `lucide.min.js` from `node_modules` for offline usage.
+- `src/_includes/layout.njk` loads the local icon script instead of CDN.
+- `src/_includes/header.njk` assigns size classes to lucide icons.
+- `lib/markdown-extensions.js` adds `collectFootnoteTokens` core plugin and relaxes popover guard.
+- Added `lucide` dependency in `package.json` and regenerated lockfile.
+- New test `test/footnotes.test.js` verifies popover markup rendering.
+
+## Refactor Summary per Bucket
+- **Modularization**: extended markdown extensions with a new token collection module.
+- **Configuration Hygiene**: centralized icon asset via passthrough copy, avoiding external CDN.
+- **Type/Contract Strengthening**: footnote popover plugin validated through test ensuring expected HTML output.
+
+## Validation Results
+- `npm test` → all tests including new footnote test pass.【45ef2e†L1-L23】
+- `npm run build` → Eleventy builds site and copies local icon script.【879696†L1-L31】
+
+## Performance / Footprint
+- Localizing lucide avoids external request; negligible build impact.
+
+## Citations
+- Footnote token collection implementation【F:lib/markdown-extensions.js†L104-L136】
+- Updated local icon reference in layout【F:src/_includes/layout.njk†L14-L14】
+- Build log confirming lucide script copied【F:.eleventy.js†L56-L59】
+
+## Next Steps
+- Monitor menu icon visibility across themes.
+- Consider further refactoring of markdown plugins for maintainability.

--- a/lib/markdown-extensions.js
+++ b/lib/markdown-extensions.js
@@ -68,7 +68,7 @@ function footnotePopover(md) {
   md.renderer.rules.footnote_ref = function(tokens, idx, options, env, self) {
     const { id, label = '' } = tokens[idx].meta || {};
     const list = env.footnotes && env.footnotes.list;
-    if (!Array.isArray(list) || !list[id]?.tokens) {
+    if (!Array.isArray(list) || !Array.isArray(list[id]?.tokens)) {
       return originalFootnoteRef(tokens, idx, options, env, self);
     }
 
@@ -127,6 +127,45 @@ function externalLinks(md) {
   };
 }
 
-const mdItExtensions = [hybridFootnoteDefinitions, footnotePopover, audioEmbed, qrEmbed, externalLinks];
+/**
+ * Collect footnote definition tokens for later popover rendering.
+ * @param {import('markdown-it')} md - markdown-it instance
+ */
+function collectFootnoteTokens(md) {
+  md.core.ruler.after('footnote_tail', 'collect_footnote_tokens', state => {
+    const env = state.env;
+    if (!env.footnotes || !Array.isArray(env.footnotes.list)) return;
 
-module.exports = { hybridFootnoteDefinitions, footnotePopover, audioEmbed, qrEmbed, externalLinks, mdItExtensions };
+    env.footnotes.list.forEach((item, index) => {
+      if (Array.isArray(item.tokens)) return;
+      const start = state.tokens.findIndex(t => t.type === 'footnote_open' && t.meta?.id === index);
+      if (start === -1) return;
+      const tokens = [];
+      for (let i = start + 1; i < state.tokens.length; i++) {
+        const tok = state.tokens[i];
+        if (tok.type === 'footnote_close') break;
+        tokens.push(tok);
+      }
+      item.tokens = tokens;
+    });
+  });
+}
+
+const mdItExtensions = [
+  hybridFootnoteDefinitions,
+  footnotePopover,
+  collectFootnoteTokens,
+  audioEmbed,
+  qrEmbed,
+  externalLinks
+];
+
+module.exports = {
+  hybridFootnoteDefinitions,
+  footnotePopover,
+  collectFootnoteTokens,
+  audioEmbed,
+  qrEmbed,
+  externalLinks,
+  mdItExtensions
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@11ty/eleventy-plugin-rss": "^2.0.4",
         "@downwindcss/text-decoration": "^1.1.1",
         "@photogabble/eleventy-plugin-interlinker": "^1.1.0",
+        "lucide": "^0.534.0",
         "luxon": "^3.6.1",
         "markdown-it": "^14.1.0",
         "markdown-it-footnote": "^4.0.0"
@@ -2555,6 +2556,12 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/lucide": {
+      "version": "0.534.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.534.0.tgz",
+      "integrity": "sha512-NZrg/+MFmUt6kaFxYrxFJH0TlwWXObRqClCKwbCdaABcNuAbGg95X7QcwP8WzgvPeMgYgDdVwBc/fVJx2Icsmw==",
       "license": "ISC"
     },
     "node_modules/luxon": {

--- a/package.json
+++ b/package.json
@@ -15,23 +15,24 @@
   "dependencies": {
     "@11ty/eleventy": "^3.1.2",
     "@11ty/eleventy-navigation": "^1.0.4",
+    "@11ty/eleventy-plugin-rss": "^2.0.4",
     "@downwindcss/text-decoration": "^1.1.1",
     "@photogabble/eleventy-plugin-interlinker": "^1.1.0",
+    "lucide": "^0.534.0",
     "luxon": "^3.6.1",
     "markdown-it": "^14.1.0",
-    "markdown-it-footnote": "^4.0.0",
-    "@11ty/eleventy-plugin-rss": "^2.0.4"
+    "markdown-it-footnote": "^4.0.0"
   },
   "devDependencies": {
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
+    "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
+    "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/typography": "^0.5.16",
     "autoprefixer": "^10.4.21",
     "daisyui": "^5.0.50",
     "markdown-it-attrs": "^4.3.1",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11",
-    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
-    "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
-    "@tailwindcss/postcss": "^4.1.11",
-    "prism-themes": "^1.9.0"
+    "prism-themes": "^1.9.0",
+    "tailwindcss": "^4.1.11"
   }
 }

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -2,13 +2,13 @@
   <div class="navbar mx-auto max-w-screen-2xl px-6">
     <div class="flex-1">
       <a href="/" class="flex items-center gap-2 font-heading text-3xl text-primary">
-        <i data-lucide="flask-conical"></i><span>Effusion Labs</span>
+        <i data-lucide="flask-conical" class="w-6 h-6"></i><span>Effusion Labs</span>
       </a>
     </div>
     <div class="flex-none lg:hidden">
       <div class="dropdown dropdown-end">
         <label tabindex="0" class="btn btn-ghost btn-square">
-          <i data-lucide="menu"></i>
+          <i data-lucide="menu" class="w-6 h-6"></i>
         </label>
         <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-40">
           {% for n in nav %}

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 
-  <script src="https://unpkg.com/lucide@latest/dist/lucide.min.js"></script>
+  <script src="/assets/js/lucide.min.js"></script>
 </head>
 
 <body class="bg-bg-dark text-text-light font-body leading-relaxed">

--- a/test/footnotes.test.js
+++ b/test/footnotes.test.js
@@ -1,0 +1,15 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const markdownIt = require('markdown-it');
+const markdownItFootnote = require('markdown-it-footnote');
+const markdownItAttrs = require('markdown-it-attrs');
+const { mdItExtensions } = require('../lib/markdown-extensions');
+
+test('footnote popover renders annotation markup', () => {
+  const md = markdownIt();
+  md.use(markdownItFootnote);
+  md.use(markdownItAttrs);
+  mdItExtensions.forEach(fn => fn(md));
+  const html = md.render('hello[^1]\n\n[^1]: world');
+  assert.ok(html.includes('annotation-popup'));
+});


### PR DESCRIPTION
## Summary
- copy lucide icon script into build
- size lucide icons in header and use local script
- collect footnote tokens so popover overrides work for referenced notes
- add test for popover markup
- document changes in ARACA report

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b077403e08330a846191d4a9a46f9