### PR TITLE
fix(home): restore hero and correct explore counts

### DIFF
--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -1,4 +1,7 @@
 const { dailySeed, seededShuffle } = require('./seeded');
+const fs = require('node:fs');
+const path = require('node:path');
+const { baseContentPath } = require('./constants');
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -43,6 +46,23 @@ function safeUrl(item) {
   return item && item.url ? item.url : '#';
 }
 
+function countEntries(coll, folder) {
+  if (Array.isArray(coll)) {
+    return coll.filter((p) => {
+      const stem = p.filePathStem || '';
+      return stem !== 'index' && !stem.endsWith('/index');
+    }).length;
+  }
+  try {
+    const dir = path.join(baseContentPath, folder);
+    return fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.md') && f !== 'index.md').length;
+  } catch {
+    return 0;
+  }
+}
+
 function buildIdeaPathways(collections, { seed, limit = 3 } = {}) {
   const concepts = collections.concepts || [];
   const projects = collections.projects || [];
@@ -74,12 +94,17 @@ function getQuestions(arr, { seed, limit = 3 } = {}) {
 }
 
 function exploreLinks(collections) {
-  return [
-    { title: 'Projects', url: '/projects/', count: (collections.projects || []).length },
-    { title: 'Concepts', url: '/concepts/', count: (collections.concepts || []).length },
-    { title: 'Sparks', url: '/sparks/', count: (collections.sparks || []).length },
-    { title: 'Meta', url: '/meta/', count: (collections.meta || []).length },
+  const defs = [
+    { title: 'Projects', url: '/projects/', key: 'projects' },
+    { title: 'Concepts', url: '/concepts/', key: 'concepts' },
+    { title: 'Sparks', url: '/sparks/', key: 'sparks' },
+    { title: 'Meta', url: '/meta/', key: 'meta' },
   ];
+  return defs.map(({ title, url, key }) => ({
+    title,
+    url,
+    count: countEntries(collections[key], key),
+  }));
 }
 
 module.exports = {
@@ -92,4 +117,5 @@ module.exports = {
   exploreLinks,
   tagNormalize,
   safeUrl,
+  countEntries,
 };

--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -1,5 +1,7 @@
 <section class="space-y-4 text-center">
-  <img src="/assets/static/logo.png" alt="" class="mx-auto w-24" />
-  <p class="mx-auto max-w-prose text-gray-400">A calm hub for art, culture, and innovation.</p>
+  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-24" />
+  <h1 class="font-heading text-5xl sm:text-6xl">Effusion Labs</h1>
+  <p class="text-lg text-gray-300">Art · Culture · Innovation</p>
+  <p class="mx-auto max-w-prose text-gray-400">Where experimental ideas meet practical prototypes.</p>
   <a href="/map/" class="inline-block rounded-md bg-primary px-6 py-3 font-heading text-bg-dark transition hover:bg-lapis focus:outline-none focus:ring">Launch the Map</a>
 </section>

--- a/src/_includes/components/kpis.njk
+++ b/src/_includes/components/kpis.njk
@@ -2,7 +2,7 @@
 <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-4">
   {% for l in links %}
   <a href="{{ l.url }}" class="block rounded border border-white/10 p-4 hover:bg-white/5 focus:outline-none focus:ring">
-    {{ l.title }}{% if l.count > 0 %} <span class="text-sm text-gray-400">({{ l.count }})</span>{% endif %}
+    {{ l.title }}{% if l.count !== undefined %} <span class="text-sm text-gray-400">({{ l.count }})</span>{% endif %}
   </a>
   {% endfor %}
 </div>

--- a/test/__snapshots__/homepage-empty.html
+++ b/test/__snapshots__/homepage-empty.html
@@ -1,6 +1,8 @@
 <section class="space-y-4 text-center">
-  <img src="/assets/static/logo.png" alt="" class="mx-auto w-24" />
-  <p class="mx-auto max-w-prose text-gray-400">A calm hub for art, culture, and innovation.</p>
+  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-24" />
+  <h1 class="font-heading text-5xl sm:text-6xl">Effusion Labs</h1>
+  <p class="text-lg text-gray-300">Art · Culture · Innovation</p>
+  <p class="mx-auto max-w-prose text-gray-400">Where experimental ideas meet practical prototypes.</p>
   <a href="/map/" class="inline-block rounded-md bg-primary px-6 py-3 font-heading text-bg-dark transition hover:bg-lapis focus:outline-none focus:ring">Launch the Map</a>
 </section>
 

--- a/test/__snapshots__/homepage-populated.html
+++ b/test/__snapshots__/homepage-populated.html
@@ -1,6 +1,8 @@
 <section class="space-y-4 text-center">
-  <img src="/assets/static/logo.png" alt="" class="mx-auto w-24" />
-  <p class="mx-auto max-w-prose text-gray-400">A calm hub for art, culture, and innovation.</p>
+  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-24" />
+  <h1 class="font-heading text-5xl sm:text-6xl">Effusion Labs</h1>
+  <p class="text-lg text-gray-300">Art · Culture · Innovation</p>
+  <p class="mx-auto max-w-prose text-gray-400">Where experimental ideas meet practical prototypes.</p>
   <a href="/map/" class="inline-block rounded-md bg-primary px-6 py-3 font-heading text-bg-dark transition hover:bg-lapis focus:outline-none focus:ring">Launch the Map</a>
 </section>
 

--- a/test/homepage.test.js
+++ b/test/homepage.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { dailySeed, seededShuffle } = require('../lib/seeded');
+const { exploreLinks } = require('../lib/homepage');
 
 test('seed override', () => {
   process.env.HOMEPAGE_SEED = 'TEST';
@@ -18,4 +19,16 @@ test('seeded shuffle deterministic', () => {
 test('dailySeed accepts date', () => {
   const seed = dailySeed('2025-08-09');
   assert.ok(seed.startsWith('2025-08-09'));
+});
+
+test('exploreLinks counts exclude index files', () => {
+  const collections = {
+    projects: [{ filePathStem: 'projects/index' }, { filePathStem: 'projects/a' }],
+    concepts: [{ filePathStem: 'concepts/index' }],
+  };
+  const links = exploreLinks(collections);
+  const proj = links.find((l) => l.title === 'Projects');
+  const concept = links.find((l) => l.title === 'Concepts');
+  assert.strictEqual(proj.count, 1);
+  assert.strictEqual(concept.count, 0);
 });


### PR DESCRIPTION
## Summary
- restore full homepage hero with title and tagline
- display KPI counts even when zero and derive counts from real content
- test collection counts to ignore index files

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898c2d95824833085e545311f707b76