### PR TITLE
feat(test): add targeted runner for changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Content is organised into **Sparks**, **Concepts**, **Projects** and **Meta** ar
 ## Features / Capabilities
 
 - **Eleventy static site** with configurable collections for Sparks, Concepts, Projects and Meta documents, generated via the shared register module and constants【F:lib/eleventy/register.js†L33-L38】【F:lib/constants.js†L7-L13】
-- **Nunjucks layout** with an accessible dark/light theme toggle (defaulting to dark) driven by CSS variables, skip navigation link and meta sidebar for document metadata【F:src/_includes/layout.njk†L1-L37】【F:src/_includes/header.njk†L20-L27】
+- **Nunjucks layout** with an accessible dark/light theme toggle (defaulting to dark) driven by CSS variables, skip navigation link and meta sidebar for document metadata【F:src/\_includes/layout.njk†L1-L37】【F:src/\_includes/header.njk†L20-L27】
 - **Tailwind CSS v4** configured through PostCSS, extended with custom colours and fonts, and wired to theme tokens via daisyUI【F:tailwind.config.cjs†L1-L43】【F:postcss.config.cjs†L1-L5】
 - **Bidirectional linking** using `@photogabble/eleventy-plugin-interlinker`, producing annotated `<a class="interlink">` elements for internal references【F:lib/plugins.js†L1-L26】
 - **Syntax highlighting** via `@11ty/eleventy-plugin-syntaxhighlight` and Prism themes loaded through the Tailwind entry file【F:lib/plugins.js†L27-L31】【F:src/styles/app.tailwind.css†L4-L5】
@@ -39,7 +39,7 @@ Content is organised into **Sparks**, **Concepts**, **Projects** and **Meta** ar
 - **Interactive concept map** built with `vis-network`, exposing collections as a node‑edge graph at `/map/` for exploratory browsing【F:src/map.njk†L38-L121】
 - **Webpage ingestion helper** providing both an Eleventy filter and a CLI to convert external pages to Markdown using Readability.js and Turndown【F:lib/filters.js†L1-L5】【F:lib/webpageToMarkdown.js†L1-L26】
 - **PostCSS pipeline** that compiles `src/styles/app.tailwind.css` on each build and copies static assets through to `_site/`【F:lib/eleventy/register.js†L69-L72】
-- **Accessible baseline** including skip‑link, semantic landmarks and footnote enhancements for improved keyboard navigation and readability【F:src/_includes/layout.njk†L33-L75】【F:src/styles/app.tailwind.css†L12-L38】
+- **Accessible baseline** including skip‑link, semantic landmarks and footnote enhancements for improved keyboard navigation and readability【F:src/\_includes/layout.njk†L33-L75】【F:src/styles/app.tailwind.css†L12-L38】
 
 ## Quickstart
 
@@ -90,7 +90,7 @@ No lint or format scripts are defined.
 ## Configuration
 
 - **Content directories**: Markdown lives under `src/content/{sparks,concepts,projects,meta}`【F:lib/constants.js†L7-L13】
-- **Data files**: `src/_data/` holds global data such as navigation links【F:src/_data/nav.js†L1-L11】
+- **Data files**: `src/_data/` holds global data such as navigation links【F:src/\_data/nav.js†L1-L11】
 - **Includes**: Nunjucks layouts and partials reside in `src/_includes/`
 - **Env vars**:
   - `CASSETTE_DIR` – path to snapshot vault (`docs/cassettes/` by default)
@@ -100,7 +100,7 @@ Setting these variables allows custom storage locations for captures or twins wh
 
 ## Testing
 
-`npm test` invokes Node’s built‑in test runner and executes all files under `test/`. The suite mixes unit tests for utility functions with integration tests that assert build outputs and runtime behaviour. Integration tests that exercise network calls use the **Live‑Capture‑Lock** policy:
+`npm test` runs an adaptive harness that targets only tests related to your changes. It inspects `git status` to detect modified files and executes matching tests, falling back to the full suite when no direct matches are found. Use `npm run test:all` to force a complete run or when CI sets `CI=true`. Integration tests that exercise network calls use the **Live‑Capture‑Lock** policy:
 
 - **Snapshot vault**: Recorded HTTP interactions are stored under `docs/cassettes/`【9ad1e7†L1-L2】
 - **Creating captures**: run the relevant tests with network access; responses are saved as fixtures for replay
