### PR TITLE
feat(theme): default dark mode with accessible toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Content is organised into **Sparks**, **Concepts**, **Projects** and **Meta** ar
 ## Features / Capabilities
 
 - **Eleventy static site** with configurable collections for Sparks, Concepts, Projects and Meta documents, generated via the shared register module and constants【F:lib/eleventy/register.js†L33-L38】【F:lib/constants.js†L7-L13】
-- **Nunjucks layout** with dark/light theme toggle, skip navigation link and meta sidebar for document metadata. The layout preloads fonts, exposes lucide icons and surfaces status, tags, importance and memory references for each document【F:src/_includes/layout.njk†L33-L80】
-- **Tailwind CSS v4** configured through PostCSS, extended with custom colours and fonts, and themed with daisyUI’s `lab` palette【F:tailwind.config.cjs†L2-L31】【F:postcss.config.cjs†L1-L5】
+- **Nunjucks layout** with an accessible dark/light theme toggle (defaulting to dark) driven by CSS variables, skip navigation link and meta sidebar for document metadata【F:src/_includes/layout.njk†L1-L37】【F:src/_includes/header.njk†L20-L27】
+- **Tailwind CSS v4** configured through PostCSS, extended with custom colours and fonts, and wired to theme tokens via daisyUI【F:tailwind.config.cjs†L1-L43】【F:postcss.config.cjs†L1-L5】
 - **Bidirectional linking** using `@photogabble/eleventy-plugin-interlinker`, producing annotated `<a class="interlink">` elements for internal references【F:lib/plugins.js†L1-L26】
 - **Syntax highlighting** via `@11ty/eleventy-plugin-syntaxhighlight` and Prism themes loaded through the Tailwind entry file【F:lib/plugins.js†L27-L31】【F:src/styles/app.tailwind.css†L4-L5】
 - **Responsive image transform**: `@11ty/eleventy-img` generates AVIF, WebP and original formats at multiple widths with lazy‑loading and async decoding attributes【F:lib/eleventy/register.js†L40-L52】

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,28 @@
+# Theming
+
+Effusion Labs ships with a default dark theme and an optional light mode. Theme colors are driven by CSS custom properties declared in `src/styles/tokens.css` and exposed to Tailwind as design tokens.
+
+## Tokens
+
+```css
+html[data-theme="dark"] {
+  --color-bg: 0 0 0;
+  --color-surface: 26 26 26;
+  --color-text: 240 240 240;
+}
+html[data-theme="light"] {
+  --color-bg: 255 255 255;
+  --color-surface: 240 240 240;
+  --color-text: 26 26 26;
+}
+```
+
+Utilities like `bg-background`, `bg-surface` and `text-text` resolve to these variables so the same classes work across themes.
+
+## Toggle
+
+The header exposes a keyboard-accessible button that switches between dark and light modes. The choice is saved to `localStorage` and applies on first paint without flashing.
+
+## Extending
+
+Add new variables in `tokens.css` and reference them from `tailwind.config.cjs` to create additional color roles.

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -18,7 +18,8 @@
       </div>
     </div>
     <div class="flex-none flex items-center gap-2">
