### PR TITLE
Refactor Eleventy and PostCSS setup

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,59 +1,8 @@
-const markdownItFootnote = require('markdown-it-footnote');
-const markdownItAttrs = require('markdown-it-attrs');
-
-const getPlugins = require('./lib/plugins');
-const filters = require('./lib/filters');
-const { applyMarkdownExtensions } = require('./lib/markdown');
-const { specnote } = require('./lib/shortcodes');
-const { CONTENT_AREAS, baseContentPath } = require('./lib/constants');
-const runPostcss = require('./lib/postcss');
-
-const glob = d => `${baseContentPath}/${d}/**/*.md`;
+const register = require('./lib/eleventy/register');
 
 
 module.exports = function(eleventyConfig) {
-  const plugins = getPlugins();
-  plugins.forEach(([plugin, opts = {}]) => eleventyConfig.addPlugin(plugin, opts));
-
-  eleventyConfig.amendLibrary('md', md => {
-    md.use(markdownItFootnote);
-    md.use(markdownItAttrs);
-    applyMarkdownExtensions(md);
-    return md;
-  });
-
-  Object.entries(filters).forEach(([key, value]) => {
-    eleventyConfig.addFilter(key, value);
-  });
-
-  CONTENT_AREAS.forEach(name => {
-    eleventyConfig.addCollection(name, api => api.getFilteredByGlob(glob(name)));
-  });
-  eleventyConfig.addCollection('nodes', api =>
-    api.getFilteredByGlob(CONTENT_AREAS.map(glob))
-  );
-
-  // Copy raw Tailwind source for direct inspection
-  eleventyConfig.addPassthroughCopy({ 'src/assets/css': 'assets/css' });
-  eleventyConfig.addPassthroughCopy({ 'src/favicon.ico': 'favicon.ico' });
-  eleventyConfig.addPassthroughCopy({
-    'node_modules/lucide/dist/umd/lucide.min.js': 'assets/js/lucide.min.js'
-  });
-
-  eleventyConfig.setBrowserSyncConfig({
-    index: 'index.html',
-    server: { baseDir: '_site' }
-  });
-
-  eleventyConfig.addShortcode('specnote', specnote);
-
-  eleventyConfig.on('eleventy.before', () => {
-    console.log('🚀 Eleventy build starting with enhanced footnote system...');
-  });
-  eleventyConfig.on('eleventy.after', async ({ results }) => {
-    console.log(`✅ Eleventy build completed. Generated ${results.length} files.`);
-    await runPostcss('src/assets/css/tailwind.css', '_site/assets/css/tailwind.css');
-  });
+  register(eleventyConfig);
 
   return {
     dir: {

--- a/ARACA_REPORT_20250731-072650.md
+++ b/ARACA_REPORT_20250731-072650.md
@@ -1,0 +1,22 @@
+# ARACA Report
+Generated: 2025-07-31T07:26:50Z
+
+## Objectives & Constraints
+- Modularized Eleventy config and PostCSS pipeline.
+- Reduced duplication and centralized plugin definitions.
+- Added lightweight tests for new modules.
+
+## Inventory of Changes
+- `.eleventy.js` now delegates setup to `lib/eleventy/register.js`.
+- New utilities in `lib/utils.js` and `lib/postcssPlugins.js`.
+- `lib/postcss.js` gains cache logic and uses centralized plugins.
+- `lib/filters.js` uses `ordinalSuffix` from utils.
+- Added tests `postcss.test.js` and `postcssPlugins.test.js`.
+- README updated to reference PostCSS plugin module.
+
+## Validation
+- `npm test` – all 12 tests pass.
+
+## Next Steps
+- Consider expanding unit tests for Eleventy collections.
+- Review build performance with caching in CI.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The site supports bidirectional linking, knowledge-graph visualisation, and cont
 * **Site generator**: Eleventy  
 * **Bidirectional linking**: [`@photogabble/eleventy-plugin-interlinker`](https://github.com/photogabble/eleventy-plugin-interlinker)  
 * **Styling**: Tailwind CSS v4 compiled with PostCSS and [daisyUI](https://daisyui.com) v5 components
+* **PostCSS config**: plugins are loaded via `lib/postcssPlugins.js` for reuse
 * **Syntax highlighting**: [`@11ty/eleventy-plugin-syntaxhighlight`](https://github.com/11ty/eleventy-plugin-syntaxhighlight)
 * **Sitemap generation**: [`@quasibit/eleventy-plugin-sitemap`](https://github.com/quasibit/eleventy-plugin-sitemap)
 * **Graph view**: [`vis-network`](https://visjs.org/)

--- a/lib/eleventy/register.js
+++ b/lib/eleventy/register.js
@@ -1,0 +1,59 @@
+const markdownItFootnote = require('markdown-it-footnote');
+const markdownItAttrs = require('markdown-it-attrs');
+
+const getPlugins = require('../plugins');
+const filters = require('../filters');
+const { applyMarkdownExtensions } = require('../markdown');
+const { specnote } = require('../shortcodes');
+const { CONTENT_AREAS, baseContentPath } = require('../constants');
+const runPostcss = require('../postcss');
+
+const glob = d => `${baseContentPath}/${d}/**/*.md`;
+
+/**
+ * Register plugins, filters and other behaviour on the given Eleventy config.
+ * @param {import('@11ty/eleventy/src/EleventyConfig')} eleventyConfig
+ */
+module.exports = function register(eleventyConfig) {
+  const plugins = getPlugins();
+  plugins.forEach(([plugin, opts = {}]) => eleventyConfig.addPlugin(plugin, opts));
+
+  eleventyConfig.amendLibrary('md', md => {
+    md.use(markdownItFootnote);
+    md.use(markdownItAttrs);
+    applyMarkdownExtensions(md);
+    return md;
+  });
+
+  Object.entries(filters).forEach(([key, value]) => {
+    eleventyConfig.addFilter(key, value);
+  });
+
+  CONTENT_AREAS.forEach(name => {
+    eleventyConfig.addCollection(name, api => api.getFilteredByGlob(glob(name)));
+  });
+  eleventyConfig.addCollection('nodes', api =>
+    api.getFilteredByGlob(CONTENT_AREAS.map(glob))
+  );
+
+  eleventyConfig.addPassthroughCopy({ 'src/assets/css': 'assets/css' });
+  eleventyConfig.addPassthroughCopy({ 'src/favicon.ico': 'favicon.ico' });
+  eleventyConfig.addPassthroughCopy({
+    'node_modules/lucide/dist/umd/lucide.min.js': 'assets/js/lucide.min.js'
+  });
+
+  eleventyConfig.setBrowserSyncConfig({
+    index: 'index.html',
+    server: { baseDir: '_site' }
+  });
+
+  eleventyConfig.addShortcode('specnote', specnote);
+
+  eleventyConfig.on('eleventy.before', () => {
+    console.log('🚀 Eleventy build starting with enhanced footnote system...');
+  });
+  eleventyConfig.on('eleventy.after', async ({ results }) => {
+    console.log(`✅ Eleventy build completed. Generated ${results.length} files.`);
+    await runPostcss('src/assets/css/tailwind.css', '_site/assets/css/tailwind.css');
+  });
+};

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,12 +1,7 @@
 const fs = require('fs');
 const { DateTime } = require('luxon');
+const { ordinalSuffix } = require('./utils');
 
-/**
- * Append ordinal suffix to a given day number.
- * @param {number} n
- * @returns {string}
- */
-const ord = n => (n % 100 >= 11 && n % 100 <= 13 ? 'th' : ['th','st','nd','rd'][n%10] || 'th');
 
 /**
  * Format a Date into a human readable string.
@@ -17,7 +12,7 @@ const ord = n => (n % 100 >= 11 && n % 100 <= 13 ? 'th' : ['th','st','nd','rd'][
 function readableDate(d, zone = 'utc') {
   if (!(d instanceof Date)) return '';
   const dt = DateTime.fromJSDate(d, { zone });
-  return `${dt.toFormat('MMMM d')}${ord(dt.day)}, ${dt.toFormat('yyyy')}`;
+  return `${dt.toFormat('MMMM d')}${ordinalSuffix(dt.day)}, ${dt.toFormat('yyyy')}`;
 }
 
 /**

--- a/lib/postcss.js
+++ b/lib/postcss.js
@@ -1,18 +1,27 @@
 const fs = require('fs');
+const path = require('path');
 const postcss = require('postcss');
+const loadPostcssPlugins = require('./postcssPlugins');
 
 /**
- * Compile a CSS file using PostCSS with Tailwind and Autoprefixer.
- * @param {string} inputPath - source CSS file
- * @param {string} outputPath - destination path
+ * Compile a CSS file using PostCSS with plugins from the project config.
+ * Skips processing when the destination is newer than the source.
+ *
+ * @param {string} inputPath  source CSS file
+ * @param {string} outputPath destination path
+ * @returns {Promise<void>}
  */
 module.exports = async function runPostcss(inputPath, outputPath) {
-  const css = fs.readFileSync(inputPath, 'utf8');
-  const result = await postcss([
-    require('@tailwindcss/postcss'),
-    require('autoprefixer')
-  ]).process(css, { from: inputPath });
+  const inputStat = fs.statSync(inputPath);
+  const outStat = fs.existsSync(outputPath) ? fs.statSync(outputPath) : null;
+  if (outStat && outStat.mtimeMs >= inputStat.mtimeMs) {
+    return; // up to date
+  }
 
-  fs.mkdirSync(require('path').dirname(outputPath), { recursive: true });
+  const css = fs.readFileSync(inputPath, 'utf8');
+  const plugins = loadPostcssPlugins();
+  const result = await postcss(plugins).process(css, { from: inputPath });
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, result.css);
 };

--- a/lib/postcssPlugins.js
+++ b/lib/postcssPlugins.js
@@ -1,0 +1,11 @@
+/**
+ * Load PostCSS plugins defined in `postcss.config.cjs`.
+ * @returns {Array<import('postcss').Plugin>}
+ */
+function loadPostcssPlugins() {
+  const config = require('../postcss.config.cjs');
+  const plugins = config.plugins || {};
+  return Object.entries(plugins).map(([name, opts]) => require(name)(opts));
+}
+
+module.exports = loadPostcssPlugins;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,16 @@
+/**
+ * Miscellaneous utility helpers used across the codebase.
+ * @module utils
+ */
+
+/**
+ * Return the ordinal suffix for a day number.
+ * @param {number} n
+ * @returns {string}
+ */
+function ordinalSuffix(n) {
+  if (n % 100 >= 11 && n % 100 <= 13) return 'th';
+  return ['th', 'st', 'nd', 'rd'][n % 10] || 'th';
+}
+
+module.exports = { ordinalSuffix };

--- a/test/postcss.test.js
+++ b/test/postcss.test.js
@@ -1,0 +1,21 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const runPostcss = require('../lib/postcss');
+
+/** Helper to create a temp directory */
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'css-'));
+}
+
+test('runPostcss processes CSS with configured plugins', async () => {
+  const dir = tmp();
+  const src = path.join(dir, 'in.css');
+  const dest = path.join(dir, 'out.css');
+  fs.writeFileSync(src, 'a{appearance:none}');
+  await runPostcss(src, dest);
+  const out = fs.readFileSync(dest, 'utf8');
+  assert.ok(out.includes('-webkit-appearance')); // autoprefixer applied
+});

--- a/test/postcssPlugins.test.js
+++ b/test/postcssPlugins.test.js
@@ -1,0 +1,10 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const loadPlugins = require('../lib/postcssPlugins');
+
+test('loadPostcssPlugins returns plugin objects', () => {
+  const plugins = loadPlugins();
+  assert.ok(Array.isArray(plugins));
+  assert.ok(plugins.length >= 2);
+  plugins.forEach(p => assert.ok(typeof p === 'object'));
+});


### PR DESCRIPTION
## Summary
- centralize ordinal suffix logic
- add PostCSS plugin loader module
- cache PostCSS output and reuse plugins
- move Eleventy config into dedicated module
- update README and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b199196708330bd6010884b7d965b