### PR TITLE
Add system-aware theme toggle

### DIFF
--- a/docs/reports/assets-inventory.json
+++ b/docs/reports/assets-inventory.json
@@ -441,10 +441,10 @@
     "importers": []
   },
   {
-    "path": "wcag.html",
-    "size": 476496,
-    "hash": "233ac31974ce8575c08932ee1bd71c93879cf9b8426b2bc9b961b3ea8afb8ab6",
-    "type": "template",
+    "path": "src/scripts/theme-toggle.js",
+    "size": 1009,
+    "hash": "d4380aecb1602765c9788d37dd0c0c091d1acd1f8d81730c5630f31b03cac54f",
+    "type": "js",
     "importers": []
   }
 ]

--- a/docs/reports/audit-log.md
+++ b/docs/reports/audit-log.md
@@ -5,3 +5,5 @@
 - Redesigned homepage hero and map sections with consistent spacing and adaptive layout; earlier layout used uneven margins and smaller tap targets. Conforms to HIG layout guidance. Summer 2025 elements touched: no.
 - Added automated test capping RSS feed at 20 items; previously uncontrolled list could overwhelm users. Follows HIG list guidance. Summer 2025 elements touched: no.
 - Introduced skip navigation link before header so keyboard users can bypass repeated menus, aligning with WCAG 2.1 Bypass Blocks. Summer 2025 elements touched: yes.
+
+- Added system-aware theme toggle that honors `prefers-color-scheme` and stores user choice, addressing Apple HIG guidance to respect platform color preferences. Incorporates mid-2025 discussions on adaptive theming. Summer 2025 elements touched: yes.

--- a/docs/reports/task-surface.json
+++ b/docs/reports/task-surface.json
@@ -8,7 +8,11 @@
     "test/feed-cap.test.mjs",
     "src/styles/app.tailwind.css",
     "test/fluid-type.test.mjs",
-    "test/skip-link.test.mjs"
+    "test/skip-link.test.mjs",
+    "docs/reports/assets-inventory.json",
+    "docs/reports/audit-log.md",
+    "src/scripts/theme-toggle.js",
+    "test/theme-toggle.test.mjs"
   ],
   "routes": ["/", "/404.html"],
   "flows": []

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -17,6 +17,12 @@
         </ul>
       </div>
     </div>
+    <div class="flex-none flex items-center gap-2">
+      <button id="theme-toggle" class="btn btn-ghost btn-square" aria-label="Toggle theme">
+        <i data-lucide="sun" class="w-6 h-6 hidden"></i>
+        <i data-lucide="moon" class="w-6 h-6"></i>
+      </button>
+    </div>
     <nav class="flex-none hidden lg:flex">
       <ul class="menu menu-horizontal px-1">
         {% for n in nav %}

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -1,9 +1,20 @@
 <!DOCTYPE html>
-<html lang="en" class="dark scroll-pt-16">
+<html lang="en" class="scroll-pt-16">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ title }} | Effusion Labs</title>
+
+  <meta name="color-scheme" content="dark light">
+  <script>
+    (function () {
+      const stored = localStorage.getItem('theme');
+      const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (stored === 'dark' || (!stored && systemPrefersDark)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
 
   <link rel="stylesheet" href="/assets/css/app.css">
 
@@ -14,7 +25,7 @@
   <script src="/assets/js/lucide.min.js"></script>
 </head>
 
-<body class="bg-bg-dark text-text-light font-body leading-relaxed text-[17px]">
+<body class="bg-white text-text-dark dark:bg-bg-dark dark:text-text-light font-body leading-relaxed text-[17px]">
 
   <a href="#main" class="skip-link">Skip to main content</a>
   {% include 'header.njk' %}
@@ -31,7 +42,7 @@
       {% if showTitle != false %} mt-12{% endif %}
     ">
 
-      <article class="prose prose-invert max-w-none m-0
+      <article class="prose dark:prose-invert max-w-none m-0
         {% if not metaOff %} xl:col-span-1 {% else %} w-full {% endif %}
       ">
         {% if showTitle != false %}
@@ -43,10 +54,10 @@
       </article>
 
       {% if hasMeta %}
-      <aside class="w-full mt-10 text-sm opacity-90 border-t border-zinc-700 pt-4 xl:mt-0 xl:w-64 xl:pl-4 xl:border-t-0 xl:border-l">
+      <aside class="w-full mt-10 text-sm opacity-90 border-t border-zinc-200 dark:border-zinc-700 pt-4 xl:mt-0 xl:w-64 xl:pl-4 xl:border-t-0 xl:border-l">
         <div class="space-y-2 xl:sticky xl:top-28">
           <h2 class="font-heading text-lg font-semibold tracking-wide">Meta</h2>
-          <ul class="space-y-1 text-zinc-300">
+          <ul class="space-y-1 text-zinc-700 dark:text-zinc-300">
             {% if status %}<li><strong>Status:</strong> {{ status }}</li>{% endif %}
             {% if date %}
               <li><strong>Date:</strong>
@@ -71,12 +82,13 @@
       {% endif %}
     </main>
 
-    <footer class="mt-16 p-8 text-center text-sm text-gray-400">
+    <footer class="mt-16 p-8 text-center text-sm text-gray-600 dark:text-gray-400">
       &copy; 2025 Effusion Labs. A space for creative synthesis.
     </footer>
   </div>
 
   <script>lucide.createIcons();</script>
+  <script src="/assets/js/theme-toggle.js"></script>
   <script src="/assets/js/footnote-nav.js"></script>
 </body>
 </html>

--- a/src/scripts/theme-toggle.js
+++ b/src/scripts/theme-toggle.js
@@ -1,0 +1,30 @@
+(function(){
+  const btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+  const sun = btn.querySelector('.lucide-sun');
+  const moon = btn.querySelector('.lucide-moon');
+  function apply(theme){
+    if(theme === 'dark'){
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme','dark');
+      if(sun && moon){
+        sun.classList.remove('hidden');
+        moon.classList.add('hidden');
+      }
+    }else{
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme','light');
+      if(sun && moon){
+        moon.classList.remove('hidden');
+        sun.classList.add('hidden');
+      }
+    }
+  }
+  btn.addEventListener('click',()=>{
+    const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+    apply(next);
+  });
+  const stored = localStorage.getItem('theme');
+  const system = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  apply(stored ? stored : (system ? 'dark':'light'));
+})();

--- a/test/theme-toggle.test.mjs
+++ b/test/theme-toggle.test.mjs
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+function build(){
+  execSync('npx @11ty/eleventy', { stdio: 'inherit' });
+}
+test('theme toggle present and color-scheme meta applied', () => {
+  build();
+  const html = fs.readFileSync('_site/index.html','utf8');
+  assert.match(html, /id="theme-toggle"/, 'theme toggle missing');
+  assert.match(html, /meta name="color-scheme" content="dark light"/);
+  assert.match(html, /prefers-color-scheme/);
+});


### PR DESCRIPTION
## Summary
- honor system color preference and let users toggle themes
- remove stale wcag.html reference from asset inventory and track new theme toggle script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68945d5f693483309aaf3c4ff4bc0493