### PR TITLE
Restore inline footnote rendering

### DIFF
--- a/lib/markdown-extensions.js
+++ b/lib/markdown-extensions.js
@@ -9,22 +9,6 @@
  * @param {import('markdown-it')} md - markdown-it instance to mutate
  */
 function hybridFootnoteDefinitions(md) {
-  const originalFootnoteOpen = md.renderer.rules.footnote_open || function(tokens, idx, options, env, slf) {
-    let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
-    if (tokens[idx].meta.subId > 0) id += `:${tokens[idx].meta.subId}`;
-    return `<li id="fn${id}" class="footnote-item">`;
-  };
-
-  const originalFootnoteClose = md.renderer.rules.footnote_close || function() {
-    return '</li>\n';
-  };
-
-  const originalFootnoteAnchor = md.renderer.rules.footnote_anchor || function(tokens, idx, options, env, slf) {
-    let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
-    if (tokens[idx].meta.subId > 0) id += `:${tokens[idx].meta.subId}`;
-    return ` <a href="#fnref${id}" class="footnote-backref">\u21a9\uFE0E</a>`;
-  };
-
   md.renderer.rules.footnote_reference_open = (tokens, idx, _opts, env) => {
     const label = tokens[idx].meta?.label;
     const id = label && env.footnotes?.refs?.hasOwnProperty(':' + label)
@@ -38,22 +22,20 @@ function hybridFootnoteDefinitions(md) {
   md.renderer.rules.footnote_reference_close = (_t, _i, _o, env) =>
     `</div> <a href="#fnref${env.__currentFootnoteId}" class="footnote-backref">↩︎</a></div>\n`;
 
-  md.renderer.rules.footnote_block_open = () => '<section class="footnotes-hybrid">\n';
-  md.renderer.rules.footnote_block_close = () => '</section>\n';
+  md.renderer.rules.footnote_block_open = () => '';
+  md.renderer.rules.footnote_block_close = () => '';
 
-  md.renderer.rules.footnote_open = function(tokens, idx, options, env, slf) {
-    const original = originalFootnoteOpen(tokens, idx, options, env, slf);
-    return original.replace('class="footnote-item"', 'class="footnote-item footnote-enhanced"');
-  };
+  md.renderer.rules.footnote_open = () => '';
+  md.renderer.rules.footnote_close = () => '';
+  md.renderer.rules.footnote_anchor = () => '';
 
-  md.renderer.rules.footnote_close = originalFootnoteClose;
-  md.renderer.rules.footnote_anchor = originalFootnoteAnchor;
+  md.renderer.rules.footnote_body_open = () => '';
+  md.renderer.rules.footnote_body_close = () => '';
+  md.renderer.rules.footnote_caption = () => '';
 
-  const originalRender = md.renderer.render.bind(md.renderer);
-  md.renderer.render = function(tokens, options, env) {
-    let html = originalRender(tokens, options, env);
-    html = html.replace(/(<div class="footnote-content">[\s\S]*?)<p>\s*Source:/g, '$1<p class="footnote-source">Source:');
-    return html;
+  md.renderer.renderFootnoteTokens = function(tokens, options, env) {
+    const html = md.renderer.render(tokens, options, env);
+    return html.replace(/(?:^|\n)<p>\s*Source:/g, '\n<p class="footnote-source">Source:');
   };
 }
 
@@ -128,25 +110,24 @@ function externalLinks(md) {
 }
 
 /**
- * Collect footnote definition tokens for later popover rendering.
+ * Capture footnote definition tokens when footnote_tail is disabled.
  * @param {import('markdown-it')} md - markdown-it instance
  */
 function collectFootnoteTokens(md) {
-  md.core.ruler.after('footnote_tail', 'collect_footnote_tokens', state => {
+  md.core.ruler.after('inline', 'collect_footnote_tokens', state => {
     const env = state.env;
     if (!env.footnotes || !Array.isArray(env.footnotes.list)) return;
 
-    env.footnotes.list.forEach((item, index) => {
-      if (Array.isArray(item.tokens)) return;
-      const start = state.tokens.findIndex(t => t.type === 'footnote_open' && t.meta?.id === index);
-      if (start === -1) return;
-      const tokens = [];
-      for (let i = start + 1; i < state.tokens.length; i++) {
-        const tok = state.tokens[i];
-        if (tok.type === 'footnote_close') break;
-        tokens.push(tok);
+    const stack = [];
+    state.tokens.forEach((tok, idx) => {
+      if (tok.type === 'footnote_reference_open') {
+        stack.push({ id: tok.meta.label ? env.footnotes.refs[':' + tok.meta.label] : tok.meta.id, start: idx });
+      } else if (tok.type === 'footnote_reference_close') {
+        const entry = stack.pop();
+        if (!entry) return;
+        const tokens = state.tokens.slice(entry.start + 1, idx);
+        env.footnotes.list[entry.id].tokens = tokens;
       }
-      item.tokens = tokens;
     });
   });
 }


### PR DESCRIPTION
## Summary
- revive custom inline footnote rendering
- collect footnote tokens when `footnote_tail` is disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b0e6404a48330a8c75dbb37ffc9cf