### PR TITLE
fix(build): suppress dead link warnings

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -15,6 +15,7 @@ function getPlugins() {
       interlinker,
       {
         defaultLayout: 'layouts/embed.njk',
+        deadLinkReport: 'none',
         resolvingFns: new Map([
           ['default', link => {
             const href = link.href || link.link;


### PR DESCRIPTION
## Summary
- silence dead link reports from `@photogabble/eleventy-plugin-interlinker` to prevent build noise

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689872186420833084038ed53a26d55e