### PR TITLE
Fix dark-mode toggle to switch theme attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@tailwindcss/postcss": "^4.1.11",
         "@tailwindcss/typography": "^0.5.16",
         "daisyui": "^5.0.50",
+        "jsdom": "^26.1.0",
         "markdown-it-attrs": "^4.3.1",
         "postcss": "^8.5.6",
         "prism-themes": "^1.9.0",
@@ -919,6 +920,52 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/@photogabble/eleventy-plugin-interlinker/node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@photogabble/eleventy-plugin-interlinker/node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
+    },
     "node_modules/@quasibit/eleventy-plugin-sitemap": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@quasibit/eleventy-plugin-sitemap/-/eleventy-plugin-sitemap-2.2.0.tgz",
@@ -1686,12 +1733,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "license": "MIT"
     },
     "node_modules/daisyui": {
       "version": "5.0.50",
@@ -2575,30 +2616,30 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
-      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.1.0",
+        "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
+        "decimal.js": "^10.5.0",
         "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.12",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.0.0",
+        "tough-cookie": "^5.1.1",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
+        "whatwg-url": "^14.1.1",
         "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
@@ -2606,7 +2647,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -3518,9 +3559,9 @@
       }
     },
     "node_modules/rrweb-cssom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "license": "MIT"
     },
     "node_modules/safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/typography": "^0.5.16",
     "daisyui": "^5.0.50",
+    "jsdom": "^26.1.0",
     "markdown-it-attrs": "^4.3.1",
     "postcss": "^8.5.6",
     "prism-themes": "^1.9.0",

--- a/src/scripts/theme-toggle.js
+++ b/src/scripts/theme-toggle.js
@@ -6,6 +6,7 @@
   function apply(theme){
     if(theme === 'dark'){
       document.documentElement.classList.add('dark');
+      document.documentElement.dataset.theme = 'dark';
       localStorage.setItem('theme','dark');
       if(sun && moon){
         sun.classList.remove('hidden');
@@ -13,6 +14,7 @@
       }
     }else{
       document.documentElement.classList.remove('dark');
+      document.documentElement.dataset.theme = 'lab';
       localStorage.setItem('theme','light');
       if(sun && moon){
         moon.classList.remove('hidden');

--- a/test/theme-toggle.test.mjs
+++ b/test/theme-toggle.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import { execSync } from 'node:child_process';
+import { JSDOM } from 'jsdom';
 function build(){
   execSync('npx @11ty/eleventy', { stdio: 'inherit' });
 }
@@ -11,4 +12,24 @@ test('theme toggle present and color-scheme meta applied', () => {
   assert.match(html, /id="theme-toggle"/, 'theme toggle missing');
   assert.match(html, /meta name="color-scheme" content="dark light"/);
   assert.match(html, /prefers-color-scheme/);
+});
+
+test('theme toggle updates html data-theme attribute', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>
+    <button id="theme-toggle">
+      <i class="lucide-sun hidden"></i>
+      <i class="lucide-moon"></i>
+    </button>
+  </body></html>`, { url: 'http://localhost', runScripts: 'dangerously' });
+
+  dom.window.matchMedia = () => ({ matches: false, addEventListener(){}, removeEventListener(){} });
+
+  const script = fs.readFileSync('src/scripts/theme-toggle.js', 'utf8');
+  dom.window.eval(script);
+
+  const html = dom.window.document.documentElement;
+  assert.equal(html.dataset.theme, 'lab');
+
+  dom.window.document.getElementById('theme-toggle').click();
+  assert.equal(html.dataset.theme, 'dark');
 });


### PR DESCRIPTION
## Summary
- extend theme toggle script to update `data-theme` alongside the `dark` class
- add jsdom-based test proving previous implementation failed to change theme attribute
- include jsdom dev dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c9db58d48330b253c86ca5161c23