### PR TITLE
chore(proxy): add audit harness and report

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "proxy:test": "node scripts/outbound-proxy.e2e.mjs",
     "docs:archive": "node tools/archive-docs.js",
     "docs:validate": "node tools/validate-docs.js",
-    "docs:reindex": "node tools/build-vendor-index.js"
+    "docs:reindex": "node tools/build-vendor-index.js",
+    "build:tools": "npm install --prefix tools/google-search && npm run build --prefix tools/google-search"
   },
   "engines": {
     "node": ">=20"

--- a/proxy_audit_report.md
+++ b/proxy_audit_report.md
@@ -1,0 +1,69 @@
+# Proxy Audit Report
+
+## Environment Snapshot
+- Node: v22.18.0
+- npm: 11.4.2
+- Playwright: Version 1.54.2
+- OUTBOUND_PROXY_ENABLED: 1
+- OUTBOUND_PROXY_URL: http://mildlyawesome.com:49159
+- OUTBOUND_PROXY_USER: toxic
+- OUTBOUND_PROXY_PASS: A***x
+- CODEX_PROXY_CERT present: yes 
+
+## Proxy Preflight
+### DNS
+```
+172.96.160.178  mildlyawesome.com
+```
+### TCP Reachability
+```
+nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
+```
+### Unauthenticated HTTP
+```
+curl: (7) Failed to connect to mildlyawesome.com port 49159 after 24 ms: Couldn't connect to server
+000
+```
+### Authenticated CONNECT
+```
+curl: (7) Failed to connect to mildlyawesome.com port 49159 after 82 ms: Couldn't connect to server
+000
+```
+
+## Dependency Installs
+- `npm ci` (root, tools/search2serp, tools/web2md)
+- `npx playwright install chromium` (success)
+- `npx playwright install-deps` (failed: proxy unreachable)
+- `npm run build:tools` (failed: tools/google-search missing)
+
+## Code Changes
+- Added `build:tools` script to package.json.
+- Added `scripts/e2e-serp-proxy-check.sh` harness.
+- Added `scripts/self-heal-run.sh` automation loop.
+
+## E2E Harness Output
+```
+[Preflight] DNS lookup
+172.96.160.178  mildlyawesome.com
+[Preflight] TCP connectivity
+nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
+TCP connection failed
+```
+
+## Self-Heal Attempts
+```
+[self-heal] cycle 1
+[Preflight] DNS lookup
+172.96.160.178  mildlyawesome.com
+[Preflight] TCP connectivity
+nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
+TCP connection failed
+[self-heal] no change, stopping
+```
+
+## Remaining Issues
+- Proxy at mildlyawesome.com:49159 unreachable from environment; all network calls fail.
+- google-search vendored tool could not be fetched.
+
+## Final Status
+FAIL – network unable to reach proxy, so search2serp and web2md could not be verified end-to-end.

--- a/scripts/e2e-serp-proxy-check.sh
+++ b/scripts/e2e-serp-proxy-check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Proxy preflight
+DOMAIN="mildlyawesome.com"
+PORT=49159
+
+echo "[Preflight] DNS lookup"
+getent hosts "$DOMAIN" || { echo "DNS lookup failed"; exit 1; }
+
+echo "[Preflight] TCP connectivity"
+if ! nc -vz "$DOMAIN" "$PORT"; then
+  echo "TCP connection failed"; exit 1; fi
+
+echo "[Preflight] Unauthenticated HTTP via proxy"
+code=$(curl -sS -o /dev/null -w '%{http_code}\n' -x "http://$DOMAIN:$PORT" http://example.com --connect-timeout 8 || true)
+echo "HTTP status: $code"
+if [ "$code" != "407" ]; then echo "Expected 407"; exit 1; fi
+
+echo "[Preflight] Authenticated CONNECT"
+code=$(curl -sS -o /dev/null -w '%{http_code}\n' --connect-timeout 12 -x "http://$DOMAIN:$PORT" -U "$OUTBOUND_PROXY_USER:$OUTBOUND_PROXY_PASS" https://httpbin.org/ip || true)
+echo "HTTP status: $code"
+if [ "$code" != "200" ] && [ "$code" != "301" ] && [ "$code" != "302" ]; then
+  echo "Authenticated CONNECT failed"; exit 1; fi
+
+QUERY="pop mart monsters time to chill site:popmart.com"
+MAX_RETRIES=3
+BACKOFF=2
+RESULT_LINK=""
+
+for ((i=1;i<=MAX_RETRIES;i++)); do
+  echo "[search2serp] Attempt $i"
+  out=$(node tools/search2serp/cli.js "$QUERY" 2>/tmp/search2serp.err || true)
+  if echo "$out" | grep -qi 'popmart.com'; then
+    RESULT_LINK=$(echo "$out" | node -e "const data=JSON.parse(fs.readFileSync(0,'utf8'));const r=data.results.find(r=>/popmart.com/.test(r.url));if(r)console.log(r.url);")
+    [ -n "$RESULT_LINK" ] && break
+  fi
+  sleep $((BACKOFF*i))
+done
+
+if [ -z "$RESULT_LINK" ]; then
+  echo "search2serp failed"; exit 1; fi
+
+echo "[web2md] Fetching $RESULT_LINK"
+for ((i=1;i<=MAX_RETRIES;i++)); do
+  page=$(node webpage-to-markdown.js "$RESULT_LINK" 2>/tmp/web2md.err || true)
+  if echo "$page" | grep -q "October 31, 2022"; then
+    echo "$page" > /tmp/web2md.out
+    echo "Success"; exit 0
+  fi
+  sleep $((BACKOFF*i))
+done
+
+echo "web2md failed"; exit 1

--- a/scripts/self-heal-run.sh
+++ b/scripts/self-heal-run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cycle=1
+prev=""
+while [ $cycle -le 2 ]; do
+  echo "[self-heal] cycle $cycle"
+  npm ci >/tmp/npm.root.log 2>&1 || npm install >/tmp/npm.root.log 2>&1
+  (cd tools/search2serp && (npm ci || npm install)) >/tmp/npm.search.log 2>&1 || true
+  (cd tools/web2md && (npm ci || npm install)) >/tmp/npm.web.log 2>&1 || true
+  npm run build:tools >/tmp/build.tools.log 2>&1 || true
+  if scripts/e2e-serp-proxy-check.sh; then
+    echo "[self-heal] success"; exit 0
+  fi
+  err="$(cat /tmp/search2serp.err /tmp/web2md.err 2>/tmp/empty 2>/dev/null || true)"
+  if echo "$err" | grep -qi 'missing.*chromium'; then
+    npx playwright install chromium >/tmp/playwright.install.log 2>&1 || true
+    npx playwright install-deps >/tmp/playwright.deps.log 2>&1 || true
+    git add -A && git commit -m "chore(self-heal): install playwright deps" || true
+  fi
+  if [ "$err" = "$prev" ]; then
+    echo "[self-heal] no change, stopping"; exit 1
+  fi
+  prev="$err"
+  cycle=$((cycle+1))
+done
+exit 1


### PR DESCRIPTION
## Summary
- add build:tools script
- add e2e proxy check and self-heal scripts
- document proxy audit results

## Testing
- `npm test` *(hangs; aborted)*
- `scripts/e2e-serp-proxy-check.sh` *(fails: TCP connection to proxy unreachable)*
- `scripts/self-heal-run.sh` *(fails: TCP connection to proxy unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899a79afdbc8330be6ca0fef63b9f40