### PR TITLE
Refactor markdown extensions; improve footnote UX

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,7 +3,7 @@ const markdownItAttrs = require('markdown-it-attrs');
 
 const getPlugins = require('./lib/plugins');
 const filters = require('./lib/filters');
-const { mdItExtensions } = require('./lib/markdown-extensions');
+const { mdItExtensions } = require('./lib/markdown');
 const { specnote } = require('./lib/shortcodes');
 const fs = require('fs');
 const postcss = require('postcss');

--- a/ARACA_REPORT_20250731-070132.md
+++ b/ARACA_REPORT_20250731-070132.md
@@ -1,0 +1,26 @@
+# ARACA Report - 2025-07-31T07:01:32Z
+
+## Objectives and Constraints
+- Refactor codebase for improved structure.
+- Preserve Eleventy/Nunjucks/Tailwind stack.
+- Disable footnote bottom forcing and fix popup on mobile.
+
+## Architecture Overview
+- **lib/markdown/** – new module directory housing footnote logic (`footnotes.js`), inline macros (`inlineMacros.js`), link tweaks (`links.js`), and aggregator (`index.js`).
+- **src/assets/css/tailwind.css** – adjusted mobile styles for annotation popups.
+- **tests** – updated footnote tests verifying absence of bottom footnote block.
+
+## Implementation Summary
+- **Modularization**: split former `markdown-extensions.js` into multiple focused files under `lib/markdown/` and adjusted imports accordingly.
+- **Configuration Hygiene**: added `disableFootnoteTail` to remove unwanted footer injection.
+- **Type/Contract Strengthening**: added guards when collecting footnote tokens and documented functions via JSDoc.
+- **Naming/Locality**: centralized extension list via `lib/markdown/index.js` improving clarity.
+- **Performance Trivial**: refined mobile popup CSS to use `inset-x-4` for responsive centering.
+
+## Validation Results
+- `npm test` – all tests pass including new check for disabled footnote tail【2d6b4a†L1-L19】.
+- `npm run build` – Eleventy build succeeds generating 34 files despite wiki warnings【bf060b†L1-L31】.
+
+## Next Steps
+- Monitor for any edge cases in footnote parsing where definitions are missing.
+- Evaluate further modularisation of build steps or CSS.

--- a/lib/markdown/footnotes.js
+++ b/lib/markdown/footnotes.js
@@ -1,12 +1,14 @@
-// Custom markdown-it extensions used by Eleventy
 /**
- * Collection of markdown-it extension functions for footnotes, embeds and links.
- * @module markdownExtensions
+ * Footnote rendering tweaks for markdown-it.
+ * - Disables footer output via footnote_tail.
+ * - Renders inline popover markup for each reference.
+ * - Captures definition tokens for later reuse.
+ * @module footnotes
  */
 
 /**
- * Enhance the default footnote output to support local display and hybrid blocks.
- * @param {import('markdown-it')} md - markdown-it instance to mutate
+ * Enhance the default footnote output to support local display.
+ * @param {import('markdown-it')} md markdown-it instance
  */
 function hybridFootnoteDefinitions(md) {
   md.renderer.rules.footnote_reference_open = (tokens, idx, _opts, env) => {
@@ -24,11 +26,9 @@ function hybridFootnoteDefinitions(md) {
 
   md.renderer.rules.footnote_block_open = () => '';
   md.renderer.rules.footnote_block_close = () => '';
-
   md.renderer.rules.footnote_open = () => '';
   md.renderer.rules.footnote_close = () => '';
   md.renderer.rules.footnote_anchor = () => '';
-
   md.renderer.rules.footnote_body_open = () => '';
   md.renderer.rules.footnote_body_close = () => '';
   md.renderer.rules.footnote_caption = () => '';
@@ -41,7 +41,7 @@ function hybridFootnoteDefinitions(md) {
 
 /**
  * Replace footnote references with popover-enabled anchors.
- * @param {import('markdown-it')} md - markdown-it instance to mutate
+ * @param {import('markdown-it')} md markdown-it instance
  */
 function footnotePopover(md) {
   const originalFootnoteRef = md.renderer.rules.footnote_ref;
@@ -53,7 +53,6 @@ function footnotePopover(md) {
     if (!Array.isArray(list) || !Array.isArray(list[id]?.tokens)) {
       return originalFootnoteRef(tokens, idx, options, env, self);
     }
-
     const n = id + 1;
     let defHtml = '';
     try {
@@ -71,47 +70,8 @@ function footnotePopover(md) {
 }
 
 /**
- * Helper to define simple inline macros.
- * @param {string} name - macro name
- * @param {string} after - rule to insert after
- * @param {(value:string)=>string} toHtml - HTML generator
- */
-const inlineMacro = (name, after, toHtml) => md => {
-  md.inline.ruler.after(after, name, (state, silent) => {
-    const m = state.src.slice(state.pos).match(new RegExp(`^@${name}\\(([^)]+)\\)`));
-    if (!m) return false;
-    if (!silent) state.push({ type: 'html_inline', content: toHtml(m[1]) });
-    state.pos += m[0].length;
-    return true;
-  });
-};
-
-/** Inline audio embedding macro */
-const audioEmbed = inlineMacro('audio', 'emphasis', src => `<audio controls class="audio-embed" src="${src}"></audio>`);
-
-/** Inline QR-code embedding macro */
-const qrEmbed = inlineMacro('qr', 'audio', s => {
-  const src = encodeURIComponent(s);
-  return `<img class="qr-code" src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${src}" alt="QR code">`;
-});
-
-/**
- * Add an external-link class and arrow to outbound links.
- * @param {import('markdown-it')} md - markdown-it instance
- */
-function externalLinks(md) {
-  const base = md.renderer.rules.link_open || ((t, i, o, e, s) => s.renderToken(t, i, o));
-  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-    tokens[idx].attrJoin('class', 'external-link');
-    const nxt = tokens[idx + 1];
-    if (nxt?.type === 'text') nxt.content = '↗ source';
-    return base(tokens, idx, options, env, self);
-  };
-}
-
-/**
  * Capture footnote definition tokens when footnote_tail is disabled.
- * @param {import('markdown-it')} md - markdown-it instance
+ * @param {import('markdown-it')} md markdown-it instance
  */
 function collectFootnoteTokens(md) {
   md.core.ruler.after('inline', 'collect_footnote_tokens', state => {
@@ -125,28 +85,26 @@ function collectFootnoteTokens(md) {
       } else if (tok.type === 'footnote_reference_close') {
         const entry = stack.pop();
         if (!entry) return;
+        const target = env.footnotes.list[entry.id];
+        if (!target) return;
         const tokens = state.tokens.slice(entry.start + 1, idx);
-        env.footnotes.list[entry.id].tokens = tokens;
+        target.tokens = tokens;
       }
     });
   });
 }
 
-const mdItExtensions = [
-  hybridFootnoteDefinitions,
-  footnotePopover,
-  collectFootnoteTokens,
-  audioEmbed,
-  qrEmbed,
-  externalLinks
-];
+/**
+ * Disable markdown-it-footnote's tail injection behavior.
+ * @param {import('markdown-it')} md markdown-it instance
+ */
+function disableFootnoteTail(md) {
+  md.core.ruler.disable('footnote_tail');
+}
 
 module.exports = {
   hybridFootnoteDefinitions,
   footnotePopover,
   collectFootnoteTokens,
-  audioEmbed,
-  qrEmbed,
-  externalLinks,
-  mdItExtensions
+  disableFootnoteTail
 };

--- a/lib/markdown/index.js
+++ b/lib/markdown/index.js
@@ -1,0 +1,25 @@
+const { hybridFootnoteDefinitions, footnotePopover, collectFootnoteTokens, disableFootnoteTail } = require('./footnotes');
+const { audioEmbed, qrEmbed } = require('./inlineMacros');
+const { externalLinks } = require('./links');
+
+/** Array of markdown-it extension functions to apply */
+const mdItExtensions = [
+  hybridFootnoteDefinitions,
+  footnotePopover,
+  collectFootnoteTokens,
+  disableFootnoteTail,
+  audioEmbed,
+  qrEmbed,
+  externalLinks
+];
+
+module.exports = {
+  hybridFootnoteDefinitions,
+  footnotePopover,
+  collectFootnoteTokens,
+  disableFootnoteTail,
+  audioEmbed,
+  qrEmbed,
+  externalLinks,
+  mdItExtensions
+};

--- a/lib/markdown/inlineMacros.js
+++ b/lib/markdown/inlineMacros.js
@@ -1,0 +1,26 @@
+/**
+ * Helper to define simple inline macros.
+ * @param {string} name - macro name
+ * @param {string} after - rule to insert after
+ * @param {(value:string)=>string} toHtml - HTML generator
+ */
+const inlineMacro = (name, after, toHtml) => md => {
+  md.inline.ruler.after(after, name, (state, silent) => {
+    const m = state.src.slice(state.pos).match(new RegExp(`^@${name}\\(([^)]+)\\)`));
+    if (!m) return false;
+    if (!silent) state.push({ type: 'html_inline', content: toHtml(m[1]) });
+    state.pos += m[0].length;
+    return true;
+  });
+};
+
+/** Inline audio embedding macro */
+const audioEmbed = inlineMacro('audio', 'emphasis', src => `<audio controls class="audio-embed" src="${src}"></audio>`);
+
+/** Inline QR-code embedding macro */
+const qrEmbed = inlineMacro('qr', 'audio', s => {
+  const src = encodeURIComponent(s);
+  return `<img class="qr-code" src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${src}" alt="QR code">`;
+});
+
+module.exports = { inlineMacro, audioEmbed, qrEmbed };

--- a/lib/markdown/links.js
+++ b/lib/markdown/links.js
@@ -1,0 +1,15 @@
+/**
+ * Add an external-link class and arrow to outbound links.
+ * @param {import('markdown-it')} md - markdown-it instance
+ */
+function externalLinks(md) {
+  const base = md.renderer.rules.link_open || ((t, i, o, e, s) => s.renderToken(t, i, o));
+  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    tokens[idx].attrJoin('class', 'external-link');
+    const nxt = tokens[idx + 1];
+    if (nxt?.type === 'text') nxt.content = '↗ source';
+    return base(tokens, idx, options, env, self);
+  };
+}
+
+module.exports = { externalLinks };

--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -105,7 +105,7 @@
   /* Mobile-responsive popover positioning */
   @media (max-width: 640px) {
     .annotation-popup {
-      @apply left-0 transform-none max-w-[280px] fixed top-auto bottom-4 right-4;
+      @apply fixed inset-x-4 bottom-4 mx-auto transform-none max-w-[90vw];
     }
   }
 }

--- a/test/footnotes.test.js
+++ b/test/footnotes.test.js
@@ -3,7 +3,7 @@ const { test } = require('node:test');
 const markdownIt = require('markdown-it');
 const markdownItFootnote = require('markdown-it-footnote');
 const markdownItAttrs = require('markdown-it-attrs');
-const { mdItExtensions } = require('../lib/markdown-extensions');
+const { mdItExtensions } = require('../lib/markdown');
 
 test('footnote popover renders annotation markup', () => {
   const md = markdownIt();
@@ -12,4 +12,13 @@ test('footnote popover renders annotation markup', () => {
   mdItExtensions.forEach(fn => fn(md));
   const html = md.render('hello[^1]\n\n[^1]: world');
   assert.ok(html.includes('annotation-popup'));
+});
+
+test('footnotes are not appended to the end of the document', () => {
+  const md = markdownIt();
+  md.use(markdownItFootnote);
+  md.use(markdownItAttrs);
+  mdItExtensions.forEach(fn => fn(md));
+  const html = md.render('hi[^1]\n\n[^1]: there');
+  assert.ok(!html.includes('<section class="footnotes">'));
 });


### PR DESCRIPTION
## Summary
- modularize markdown extension logic under `lib/markdown`
- add guard and disable markdown-it footnote tail injection
- improve mobile popup styling
- update footnote tests and Eleventy config
- document work in new ARACA report

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b13bfcd7c8330a22ebf5799a5f6a9