### PR TITLE
fix(proxy): add cf handling and proxy scripts

### DIFF
--- a/lib/webpageToMarkdown.js
+++ b/lib/webpageToMarkdown.js
@@ -2,6 +2,7 @@ const { JSDOM } = require('jsdom');
 const { Readability } = require('@mozilla/readability');
 const TurndownService = require('turndown');
 const { configureProxyFromEnv } = require('./proxyAgent');
+const { isCloudflareChallenge, markChallenge } = require('../tools/shared/cf.mjs');
 
 /**
  * Fetch a webpage and convert its main content to Markdown.
@@ -17,6 +18,13 @@ async function webpageToMarkdown(url) {
     throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
   }
   const html = await res.text();
+  const headersObj = Object.fromEntries(res.headers);
+  if(isCloudflareChallenge({ body: html, headers: headersObj })){
+    markChallenge();
+    const { fetchWithFallback } = require('../tools/web2md');
+    const { markdown } = await fetchWithFallback(url);
+    return markdown;
+  }
   const dom = new JSDOM(html, { url });
   const reader = new Readability(dom.window.document);
   const article = reader.parse();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "docs:archive": "node tools/archive-docs.js",
     "docs:validate": "node tools/validate-docs.js",
     "docs:reindex": "node tools/build-vendor-index.js",
-    "build:tools": "npm install --prefix tools/google-search && npm run build --prefix tools/google-search"
+    "build:tools": "npm install --prefix tools/google-search && npm run build --prefix tools/google-search",
+    "deps:playwright": "npx playwright install chromium || true",
+    "deps:system": "npx playwright install-deps || true"
   },
   "engines": {
     "node": ">=20"

--- a/proxy_audit_report.md
+++ b/proxy_audit_report.md
@@ -1,69 +1,55 @@
-# Proxy Audit Report
+# Proxy + Cloudflare Audit Report
 
-## Environment Snapshot
+## Environment
 - Node: v22.18.0
 - npm: 11.4.2
 - Playwright: Version 1.54.2
-- OUTBOUND_PROXY_ENABLED: 1
 - OUTBOUND_PROXY_URL: http://mildlyawesome.com:49159
-- OUTBOUND_PROXY_USER: toxic
-- OUTBOUND_PROXY_PASS: A***x
-- CODEX_PROXY_CERT present: yes 
+- http_proxy: http://toxic:Ann3xx!597e5Bmx@mildlyawesome.com:49159
+- https_proxy: http://toxic:Ann3xx!597e5Bmx@mildlyawesome.com:49159
+- NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/envoy-mitmproxy-ca-cert.crt
+
+## Dependency Prep
+- npm ci executed in root, tools/search2serp, tools/web2md
+- npm run build:tools – failed (tools/google-search missing)
+- npm run deps:playwright – Chromium downloaded
+- npm run deps:system – failed (network unreachable)
 
 ## Proxy Preflight
-### DNS
-```
-172.96.160.178  mildlyawesome.com
-```
-### TCP Reachability
-```
-nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
-```
-### Unauthenticated HTTP
-```
-curl: (7) Failed to connect to mildlyawesome.com port 49159 after 24 ms: Couldn't connect to server
-000
-```
-### Authenticated CONNECT
-```
-curl: (7) Failed to connect to mildlyawesome.com port 49159 after 82 ms: Couldn't connect to server
-000
-```
+DNS:
+172.96.160.178
 
-## Dependency Installs
-- `npm ci` (root, tools/search2serp, tools/web2md)
-- `npx playwright install chromium` (success)
-- `npx playwright install-deps` (failed: proxy unreachable)
-- `npm run build:tools` (failed: tools/google-search missing)
+TCP:
+nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
+
+Unauthenticated HTTP:
+curl: (7) Failed to connect to mildlyawesome.com port 49159 after 29 ms: Couldn't connect to server
+000
+
+Authenticated CONNECT:
+curl: (7) Failed to connect to mildlyawesome.com port 49159 after 67 ms: Couldn't connect to server
+000
+
+Result: TCP connection to proxy failed; subsequent checks could not proceed.
+
+## E2E Harness
+scripts/e2e-serp-proxy-check.sh output:
+[Preflight] DNS lookup
+172.96.160.178  mildlyawesome.com
+[Preflight] TCP connectivity
+nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
+TCP connection failed
+Result: Harness aborted during preflight due to unreachable proxy.
 
 ## Code Changes
-- Added `build:tools` script to package.json.
-- Added `scripts/e2e-serp-proxy-check.sh` harness.
-- Added `scripts/self-heal-run.sh` automation loop.
-
-## E2E Harness Output
-```
-[Preflight] DNS lookup
-172.96.160.178  mildlyawesome.com
-[Preflight] TCP connectivity
-nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
-TCP connection failed
-```
-
-## Self-Heal Attempts
-```
-[self-heal] cycle 1
-[Preflight] DNS lookup
-172.96.160.178  mildlyawesome.com
-[Preflight] TCP connectivity
-nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
-TCP connection failed
-[self-heal] no change, stopping
-```
-
-## Remaining Issues
-- Proxy at mildlyawesome.com:49159 unreachable from environment; all network calls fail.
-- google-search vendored tool could not be fetched.
+- Added Playwright dependency scripts and Cloudflare handling utilities.
+- Enhanced BrowserEngine with proxy logging, fingerprinting, and persistent state.
+- Added Cloudflare detection and retry logic to search2serp and web2md.
+- Updated e2e harness to export proxy envs.
 
 ## Final Status
-FAIL – network unable to reach proxy, so search2serp and web2md could not be verified end-to-end.
+FAIL – Proxy server mildlyawesome.com:49159 unreachable (network is unreachable). Search2serp and web2md could not be fully exercised.
+
+### Next Steps
+- Verify network path to proxy or try alternative ports (3128/8080).
+- Ensure outbound firewall allows access to 172.96.160.178:49159.

--- a/scripts/e2e-serp-proxy-check.sh
+++ b/scripts/e2e-serp-proxy-check.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 # Proxy preflight
 DOMAIN="mildlyawesome.com"
 PORT=49159
+export OUTBOUND_PROXY_ENABLED=${OUTBOUND_PROXY_ENABLED:-1}
+export OUTBOUND_PROXY_URL=${OUTBOUND_PROXY_URL:-"http://$DOMAIN:$PORT"}
+export OUTBOUND_PROXY_USER=${OUTBOUND_PROXY_USER:-"toxic"}
+export OUTBOUND_PROXY_PASS=${OUTBOUND_PROXY_PASS:-"Ann3xx!597e5Bmx"}
+export http_proxy="http://$OUTBOUND_PROXY_USER:$OUTBOUND_PROXY_PASS@$DOMAIN:$PORT"
+export https_proxy="$http_proxy"
 
 echo "[Preflight] DNS lookup"
 getent hosts "$DOMAIN" || { echo "DNS lookup failed"; exit 1; }

--- a/tools/search2serp/index.js
+++ b/tools/search2serp/index.js
@@ -3,21 +3,28 @@ const { BrowserEngine } = require('../shared/BrowserEngine.mjs');
 const { buildGoogleUrl } = require('./url.js');
 const { parseSerp } = require('./parser.js');
 const { acceptConsent } = require('./consent.js');
+const { isCloudflareChallenge, markChallenge } = require('../shared/cf.mjs');
 
-async function search(q, opts={}){
+async function search(q, opts={}, attempt=0){
   const htmlPath = opts.htmlPath || process.env.SEARCH2SERP_HTML_PATH;
   if(htmlPath){
     const html = await fs.readFile(htmlPath, 'utf8');
     const results = parseSerp(html);
     return { query:q, results, proxy:{ enabled:false }, traceFile:null };
   }
-  const engine = await BrowserEngine.create();
+  const engine = await BrowserEngine.create({ retry:attempt });
   const page = await engine.newPage();
   const url = buildGoogleUrl({ q, hl:opts.hl, gl:opts.gl, num:opts.num, start:opts.start });
   await page.goto(url, { waitUntil:'domcontentloaded' });
   await acceptConsent(page);
   await page.waitForSelector('#search');
   const html = await page.content();
+  if(isCloudflareChallenge(html)){
+    console.log(`search2serp: Cloudflare challenge detected (attempt ${attempt})`);
+    markChallenge();
+    await engine.close();
+    if(attempt < 2) return await search(q, opts, attempt+1);
+  }
   const results = parseSerp(html);
   const out = { query:q, url, results, proxy:engine.proxy, traceFile:engine.traceFile };
   await engine.close();

--- a/tools/shared/BrowserEngine.mjs
+++ b/tools/shared/BrowserEngine.mjs
@@ -2,19 +2,22 @@ import { chromium } from 'playwright-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import os from 'os';
 import path from 'path';
+import fs from 'fs';
 import { buildProxyFromEnv } from './proxy.mjs';
+import { realisticHeaders, fingerprintOptions, persistedStatePath, shouldHeadful } from './cf.mjs';
 
 chromium.use(StealthPlugin());
 
 class BrowserEngine{
   static async create(opts={}){
-    const { statePath } = opts;
+    const statePath = opts.statePath || persistedStatePath;
     const { state:proxyState, config:proxyConfig } = buildProxyFromEnv();
-    const launchOpts = { headless:true };
+    const launchOpts = { headless: !shouldHeadful(opts.retry || 0) };
     if(proxyConfig) launchOpts.proxy = proxyConfig;
+    console.log(`BrowserEngine proxy: ${proxyState.enabled ? proxyState.server : 'none'} (auth:${proxyState.auth || 'none'})`);
     const browser = await chromium.launch(launchOpts);
-    const ctxOpts = { ignoreHTTPSErrors:true };
-    if(statePath) ctxOpts.storageState = statePath;
+    const ctxOpts = { ignoreHTTPSErrors:true, ...fingerprintOptions() };
+    if(statePath && fs.existsSync(statePath)) ctxOpts.storageState = statePath;
     const context = await browser.newContext(ctxOpts);
     const traceFile = path.join(os.tmpdir(), `trace-${Date.now()}.zip`);
     await context.tracing.start({ screenshots:true, snapshots:true });
@@ -34,7 +37,12 @@ class BrowserEngine{
   }
 
   async newPage(){
-    return await this.context.newPage();
+    const page = await this.context.newPage();
+    await page.setExtraHTTPHeaders(realisticHeaders());
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+    });
+    return page;
   }
 
   async saveState(file){
@@ -42,6 +50,9 @@ class BrowserEngine{
   }
 
   async close(){
+    try{
+      await this.saveState(persistedStatePath);
+    }catch{}
     await this.context.tracing.stop({ path: this.traceFile });
     await this.context.close();
     await this.browser.close();

--- a/tools/shared/cf.mjs
+++ b/tools/shared/cf.mjs
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+const stateDir = path.join(process.cwd(), 'tmp');
+if(!fs.existsSync(stateDir)) fs.mkdirSync(stateDir, {recursive:true});
+const persistedStatePath = path.join(stateDir, 'pw-state.json');
+const cfFlagFile = path.join(stateDir, 'cf-flag.json');
+
+function isCloudflareChallenge(input){
+  if(!input) return false;
+  const html = typeof input === 'string' ? input : input.body || '';
+  const headers = input.headers || {};
+  if(headers['cf-mitigated'] === 'challenge') return true;
+  if(/__cf_bm/.test(headers['set-cookie'] || '')) return true;
+  return /Just a moment/i.test(html) || /cdn-cgi\/challenge-platform/.test(html);
+}
+
+function realisticHeaders(){
+  return {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.60 Safari/537.36',
+    'Accept-Language': 'en-US,en;q=0.9',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'Upgrade-Insecure-Requests': '1'
+  };
+}
+
+function fingerprintOptions(){
+  return {
+    timezoneId: 'America/Denver',
+    viewport: { width:1920, height:1080 },
+    colorScheme: 'light',
+    locale: 'en-US',
+    permissions: []
+  };
+}
+
+function markChallenge(){
+  fs.writeFileSync(cfFlagFile, JSON.stringify({ detected: Date.now() }));
+}
+
+function shouldHeadful(retries=0){
+  let detected=false;
+  try{
+    const data = JSON.parse(fs.readFileSync(cfFlagFile,'utf8'));
+    detected = Date.now() - data.detected < 24*3600*1000;
+  }catch{}
+  return detected || retries>1;
+}
+
+export { isCloudflareChallenge, realisticHeaders, fingerprintOptions, persistedStatePath, shouldHeadful, markChallenge };


### PR DESCRIPTION
## Summary
- add playwright dependency scripts
- implement Cloudflare detection and proxy-aware BrowserEngine
- wire search2serp and web2md through new CF-aware engine
- export proxy environment in SERP e2e harness

## Testing
- `npm run build:tools` *(fails: tools/google-search missing)*
- `npm run deps:playwright`
- `npm run deps:system` *(fails: network unreachable)*
- `scripts/e2e-serp-proxy-check.sh` *(fails: TCP connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6899b228a5dc8330ba3d016f1cec2f34