### PR TITLE
feat: auto-build archive collections from content

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,9 +1,11 @@
 const register = require("./lib/eleventy/register");
 const { dirs } = require("./lib/config");
 const seeded = require("./lib/seeded");
+const registerArchiveCollections = require("./lib/eleventy/archive-collections");
 
 module.exports = function (eleventyConfig) {
   register(eleventyConfig);
+  eleventyConfig.addTemplateFormats("json");
 
   eleventyConfig.addCollection("featured", (api) =>
     api.getAll().filter((p) => p.data?.featured === true),
@@ -23,18 +25,7 @@ module.exports = function (eleventyConfig) {
     return items;
   });
 
-  // POP MART — The Monsters collections
-  const monstersBase =
-    "content/archives/collectables/designer-toys/pop-mart/the-monsters";
-  eleventyConfig.addCollection("monstersProducts", (api) =>
-    api.getFilteredByGlob(`${monstersBase}/products/*.json`),
-  );
-  eleventyConfig.addCollection("monstersSeries", (api) =>
-    api.getFilteredByGlob(`${monstersBase}/series/*.json`),
-  );
-  eleventyConfig.addCollection("monstersCharacters", (api) =>
-    api.getFilteredByGlob(`${monstersBase}/characters/*.json`),
-  );
+  registerArchiveCollections(eleventyConfig);
 
   eleventyConfig.addFilter("byCharacter", (items, slug) =>
     items.filter((p) => p.data.character === slug),

--- a/lib/eleventy/archive-collections.js
+++ b/lib/eleventy/archive-collections.js
@@ -1,0 +1,51 @@
+const fs = require("fs");
+const path = require("path");
+
+const TYPES = ["products", "series", "characters"];
+const fsJoin = path.join;
+
+function camelize(slug) {
+  return slug
+    .replace(/^the-/, "")
+    .split("-")
+    .map((w, i) => (i === 0 ? w : w[0].toUpperCase() + w.slice(1)))
+    .join("");
+}
+
+function registerArchiveCollections(eleventyConfig) {
+  const fsBase = fsJoin("src", "content", "archives");
+
+  function scan(dirFs, parts = []) {
+    const entries = fs.readdirSync(dirFs, { withFileTypes: true });
+    const typeDirs = entries.filter(
+      (e) => e.isDirectory() && TYPES.includes(e.name),
+    );
+    if (typeDirs.length) {
+      const lineSlug = parts[parts.length - 1];
+      const nameBase = camelize(lineSlug);
+      for (const { name: type } of typeDirs) {
+        const collName = `${nameBase}${type[0].toUpperCase()}${type.slice(1)}`;
+        const fsDir = fsJoin(dirFs, type);
+        eleventyConfig.addCollection(collName, () =>
+          fs
+            .readdirSync(fsDir)
+            .filter((f) => f.endsWith(".json"))
+            .map((f) => ({
+              data: JSON.parse(fs.readFileSync(fsJoin(fsDir, f), "utf8")),
+            })),
+        );
+      }
+    } else {
+      for (const entry of entries.filter((e) => e.isDirectory())) {
+        scan(fsJoin(dirFs, entry.name), [...parts, entry.name]);
+      }
+    }
+  }
+
+  if (fs.existsSync(fsBase)) {
+    scan(fsBase, []);
+  }
+}
+
+module.exports = registerArchiveCollections;
+module.exports._camelize = camelize;

--- a/test/archive-collections.test.mjs
+++ b/test/archive-collections.test.mjs
@@ -1,0 +1,27 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import registerArchiveCollections from "../lib/eleventy/archive-collections.js";
+
+// helper fake Eleventy config
+function createConfig() {
+  const calls = {};
+  return {
+    addCollection(name, fn) {
+      calls[name] = fn;
+    },
+    calls,
+  };
+}
+
+test("registerArchiveCollections discovers line collections", () => {
+  const cfg = createConfig();
+  registerArchiveCollections(cfg);
+  const names = Object.keys(cfg.calls);
+  assert.ok(names.includes("monstersProducts"));
+  assert.ok(names.includes("monstersSeries"));
+  assert.ok(names.includes("monstersCharacters"));
+
+  const items = cfg.calls.monstersProducts();
+  assert.ok(Array.isArray(items));
+  assert.ok(items.length > 0);
+});

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -1,14 +1,19 @@
-import { test } from 'node:test';
-import assert from 'node:assert';
-import fs from 'node:fs';
-import { execSync } from 'node:child_process';
+import { test } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import { execSync } from "node:child_process";
 
 function build() {
-  execSync('npx @11ty/eleventy', { stdio: 'inherit' });
+  execSync("npx @11ty/eleventy", { stdio: "inherit" });
 }
 
-test('Eleventy build generates expected assets and pages', () => {
+test("Eleventy build generates expected assets and pages", () => {
   build();
-  assert.ok(fs.existsSync('_site/assets/css/app.css'));
-  assert.ok(fs.existsSync('_site/archives/index.html'));
+  assert.ok(fs.existsSync("_site/assets/css/app.css"));
+  assert.ok(fs.existsSync("_site/archives/index.html"));
+  assert.ok(
+    fs.existsSync(
+      "_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--time-to-chill--figure--std--20221031/index.html",
+    ),
+  );
 });


### PR DESCRIPTION
## Summary
- register Eleventy JSON template support and dynamic archive collections
- add archive collection generator from content tree
- verify product pages build and collection registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68990a4de9f08330bff5c9697e0ad7c6