### PR TITLE
fix(theme): respect system color scheme preference

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -1,12 +1,12 @@
 {# src/_includes/layout.njk #}
 <!DOCTYPE html>
-<html lang="en" data-theme="dark" class="scroll-pt-16 dark">
+<html lang="en" class="scroll-pt-16">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ title }} | Effusion Labs</title>
 
-  <meta name="color-scheme" content="dark light">
+  <meta name="color-scheme" content="light dark">
   <script>{% include '../scripts/theme-init.js' %}</script>
 
   <link rel="stylesheet" href="/assets/css/app.css">

--- a/src/scripts/theme-init.js
+++ b/src/scripts/theme-init.js
@@ -9,10 +9,8 @@
     return m;
   })();
   let theme = stored;
-  if (theme === 'auto') {
+  if (theme !== 'dark' && theme !== 'light') {
     theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  } else if (theme !== 'dark' && theme !== 'light') {
-    theme = 'dark';
   }
   doc.dataset.theme = theme;
   doc.classList.toggle('dark', theme === 'dark');


### PR DESCRIPTION
## Summary
- Default initial theme to match the user's OS preference when no stored choice exists.
- Remove hard-coded dark defaults in layout and expose both schemes.
- Expand theme toggle tests to cover system preferences and persistence.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689946f57d4c83308fab3182a1c1e509