@@ -147,7 +147,13 @@ Example response:
 {
   "query": "effusion labs",
   "results": [
-    { "rank": 1, "title": "Result One", "url": "https://example.com/1", "snippet": "Snippet one", "type": "organic" }
+    {
+      "rank": 1,
+      "title": "Result One",
+      "url": "https://example.com/1",
+      "snippet": "Snippet one",
+      "type": "organic"
+    }
     // ...
   ]
 }
@@ -215,7 +221,7 @@ The running container serves the static site with caching headers and an SPA fal
 2. Install dependencies with `npm install`.
 3. Create feature branches that keep experimental work behind flags.
 4. Update or add tests alongside code changes; record any new external captures in `docs/knowledge/` and commit snapshots under `docs/cassettes/`.
-5. Run `npm test` to ensure the suite passes and snapshots are replayed without network access.
+5. Run `npm test` for fast feedback or `npm run test:all` to execute the entire suite and verify snapshots without network access.
 6. Submit a pull request describing your changes, snapshot updates and any assumptions.
 
 ## License

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This is a digital studio and knowledge base for Effusion Labs, built with Eleventy and the powerful `@photogabble/eleventy-plugin-interlinker`.",
   "main": "index.js",
   "scripts": {
-    "test": "node --test",
+    "test": "node tools/test-changed.mjs",
+    "test:all": "node --test",
     "build": "npx @11ty/eleventy",
     "dev": "npx @11ty/eleventy --serve",
     "web2md": "node webpage-to-markdown.js",

--- a/test/test-changed.cli.test.mjs
+++ b/test/test-changed.cli.test.mjs
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+test("runs explicit test file", () => {
+  const tmp = path.join(os.tmpdir(), "llm-sample.test.mjs");
+  writeFileSync(tmp, "import test from 'node:test'; test('ok', ()=>{});");
+  const env = { ...process.env };
+  delete env.CI;
+  const proc = spawnSync("node", ["tools/test-changed.mjs", tmp], {
+    env,
+    stdio: "inherit",
+  });
+  unlinkSync(tmp);
+  assert.equal(proc.status, 0);
+});

--- a/tools/test-changed.mjs
+++ b/tools/test-changed.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const TEST_DIRS = ["test", "tests"];
+
+function collectTests(dir, out) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collectTests(full, out);
+    else if (/\.(test|spec)\.m?js$/i.test(entry.name)) out.push(full);
+  }
+}
+
+function listAllTests() {
+  const files = [];
+  for (const dir of TEST_DIRS) {
+    if (fs.existsSync(dir)) collectTests(dir, files);
+  }
+  return files;
+}
+
+function gitChanged() {
+  try {
+    const out = execSync("git status --porcelain", { encoding: "utf8" });
+    return out
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => l.slice(3));
+  } catch {
+    return [];
+  }
+}
+
+function relatedTests(changed) {
+  const all = listAllTests();
+  const set = new Set();
+  for (const file of changed) {
+    if (/\.(test|spec)\.m?js$/i.test(file)) {
+      set.add(file);
+      continue;
+    }
+    const base = path.basename(file).replace(/\.[^.]+$/, "");
+    for (const t of all) {
+      if (t.includes(base)) set.add(t);
+    }
+  }
+  return Array.from(set);
+}
+
+function run(files) {
+  const args = ["--test", ...files];
+  const proc = spawn("node", args, { stdio: "inherit" });
+  proc.on("exit", (code) => process.exit(code ?? 1));
+}
+
+function main() {
+  if (process.env.CI) {
+    return run([]);
+  }
+  const cli = process.argv.slice(2);
+  if (cli.length) {
+    return run(cli);
+  }
+  const files = relatedTests(gitChanged());
+  if (files.length === 0) {
+    console.log("No targeted tests found; running full suite");
+    return run([]);
+  }
+  console.log("Running tests:\n" + files.join("\n"));
+  return run(files);
+}
+
+main();


### PR DESCRIPTION
## Summary
- introduce `tools/test-changed.mjs` that inspects `git status` and runs only tests related to modified files, falling back to the full suite
- add dedicated CLI test and update npm scripts to use the adaptive harness by default with a `test:all` escape hatch
- document the selective test workflow and contributor guidance in README

## Testing
- `npm test`
- `npm run test:all`


------
https://chatgpt.com/codex/tasks/task_e_6899a54a4f3083308460f59b3917812e