### PR TITLE
fix(home): restore long hero and show zero counts

### DIFF
--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -1,5 +1,7 @@
 <section class="space-y-4 text-center">
-  <img src="/assets/static/logo.png" alt="" class="mx-auto w-24" />
-  <p class="mx-auto max-w-prose text-gray-400">A calm hub for art, culture, and innovation.</p>
+  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-24" />
+  <h1 class="font-heading text-5xl sm:text-6xl">Effusion Labs</h1>
+  <p class="text-lg text-gray-300">Art · Culture · Innovation</p>
+  <p class="mx-auto max-w-prose text-gray-400">Where experimental ideas meet practical prototypes.</p>
   <a href="/map/" class="inline-block rounded-md bg-primary px-6 py-3 font-heading text-bg-dark transition hover:bg-lapis focus:outline-none focus:ring">Launch the Map</a>
 </section>

--- a/src/_includes/components/kpis.njk
+++ b/src/_includes/components/kpis.njk
@@ -2,7 +2,7 @@
 <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-4">
   {% for l in links %}
   <a href="{{ l.url }}" class="block rounded border border-white/10 p-4 hover:bg-white/5 focus:outline-none focus:ring">
-    {{ l.title }}{% if l.count > 0 %} <span class="text-sm text-gray-400">({{ l.count }})</span>{% endif %}
+    {{ l.title }}{% if l.count !== undefined %} <span class="text-sm text-gray-400">({{ l.count }})</span>{% endif %}
   </a>
   {% endfor %}
 </div>

--- a/test/__snapshots__/homepage-empty.html
+++ b/test/__snapshots__/homepage-empty.html
@@ -1,6 +1,8 @@
 <section class="space-y-4 text-center">
-  <img src="/assets/static/logo.png" alt="" class="mx-auto w-24" />
-  <p class="mx-auto max-w-prose text-gray-400">A calm hub for art, culture, and innovation.</p>
+  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-24" />
+  <h1 class="font-heading text-5xl sm:text-6xl">Effusion Labs</h1>
+  <p class="text-lg text-gray-300">Art · Culture · Innovation</p>
+  <p class="mx-auto max-w-prose text-gray-400">Where experimental ideas meet practical prototypes.</p>
   <a href="/map/" class="inline-block rounded-md bg-primary px-6 py-3 font-heading text-bg-dark transition hover:bg-lapis focus:outline-none focus:ring">Launch the Map</a>
 </section>
 

--- a/test/__snapshots__/homepage-populated.html
+++ b/test/__snapshots__/homepage-populated.html
@@ -1,6 +1,8 @@
 <section class="space-y-4 text-center">
-  <img src="/assets/static/logo.png" alt="" class="mx-auto w-24" />
-  <p class="mx-auto max-w-prose text-gray-400">A calm hub for art, culture, and innovation.</p>
+  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-24" />
+  <h1 class="font-heading text-5xl sm:text-6xl">Effusion Labs</h1>
+  <p class="text-lg text-gray-300">Art · Culture · Innovation</p>
+  <p class="mx-auto max-w-prose text-gray-400">Where experimental ideas meet practical prototypes.</p>
   <a href="/map/" class="inline-block rounded-md bg-primary px-6 py-3 font-heading text-bg-dark transition hover:bg-lapis focus:outline-none focus:ring">Launch the Map</a>
 </section>
 

--- a/test/kpis.test.js
+++ b/test/kpis.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const nunjucks = require('nunjucks');
+
+const env = nunjucks.configure(['src/_includes', 'src/_includes/components'], { autoescape: false, noCache: true });
+
+test('kpis shows zero counts', () => {
+  const tmpl = '{% from "components/kpis.njk" import kpis %}{{ kpis([{title:"Projects", url:"/projects/", count:0}]) }}';
+  const html = env.renderString(tmpl);
+  assert.match(html, /Projects\s*<span[^>]*>\(0\)<\/span>/);
+});


### PR DESCRIPTION
## Summary
- restore homepage hero with title, tagline, and description
- show KPI counts even when zero and add regression test
- refresh homepage snapshots for updated hero

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c2d95824833085e545311f707b76