-      <button id="theme-toggle" class="btn btn-ghost btn-square" aria-label="Toggle theme">
+      <button id="theme-toggle" class="btn btn-ghost btn-square" aria-label="Switch to light theme" aria-pressed="true">
+        <span class="sr-only">Toggle theme</span>
         <i data-lucide="sun" class="w-6 h-6 hidden"></i>
         <i data-lucide="moon" class="w-6 h-6"></i>
       </button>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -1,27 +1,13 @@
 {# src/_includes/layout.njk #}
 <!DOCTYPE html>
-<html lang="en" class="scroll-pt-16 dark" data-theme="dark">
+<html lang="en" data-theme="dark" class="scroll-pt-16 dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ title }} | Effusion Labs</title>
 
   <meta name="color-scheme" content="dark light">
-  <script>
-    (function(){
-      const doc = document.documentElement;
-      const stored = localStorage.getItem('theme');
-      const mql = window.matchMedia?.('(prefers-color-scheme: dark)');
-      const systemPrefersDark = mql ? mql.matches : false;
-
-      // if they’ve explicitly chosen “light,” or if (no choice && system prefers light), switch to lab
-      if (stored === 'light' || (!stored && !systemPrefersDark)) {
-        doc.classList.remove('dark');
-        doc.setAttribute('data-theme','lab');
-      }
-      // otherwise leave dark (default in markup)
-    })();
-  </script>
+  <script>{% include '../scripts/theme-init.js' %}</script>
 
   <link rel="stylesheet" href="/assets/css/app.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -30,7 +16,7 @@
   <script src="/assets/js/lucide.min.js"></script>
 </head>
 
-<body class="bg-white text-text-dark dark:bg-bg-dark dark:text-text-light font-body leading-relaxed text-[17px]">
+<body class="bg-background text-text font-body leading-relaxed text-[17px]">
   <a href="#main" class="skip-link">Skip to main content</a>
   {% include 'header.njk' %}
 
@@ -54,10 +40,10 @@
       </article>
 
       {% if hasMeta %}
-      <aside class="w-full mt-10 text-sm opacity-90 border-t border-zinc-200 dark:border-zinc-700 pt-4 xl:mt-0 xl:w-64 xl:pl-4 xl:border-t-0 xl:border-l">
+      <aside class="w-full mt-10 text-sm opacity-90 border-t border-border pt-4 xl:mt-0 xl:w-64 xl:pl-4 xl:border-t-0 xl:border-l">
         <div class="space-y-2 xl:sticky xl:top-28">
           <h2 class="font-heading text-lg font-semibold tracking-wide">Meta</h2>
-          <ul class="space-y-1 text-zinc-700 dark:text-zinc-300">
+          <ul class="space-y-1 text-text">
             {% if status %}<li><strong>Status:</strong> {{ status }}</li>{% endif %}
             {% if date %}
               <li><strong>Date:</strong>
@@ -82,7 +68,7 @@
       {% endif %}
     </main>
 
-    <footer class="mt-16 p-8 text-center text-sm text-gray-600 dark:text-gray-400">
+    <footer class="mt-16 p-8 text-center text-sm text-text/60">
       &copy; 2025 Effusion Labs. A space for creative synthesis.
     </footer>
   </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -42,7 +42,7 @@ showTitle: false
         Where <strong>experimental ideas</strong> meet practical prototypes. 
         Explore the projects, concepts, and sparks shaping tomorrow’s creative technology.
       </p>
-      <a href="#activity" class="inline-block min-h-[44px] rounded-md bg-primary px-8 py-3 font-heading text-lg text-bg-dark transition hover:bg-lapis btn btn-primary">
+      <a href="#activity" class="inline-block min-h-[44px] rounded-md bg-primary px-8 py-3 font-heading text-lg text-text transition hover:bg-lapis btn btn-primary">
         View Latest Work
       </a>
     </div>
@@ -53,14 +53,14 @@ showTitle: false
     FIX: A smaller top margin is applied here to counteract the empty space
     in the hero section above, creating a more balanced look.
   #}
-  <section class="mt-12 mx-auto max-w-5xl rounded-lg bg-text-dark/80 text-center shadow-lg shadow-black/30 backdrop-blur p-6">
+  <section class="mt-12 mx-auto max-w-5xl rounded-lg bg-surface/80 text-center shadow-lg shadow-black/30 backdrop-blur p-6">
     <h2 class="font-heading text-2xl font-bold text-primary sm:text-3xl">
       Explore the Interactive Concept Map
     </h2>
-    <p class="mx-auto max-w-2xl text-text-light sm:text-base">
+    <p class="mx-auto max-w-2xl text-text sm:text-base">
       Navigate the living knowledge graph that links every spark, concept, and project in the lab. Trace ideas from first curiosity to polished prototype.
     </p>
-    <a href="/map/" class="inline-block min-h-[44px] rounded-md bg-primary px-8 py-3 font-heading text-lg text-bg-dark transition hover:bg-lapis">
+    <a href="/map/" class="inline-block min-h-[44px] rounded-md bg-primary px-8 py-3 font-heading text-lg text-text transition hover:bg-lapis">
       Launch the Map
     </a>
   </section>

--- a/src/scripts/theme-init.js
+++ b/src/scripts/theme-init.js
@@ -1,0 +1,20 @@
+(function(){
+  const storageKey = 'theme';
+  const doc = document.documentElement;
+  const stored = localStorage.getItem(storageKey);
+  const meta = document.querySelector('meta[name="color-scheme"]') || (function(){
+    const m = document.createElement('meta');
+    m.name = 'color-scheme';
+    document.head.appendChild(m);
+    return m;
+  })();
+  let theme = stored;
+  if (theme === 'auto') {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  } else if (theme !== 'dark' && theme !== 'light') {
+    theme = 'dark';
+  }
+  doc.dataset.theme = theme;
+  doc.classList.toggle('dark', theme === 'dark');
+  meta.content = theme === 'light' ? 'light dark' : 'dark light';
+})();

--- a/src/scripts/theme-toggle.js
+++ b/src/scripts/theme-toggle.js
@@ -1,27 +1,29 @@
-(function() {
+(function(){
+  const storageKey = 'theme';
   const btn = document.getElementById('theme-toggle');
   if (!btn) return;
-  const html = document.documentElement;
+  const doc = document.documentElement;
+  const meta = document.querySelector('meta[name="color-scheme"]');
   const sun = btn.querySelector('.lucide-sun');
   const moon = btn.querySelector('.lucide-moon');
 
-  function apply(theme) {
-    html.setAttribute('data-theme', theme);
-    html.classList.toggle('dark', theme === 'dark');
-    if (sun && moon) {
+  function apply(theme, persist){
+    doc.dataset.theme = theme;
+    doc.classList.toggle('dark', theme === 'dark');
+    meta && (meta.content = theme === 'light' ? 'light dark' : 'dark light');
+    if (persist) localStorage.setItem(storageKey, theme);
+    btn.setAttribute('aria-pressed', theme === 'dark');
+    btn.setAttribute('aria-label', theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme');
+    if(sun && moon){
       sun.classList.toggle('hidden', theme === 'dark');
       moon.classList.toggle('hidden', theme !== 'dark');
     }
   }
 
-  const stored = localStorage.getItem('theme');
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const initial = stored || (prefersDark ? 'dark' : 'lab');
-  apply(initial);
+  apply(doc.dataset.theme || 'dark', false);
 
   btn.addEventListener('click', () => {
-    const next = html.getAttribute('data-theme') === 'dark' ? 'lab' : 'dark';
-    localStorage.setItem('theme', next);
-    apply(next);
+    const next = doc.dataset.theme === 'dark' ? 'light' : 'dark';
+    apply(next, true);
   });
 })();

--- a/src/styles/app.tailwind.css
+++ b/src/styles/app.tailwind.css
@@ -1,4 +1,5 @@
 @config "../../tailwind.config.cjs";
+@import "./tokens.css";
 @import "tailwindcss";
 @plugin "daisyui";
 @plugin "@tailwindcss/typography";
@@ -7,10 +8,16 @@
 @layer base {
   h1 { @apply font-heading text-[clamp(2rem,4vw+1rem,3rem)]; }
   h2 { @apply font-heading text-[clamp(1.5rem,3vw+0.75rem,2.25rem)]; }
+
+  pre[class*="language-"],
+  :not(pre) > code {
+    background-color: rgb(var(--color-code-bg));
+    color: rgb(var(--color-code-text));
+  }
 }
 
 @layer components {
-  .skip-link { @apply sr-only focus:not-sr-only fixed top-2 left-2 z-50 rounded bg-primary text-bg-dark px-4 py-2; }
+  .skip-link { @apply sr-only focus:not-sr-only fixed top-2 left-2 z-50 rounded bg-primary text-text px-4 py-2; }
 }
 
 /* ——— Small utility cluster (unchanged names) ——— */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,20 @@
+:root,
+html[data-theme="dark"] {
+  --color-bg: 0 0 0;
+  --color-surface: 26 26 26;
+  --color-text: 240 240 240;
+  --color-primary: 10 132 255;
+  --color-border: 51 51 51;
+  --color-code-bg: 30 30 30;
+  --color-code-text: 240 240 240;
+}
+
+html[data-theme="light"] {
+  --color-bg: 255 255 255;
+  --color-surface: 240 240 240;
+  --color-text: 26 26 26;
+  --color-primary: 10 132 255;
+  --color-border: 204 204 204;
+  --color-code-bg: 245 245 245;
+  --color-code-text: 26 26 26;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,10 +4,13 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        lapis:      "#0A84FF",
-        "text-light": "#f0f0f0",
-        "text-dark":  "#1a1a1a",
-        "bg-dark":    "#0f0f0f"
+        background: "rgb(var(--color-bg) / <alpha-value>)",
+        surface: "rgb(var(--color-surface) / <alpha-value>)",
+        text: "rgb(var(--color-text) / <alpha-value>)",
+        border: "rgb(var(--color-border) / <alpha-value>)",
+        codebg: "rgb(var(--color-code-bg) / <alpha-value>)",
+        codetext: "rgb(var(--color-code-text) / <alpha-value>)",
+        primary: "#0A84FF"
       },
       fontFamily: {
         heading: ["'Bebas Neue'", "sans-serif"],
@@ -19,14 +22,23 @@ module.exports = {
   daisyui: {
     themes: [
       {
-        lab: {
+        dark: {
           primary: "#0A84FF",
-          accent: "#0A84FF",
           neutral: "#1a1a1a",
-          "base-100": "#0f0f0f"
+          "base-100": "#000000",
+          "base-200": "#1a1a1a",
+          "base-300": "#2a2a2a"
         }
       },
-      "dark"
+      {
+        light: {
+          primary: "#0A84FF",
+          neutral: "#1a1a1a",
+          "base-100": "#ffffff",
+          "base-200": "#f0f0f0",
+          "base-300": "#d9d9d9"
+        }
+      }
     ]
   }
 };

--- a/test/theme-toggle.test.mjs
+++ b/test/theme-toggle.test.mjs
@@ -1,5 +1,3 @@
-// test/theme-toggle.test.mjs
-
 import { test } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
@@ -10,56 +8,62 @@ function build() {
   execSync('npx @11ty/eleventy', { stdio: 'inherit' });
 }
 
-test('theme toggle present and color-scheme meta applied', () => {
+const initScript = fs.readFileSync('src/scripts/theme-init.js', 'utf8');
+const toggleScript = fs.readFileSync('src/scripts/theme-toggle.js', 'utf8');
+
+test('build includes toggle and color-scheme meta', () => {
   build();
   const html = fs.readFileSync('_site/index.html', 'utf8');
   assert.match(html, /id="theme-toggle"/, 'theme toggle missing');
   assert.match(html, /meta name="color-scheme" content="dark light"/);
-  assert.match(html, /prefers-color-scheme/);
 });
 
-test('theme toggle updates html data-theme attribute (unit)', () => {
-  const dom = new JSDOM(`<!DOCTYPE html><html><body>
-    <button id="theme-toggle">
-      <i class="lucide-sun hidden"></i>
-      <i class="lucide-moon"></i>
-    </button>
-  </body></html>`, { url: 'http://localhost', runScripts: 'dangerously' });
+test('initial paint defaults to dark and respects stored preference', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><html><head><meta name="color-scheme" content="dark light"></head><body><button id="theme-toggle"><i class="lucide-sun hidden"></i><i class="lucide-moon"></i></button></body></html>`, { url: 'http://localhost', runScripts: 'dangerously' });
 
-  // Simulate no system dark preference
   dom.window.matchMedia = () => ({ matches: false, addEventListener(){}, removeEventListener(){} });
+  dom.window.localStorage.removeItem('theme');
+  dom.window.eval(initScript);
+  const docEl = dom.window.document.documentElement;
+  assert.equal(docEl.dataset.theme, 'dark');
+  assert.equal(dom.window.document.querySelector('meta[name="color-scheme"]').content, 'dark light');
 
-  const script = fs.readFileSync('src/scripts/theme-toggle.js', 'utf8');
-  dom.window.eval(script);
+  docEl.dataset.theme = '';
+  dom.window.localStorage.setItem('theme','light');
+  dom.window.eval(initScript);
+  assert.equal(docEl.dataset.theme,'light');
 
-  const htmlEl = dom.window.document.documentElement;
-  assert.equal(htmlEl.getAttribute('data-theme'), 'lab');
-
-  dom.window.document.getElementById('theme-toggle').click();
-  assert.equal(htmlEl.getAttribute('data-theme'), 'dark');
+  docEl.dataset.theme = '';
+  dom.window.localStorage.setItem('theme','auto');
+  dom.window.matchMedia = () => ({ matches: false, addEventListener(){}, removeEventListener(){} });
+  dom.window.eval(initScript);
+  assert.equal(docEl.dataset.theme,'light');
 });
 
-test('theme toggle switches data-theme and class on click (integration)', () => {
+test('toggle switches theme and persists', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><html><head><meta name="color-scheme" content="dark light"></head><body><button id="theme-toggle"><i class="lucide-sun hidden"></i><i class="lucide-moon"></i></button></body></html>`, { url: 'http://localhost', runScripts: 'dangerously' });
+  dom.window.matchMedia = () => ({ matches: false, addEventListener(){}, removeEventListener(){} });
+  dom.window.eval(initScript);
+  dom.window.eval(toggleScript);
+  const docEl = dom.window.document.documentElement;
+  const btn = dom.window.document.getElementById('theme-toggle');
+  assert.equal(docEl.dataset.theme,'dark');
+  btn.click();
+  assert.equal(docEl.dataset.theme,'light');
+  assert.equal(dom.window.localStorage.getItem('theme'),'light');
+});
+
+test('integration toggle on built site', () => {
   build();
   const html = fs.readFileSync('_site/index.html', 'utf8');
   const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost' });
-  const { window } = dom;
-
-  // Simulate no system dark preference
-  window.matchMedia = () => ({ matches: false });
-
-  const script = fs.readFileSync('src/scripts/theme-toggle.js', 'utf8');
-  window.eval(script);
-
-  const docEl = window.document.documentElement;
-  assert.equal(docEl.getAttribute('data-theme'), 'lab');
-
-  const btn = window.document.getElementById('theme-toggle');
-  btn.dispatchEvent(new window.Event('click', { bubbles: true }));
-  assert.equal(docEl.getAttribute('data-theme'), 'dark');
-  assert.ok(docEl.classList.contains('dark'));
-
-  btn.dispatchEvent(new window.Event('click', { bubbles: true }));
-  assert.equal(docEl.getAttribute('data-theme'), 'lab');
+  dom.window.matchMedia = () => ({ matches: false, addEventListener(){}, removeEventListener(){} });
+  dom.window.eval(initScript);
+  dom.window.eval(toggleScript);
+  const docEl = dom.window.document.documentElement;
+  const btn = dom.window.document.getElementById('theme-toggle');
+  assert.equal(docEl.dataset.theme,'dark');
+  btn.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+  assert.equal(docEl.dataset.theme,'light');
   assert.ok(!docEl.classList.contains('dark'));
 });


### PR DESCRIPTION
## Summary
- add CSS variable tokens and default dark theme with no-flash init script
- wire accessible header toggle and Tailwind to tokens
- document theming and ensure toggle persistence via tests

## Testing
- `npm test`
- `node --test test/theme-toggle.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68984735346c8330b4f9a549bcd331c8