### PR TITLE
Fix mise warning

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]


### PR DESCRIPTION
## Summary
- configure mise to recognize `.nvmrc`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b1072a9c48330b63bdcef72ed3715