### PR TITLE
Auto trust mise config

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export MISE_TRUSTED_CONFIG_PATHS="$PWD"
+


### PR DESCRIPTION
## Summary
- automatically trust mise config when loading the repo via `.envrc`

## Testing
- `npm test`
- `mise trust --show | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688b1b262dc8833084e14a5ee7752ee1