### PR TITLE
Fix footnote line breaks

### DIFF
--- a/lib/markdown/footnotes.js
+++ b/lib/markdown/footnotes.js
@@ -35,7 +35,9 @@ function hybridFootnoteDefinitions(md) {
 
   md.renderer.renderFootnoteTokens = function(tokens, options, env) {
     const html = md.renderer.render(tokens, options, env);
-    return html.replace(/(?:^|\n)<p>\s*Source:/g, '\n<p class="footnote-source">Source:');
+    return html
+      .replace(/(?:^|\n)<p>\s*Source:/g, '\n<p class="footnote-source">Source:')
+      .replace(/\n+/g, '<br>');
   };
 }
 
@@ -56,8 +58,12 @@ function footnotePopover(md) {
     const n = id + 1;
     let defHtml = '';
     try {
-      defHtml = md.renderer.render(list[id].tokens, options, env).trim();
-      defHtml = defHtml.replace(/<\/?p>/g, '');
+      defHtml = md.renderer
+        .render(list[id].tokens, { ...options, breaks: true }, env)
+        .trim();
+      defHtml = defHtml
+        .replace(/<\/?p>/g, '')
+        .replace(/\n+/g, '<br>');
     } catch {
       return originalFootnoteRef(tokens, idx, options, env, self);
     }
@@ -88,6 +94,31 @@ function collectFootnoteTokens(md) {
         const target = env.footnotes.list[entry.id];
         if (!target) return;
         const tokens = state.tokens.slice(entry.start + 1, idx);
+        let j = idx + 1;
+        if (state.tokens[j]?.type === 'blockquote_open') {
+          let level = 0;
+          while (j < state.tokens.length) {
+            const t = state.tokens[j];
+            tokens.push(t);
+            if (t.type === 'blockquote_open') level++;
+            if (t.type === 'blockquote_close') {
+              level--;
+              if (level === 0) { j++; break; }
+            }
+            j++;
+          }
+        }
+        tokens.forEach(tok => {
+          if (tok.type === 'inline' && Array.isArray(tok.children)) {
+            tok.children.forEach(child => {
+              if (child.type === 'softbreak') {
+                child.type = 'hardbreak';
+                child.tag = 'br';
+                child.markup = '<br />';
+              }
+            });
+          }
+        });
         target.tokens = tokens;
       }
     });

--- a/test/footnotes.test.js
+++ b/test/footnotes.test.js
@@ -22,3 +22,12 @@ test('footnotes are not appended to the end of the document', () => {
   const html = md.render('hi[^1]\n\n[^1]: there');
   assert.ok(!html.includes('<section class="footnotes">'));
 });
+
+test('blockquote lines in footnotes preserve line breaks', () => {
+  const md = markdownIt();
+  md.use(markdownItFootnote);
+  md.use(markdownItAttrs);
+  mdItExtensions.forEach(fn => fn(md));
+  const html = md.render('hi[^1]\n\n[^1]: foo\n> bar\n> baz');
+  assert.ok(html.includes('bar<br'));
+});


### PR DESCRIPTION
## Summary
- preserve newlines in footnote blockquote sections
- update tests for blockquote line breaks

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b27d394a883308342cda4923767da