### PR TITLE
feat: connect monster archive pages to data

### DIFF
--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
@@ -8,3 +8,10 @@ permalink: "/archives/collectables/designer-toys/pop-mart/the-monsters/character
 ---
 <h1 class="text-2xl font-bold mb-2">{{ character.data.name }}</h1>
 <p class="mb-4">{{ character.data.notes }}</p>
+
+<h2 class="text-xl font-semibold mt-4 mb-2">Products</h2>
+<ul>
+{% for p in collections.monstersProducts | byCharacter(character.data.slug) | productsSorted %}
+  <li><a href="/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/">{{ p.data.product_id }}</a></li>
+{% endfor %}
+</ul>

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
@@ -3,9 +3,24 @@ layout: "layout.njk"
 title: "POP MART — The Monsters"
 ---
 <h1 class="text-2xl font-bold mb-4">POP MART — The Monsters</h1>
+
+<h2 class="text-xl font-semibold mt-4 mb-2">Characters</h2>
+<ul>
+{% for c in collections.monstersCharacters %}
+  <li><a href="/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/">{{ c.data.name }}</a></li>
+{% endfor %}
+</ul>
+
+<h2 class="text-xl font-semibold mt-4 mb-2">Series</h2>
+<ul>
+{% for s in collections.monstersSeries %}
+  <li><a href="/archives/collectables/designer-toys/pop-mart/the-monsters/series/{{ s.data.slug }}/">{{ s.data.title }}</a></li>
+{% endfor %}
+</ul>
+
 <h2 class="text-xl font-semibold mt-4 mb-2">Products</h2>
 <ul>
-{% for p in collections.monstersProducts %}
+{% for p in collections.monstersProducts | productsSorted %}
   <li><a href="/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/">{{ p.data.product_id }}</a></li>
 {% endfor %}
 </ul>

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
@@ -8,3 +8,10 @@ permalink: "/archives/collectables/designer-toys/pop-mart/the-monsters/series/{{
 ---
 <h1 class="text-2xl font-bold mb-2">{{ series.data.title }}</h1>
 <p class="mb-4">{{ series.data.notes }}</p>
+
+<h2 class="text-xl font-semibold mt-4 mb-2">Products</h2>
+<ul>
+{% for p in collections.monstersProducts | bySeries(series.data.slug) | productsSorted %}
+  <li><a href="/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/">{{ p.data.product_id }}</a></li>
+{% endfor %}
+</ul>

--- a/test/monsters-pages.test.mjs
+++ b/test/monsters-pages.test.mjs
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+let built = false;
+function build() {
+  if (!built) {
+    execSync('npx @11ty/eleventy', { stdio: 'inherit' });
+    built = true;
+  }
+}
+
+test('monsters archive index links to characters, series, and products', () => {
+  build();
+  const html = fs.readFileSync('_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html', 'utf8');
+  assert.match(html, /characters\/labubu\//);
+  assert.match(html, /series\/time-to-chill\//);
+  assert.match(html, /products\/pop-mart--the-monsters--labubu--time-to-chill--figure--std--20221031\//);
+});
+
+test('character page lists related products', () => {
+  build();
+  const html = fs.readFileSync('_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/labubu/index.html', 'utf8');
+  assert.match(html, /pop-mart--the-monsters--labubu--time-to-chill--figure--std--20221031/);
+});
+
+test('series page lists related products', () => {
+  build();
+  const html = fs.readFileSync('_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/time-to-chill/index.html', 'utf8');
+  assert.match(html, /pop-mart--the-monsters--labubu--time-to-chill--figure--std--20221031/);
+});


### PR DESCRIPTION
## Summary
- load POP MART The Monsters archive data from JSON and expose collection filters
- render characters, series, and products with interlinked lists
- test monsters archive pages build and link correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68990a4de9f08330bff5c9697e0ad7c6