### PR TITLE
feat: tile-based layout for section indexes

### DIFF
--- a/src/content/concepts/index.njk
+++ b/src/content/concepts/index.njk
@@ -6,9 +6,11 @@ eleventyNavigation:
   key: Concepts
   parent: Showcase
 ---
+{% from "components/tile.njk" import tile %}
+
 <p>This is the central hub for all individual concepts explored within the lab.</p>
-<ul>
+<ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 {% for item in collections.concepts %}
-    {% if item.url != page.url %}<li><a href="{{ item.url }}">{{ item.data.title }}</a></li>{% endif %}
+  {% if item.url != page.url %}<li>{{ tile(item) }}</li>{% endif %}
 {% endfor %}
 </ul>

--- a/src/content/meta/index.njk
+++ b/src/content/meta/index.njk
@@ -6,10 +6,11 @@ eleventyNavigation:
   key: Meta
   parent: Showcase # Adjust parent as needed for your navigation
 ---
+{% from "components/tile.njk" import tile %}
+
 <p>This section contains information about the lab itself, its purpose, and related administrative details.</p>
-<ul>
-{# Loop through all items in the 'meta' collection, excluding the current page #}
+<ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 {% for item in collections.meta %}
-    {% if item.url != page.url %}<li><a href="{{ item.url }}">{{ item.data.title }}</a></li>{% endif %}
+  {% if item.url != page.url %}<li>{{ tile(item) }}</li>{% endif %}
 {% endfor %}
 </ul>

--- a/src/content/projects/index.njk
+++ b/src/content/projects/index.njk
@@ -6,9 +6,11 @@ eleventyNavigation:
   key: Projects
   parent: Showcase # If you use parent for navigation hierarchy
 ---
+{% from "components/tile.njk" import tile %}
+
 <p>This is the central hub for all projects explored within the lab.</p>
-<ul>
+<ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 {% for item in collections.projects %}
-    {% if item.url != page.url %}<li><a href="{{ item.url }}">{{ item.data.title }}</a></li>{% endif %}
+  {% if item.url != page.url %}<li>{{ tile(item) }}</li>{% endif %}
 {% endfor %}
 </ul>

--- a/src/content/sparks/index.njk
+++ b/src/content/sparks/index.njk
@@ -6,10 +6,11 @@ eleventyNavigation:
   key: Sparks
   parent: Showcase # Adjust parent as needed for your navigation
 ---
+{% from "components/tile.njk" import tile %}
+
 <p>Here you'll find nascent ideas, quick notes, and experimental fragments that may one day ignite into full concepts or projects.</p>
-<ul>
-{# Loop through all items in the 'sparks' collection, excluding the current page #}
+<ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 {% for item in collections.sparks %}
-    {% if item.url != page.url %}<li><a href="{{ item.url }}">{{ item.data.title }}</a></li>{% endif %}
+  {% if item.url != page.url %}<li>{{ tile(item) }}</li>{% endif %}
 {% endfor %}
 </ul>

--- a/test/section-index.test.js
+++ b/test/section-index.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const nunjucks = require('nunjucks');
+
+function render(section) {
+  const file = fs.readFileSync(path.join('src','content',section,'index.njk'), 'utf8');
+  const body = file.replace(/^---[\s\S]*?---\n/, '');
+  const env = nunjucks.configure(['src/_includes','src/_includes/components'], { autoescape:false, noCache:true });
+  env.addFilter('htmlDateString', (d) => new Date(d).toISOString());
+  env.addFilter('readableDate', (d) => new Date(d).toISOString().slice(0,10));
+  const item = {
+    url: `/${section}/alpha/`,
+    date: new Date('2025-08-01'),
+    data: { title: 'Alpha', type: section.slice(0, -1) }
+  };
+  const collections = { [section]: [item] };
+  const page = { url: `/${section}/` };
+  return env.renderString(body, { collections, page }).trim();
+}
+
+['projects','concepts','sparks','meta'].forEach(section => {
+  test(`${section} index uses tile grid`, () => {
+    const html = render(section);
+    assert.match(html, /<ul class="grid/);
+    assert.match(html, /class="tile/);
+  });
+});


### PR DESCRIPTION
## Summary
- render Projects, Concepts, Sparks, and Meta indexes as responsive tile grids for improved aesthetics
- add tests asserting section indexes output tile-based grid markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899473ab7088330ba41dd5d2585cf97