### PR TITLE
feat(proxy): add proxy-aware web2md and e2e runner

### DIFF
--- a/lib/proxyAgent.js
+++ b/lib/proxyAgent.js
@@ -1,0 +1,31 @@
+const { setGlobalDispatcher, ProxyAgent } = require('undici');
+
+function truthy(value){
+  return ['1','true','TRUE'].includes(String(value));
+}
+
+async function configureProxyFromEnv(env = process.env){
+  if(!truthy(env.OUTBOUND_PROXY_ENABLED)){
+    return { enabled:false };
+  }
+  let server = env.OUTBOUND_PROXY_URL;
+  if(!server){
+    return { enabled:false, reason:'missing_url' };
+  }
+  if(!/^https?:\/\//.test(server)) server = 'http://' + server;
+  const url = new URL(server);
+  let auth = 'absent';
+  if(env.OUTBOUND_PROXY_USER){
+    url.username = env.OUTBOUND_PROXY_USER;
+    if(env.OUTBOUND_PROXY_PASS){
+      url.password = env.OUTBOUND_PROXY_PASS;
+      auth = 'present';
+    } else {
+      auth = 'username_only';
+    }
+  }
+  setGlobalDispatcher(new ProxyAgent(url.toString()));
+  return { enabled:true, server:url.host, auth };
+}
+
+module.exports = { configureProxyFromEnv };

--- a/lib/webpageToMarkdown.js
+++ b/lib/webpageToMarkdown.js
@@ -1,6 +1,7 @@
 const { JSDOM } = require('jsdom');
 const { Readability } = require('@mozilla/readability');
 const TurndownService = require('turndown');
+const { configureProxyFromEnv } = require('./proxyAgent');
 
 /**
  * Fetch a webpage and convert its main content to Markdown.
@@ -10,6 +11,7 @@ const TurndownService = require('turndown');
  */
 async function webpageToMarkdown(url) {
   if (!url) throw new Error('URL is required');
+  await configureProxyFromEnv();
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "luxon": "^3.6.1",
         "markdown-it": "^14.1.0",
         "markdown-it-footnote": "^4.0.0",
-        "turndown": "^7.2.0"
+        "turndown": "^7.2.0",
+        "undici": "^7.13.0"
       },
       "devDependencies": {
         "@11ty/eleventy-img": "^6.0.4",
@@ -4598,6 +4599,15 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.13.0.tgz",
+      "integrity": "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "npx @11ty/eleventy",
     "dev": "npx @11ty/eleventy --serve",
     "web2md": "node webpage-to-markdown.js",
+    "proxy:test": "node scripts/outbound-proxy.e2e.mjs",
     "docs:archive": "node tools/archive-docs.js",
     "docs:validate": "node tools/validate-docs.js",
     "docs:reindex": "node tools/build-vendor-index.js"
@@ -25,6 +26,7 @@
     "@11ty/eleventy-plugin-rss": "^2.0.4",
     "@mozilla/readability": "^0.6.0",
     "@photogabble/eleventy-plugin-interlinker": "^1.1.0",
+    "undici": "^7.13.0",
     "jsdom": "^26.1.0",
     "lucide": "^0.534.0",
     "luxon": "^3.6.1",

--- a/scripts/outbound-proxy.e2e.mjs
+++ b/scripts/outbound-proxy.e2e.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { lookup } from 'node:dns/promises';
+
+function run(cmd, args, opts={}){
+  const res = spawnSync(cmd, args, { encoding:'utf8', ...opts });
+  if(res.status !== 0){
+    const err = new Error(res.stderr || res.stdout || `${cmd} exited ${res.status}`);
+    err.status = res.status;
+    throw err;
+  }
+  return res.stdout;
+}
+
+async function ensureDeps(){
+  try{ require.resolve('playwright-extra'); }
+  catch{
+    run('npm',['install'],{stdio:'inherit'});
+  }
+  run('npx',['playwright','install-deps','chromium'],{stdio:'inherit'});
+  run('npx',['playwright','install','chromium'],{stdio:'inherit'});
+}
+
+function buildProxyUrl(){
+  const { OUTBOUND_PROXY_URL:host, OUTBOUND_PROXY_USER:user, OUTBOUND_PROXY_PASS:pass } = process.env;
+  if(!host) throw new Error('OUTBOUND_PROXY_URL missing');
+  const auth = user ? `${user}:${pass || ''}@` : '';
+  return `http://${auth}${host}`;
+}
+
+async function checkIp(proxyUrl){
+  const { address:expected } = await lookup('mildlyawesome.com');
+  const ip = run('curl',['-s','--proxy',proxyUrl,'https://checkip.amazonaws.com']);
+  const val = ip.trim();
+  if(val !== expected){
+    throw new Error(`proxy ip ${val} did not match expected ${expected}`);
+  }
+  return val;
+}
+
+function runSearch(query){
+  const out = run('node',['tools/search2serp/cli.js', query]);
+  return JSON.parse(out);
+}
+
+function verifySerp(res, link){
+  const ok = Array.isArray(res.results) && res.results.some(r=>r.url===link);
+  if(!ok) throw new Error('expected link not found in SERP');
+}
+
+function runWeb2md(url){
+  const out = run('node',['webpage-to-markdown.js', url]);
+  return out;
+}
+
+async function main(){
+  await ensureDeps();
+  const proxyUrl = buildProxyUrl();
+  const ip = await checkIp(proxyUrl);
+  console.log('proxy ip', ip);
+  const query = 'pop mart monsters time to chill site:popmart.com';
+  const link = 'https://www.popmart.com/products/labubu-time-to-chill-vinyl-plush-doll';
+  const serp = runSearch(query);
+  verifySerp(serp, link);
+  console.log('serp ok');
+  const md = runWeb2md(link);
+  if(!md.includes('October 31, 2022')){
+    throw new Error('missing expected date in page');
+  }
+  console.log('web2md ok');
+}
+
+main().catch(err=>{ console.error(err.message); process.exit(1); });

--- a/tools/shared/proxy.mjs
+++ b/tools/shared/proxy.mjs
@@ -6,10 +6,11 @@ function buildProxyFromEnv(env = process.env){
   if(!truthy(env.OUTBOUND_PROXY_ENABLED)){
     return { state:{ enabled:false } };
   }
-  const url = env.OUTBOUND_PROXY_URL;
+  let url = env.OUTBOUND_PROXY_URL;
   if(!url){
     return { state:{ enabled:false, reason:'missing_url' } };
   }
+  if(!/^https?:\/\//.test(url)) url = 'http://' + url;
   const config = { server:url };
   let auth = 'absent';
   if(env.OUTBOUND_PROXY_USER){


### PR DESCRIPTION
## Summary
- add undici-based proxy agent and integrate with web2md
- normalize proxy URL handling
- introduce outbound proxy end-to-end test runner

## Testing
- `npm test`
- `npm run proxy:test` *(fails: E: Write error - write (14: Bad address))*

------
https://chatgpt.com/codex/tasks/task_e_6899a279efb4833080c99e73e5d9becf