### PR TITLE
fix(proxy): default to base proxy when outbound disabled

### DIFF
--- a/tools/shared/proxy.mjs
+++ b/tools/shared/proxy.mjs
@@ -3,12 +3,16 @@ function truthy(value){
 }
 
 function buildProxyFromEnv(env = process.env){
+  const base = env.HTTP_PROXY || env.http_proxy || env.HTTPS_PROXY || env.https_proxy;
   if(!truthy(env.OUTBOUND_PROXY_ENABLED)){
+    if(base){
+      return { config:{ server:base }, state:{ enabled:false, base } };
+    }
     return { state:{ enabled:false } };
   }
   const url = env.OUTBOUND_PROXY_URL;
   if(!url){
-    return { state:{ enabled:false, reason:'missing_url' } };
+    return { state:{ enabled:false, reason:'missing_url', base } };
   }
   const config = { server:url };
   let auth = 'absent';
@@ -21,7 +25,7 @@ function buildProxyFromEnv(env = process.env){
       auth = 'username_only';
     }
   }
-  return { config, state:{ enabled:true, server:url, auth } };
+  return { config, state:{ enabled:true, server:url, auth, base } };
 }
 
 export { buildProxyFromEnv };


### PR DESCRIPTION
## Summary
- default BrowserEngine proxy to system HTTP proxy when no outbound proxy configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899992075dc8330adf7e7c45ceca38e