### PR TITLE
chore: enforce chained proxy and CF challenge handling

### DIFF
--- a/lib/proxyAgent.js
+++ b/lib/proxyAgent.js
@@ -5,12 +5,12 @@ function truthy(value){
 }
 
 async function configureProxyFromEnv(env = process.env){
-  if(!truthy(env.OUTBOUND_PROXY_ENABLED)){
-    return { enabled:false };
-  }
-  let server = env.OUTBOUND_PROXY_URL;
+  let server = env.http_proxy || env.https_proxy || env.OUTBOUND_PROXY_URL;
   if(!server){
-    return { enabled:false, reason:'missing_url' };
+    if(truthy(env.OUTBOUND_PROXY_ENABLED)){
+      return { enabled:false, reason:'missing_url' };
+    }
+    return { enabled:false };
   }
   if(!/^https?:\/\//.test(server)) server = 'http://' + server;
   const url = new URL(server);

--- a/lib/webpageToMarkdown.js
+++ b/lib/webpageToMarkdown.js
@@ -12,17 +12,39 @@ const { configureProxyFromEnv } = require('./proxyAgent');
 async function webpageToMarkdown(url) {
   if (!url) throw new Error('URL is required');
   await configureProxyFromEnv();
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+  const { isCloudflareChallenge, realisticHeaders, persistedStatePath, shouldHeadful, markChallenge } = await import('../tools/shared/cf.mjs');
+  let res = await fetch(url, { headers: realisticHeaders() });
+  let html = await res.text();
+  if(isCloudflareChallenge({ headers: Object.fromEntries(res.headers), body: html })){
+    markChallenge();
+    let retries = 0;
+    while(retries < 3){
+      const headful = shouldHeadful(retries);
+      const jitter = retries === 2;
+      const { BrowserEngine } = await import('../tools/shared/BrowserEngine.mjs');
+      const engine = await BrowserEngine.create({ statePath: persistedStatePath, headless: !headful, jitter });
+      try{
+        const page = await engine.newPage();
+        await page.goto(url, { waitUntil:'networkidle' });
+        html = await page.content();
+        if(isCloudflareChallenge(html)){
+          markChallenge();
+          await engine.close();
+          retries++;
+          continue;
+        }
+        const markdown = htmlToMarkdown(html, url);
+        await engine.close();
+        return markdown;
+      }catch(err){
+        await engine.close();
+        retries++;
+        if(retries>=3) throw err;
+      }
+    }
+    throw new Error('cloudflare_challenge');
   }
-  const html = await res.text();
-  const dom = new JSDOM(html, { url });
-  const reader = new Readability(dom.window.document);
-  const article = reader.parse();
-  const turndownService = new TurndownService();
-  const source = article && article.content ? article.content : dom.serialize();
-  return turndownService.turndown(source);
+  return htmlToMarkdown(html, url);
 }
 
 function htmlToMarkdown(html, url='about:blank'){

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "prettier": "^3.3.3",
         "prism-themes": "^1.9.0",
         "prismjs": "^1.30.0",
+        "proxy-chain": "^2.5.0",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "tailwindcss": "^4.1.11"
       },
@@ -2726,6 +2727,27 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -2890,6 +2912,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
@@ -3957,6 +3986,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/proxy-chain": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/proxy-chain/-/proxy-chain-2.5.9.tgz",
+      "integrity": "sha512-DZZKtRz92WuXd7fzRTKgI/oGhjmSgGMgT3FweLunCztpaG5jDVOJp1jgRPAVLQD1SG6HhkOyRkj6RTF3A214bg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "socks": "^2.8.3",
+        "socks-proxy-agent": "^8.0.3",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -4399,6 +4443,47 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.6.tgz",
+      "integrity": "sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4582,8 +4667,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/turndown": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "docs:archive": "node tools/archive-docs.js",
     "docs:validate": "node tools/validate-docs.js",
     "docs:reindex": "node tools/build-vendor-index.js",
-    "build:tools": "npm install --prefix tools/google-search && npm run build --prefix tools/google-search"
+    "build:tools": "npm install --prefix tools/google-search && npm run build --prefix tools/google-search",
+    "deps:playwright": "npx playwright install chromium || true",
+    "deps:system": "npx playwright install-deps || true",
+    "proxy:chain": "node tools/shared/chain-proxy.mjs"
   },
   "engines": {
     "node": ">=20"
@@ -54,6 +57,7 @@
     "prism-themes": "^1.9.0",
     "prismjs": "^1.30.0",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "proxy-chain": "^2.5.0"
   }
 }

--- a/proxy_audit_report.md
+++ b/proxy_audit_report.md
@@ -2,68 +2,57 @@
 
 ## Environment Snapshot
 - Node: v22.18.0
-- npm: 11.4.2
-- Playwright: Version 1.54.2
-- OUTBOUND_PROXY_ENABLED: 1
+- npm: 10.9.3
+- Playwright: 1.54.2
+- HTTP_PROXY: http://proxy:8080
+- HTTPS_PROXY: http://proxy:8080
 - OUTBOUND_PROXY_URL: http://mildlyawesome.com:49159
 - OUTBOUND_PROXY_USER: toxic
-- OUTBOUND_PROXY_PASS: A***x
-- CODEX_PROXY_CERT present: yes 
+- OUTBOUND_PROXY_PASS: ******
+- NODE_EXTRA_CA_CERTS: (unset)
 
-## Proxy Preflight
-### DNS
+## Baseline Reachability
+```
+[baseline] OK
+```
+
+## DNS & TCP Gate
 ```
 172.96.160.178  mildlyawesome.com
-```
-### TCP Reachability
-```
 nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
 ```
-### Unauthenticated HTTP
+
+## Proxy Preflight
+### Unauthenticated
 ```
-curl: (7) Failed to connect to mildlyawesome.com port 49159 after 24 ms: Couldn't connect to server
+curl: (7) Failed to connect to example.com port 80 after 44 ms: Couldn't connect to server
 000
 ```
 ### Authenticated CONNECT
 ```
-curl: (7) Failed to connect to mildlyawesome.com port 49159 after 82 ms: Couldn't connect to server
+curl: (7) Failed to connect to httpbin.org port 443 after 51 ms: Couldn't connect to server
 000
 ```
 
+## Chain-Shim
+- Not started: TCP gate failed
+
+## Cloudflare Detections
+- Not attempted
+
 ## Dependency Installs
-- `npm ci` (root, tools/search2serp, tools/web2md)
-- `npx playwright install chromium` (success)
-- `npx playwright install-deps` (failed: proxy unreachable)
-- `npm run build:tools` (failed: tools/google-search missing)
+- `npm install` (added proxy-chain)
 
 ## Code Changes
-- Added `build:tools` script to package.json.
-- Added `scripts/e2e-serp-proxy-check.sh` harness.
-- Added `scripts/self-heal-run.sh` automation loop.
+- Added chain proxy shim and CF mitigation helpers
+- Wired BrowserEngine, proxy agent, search2serp, and webpageToMarkdown to env proxy and CF ladder
 
-## E2E Harness Output
-```
-[Preflight] DNS lookup
-172.96.160.178  mildlyawesome.com
-[Preflight] TCP connectivity
-nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
-TCP connection failed
-```
+## E2E Attempts
+- Not executed: outbound proxy unreachable
 
-## Self-Heal Attempts
-```
-[self-heal] cycle 1
-[Preflight] DNS lookup
-172.96.160.178  mildlyawesome.com
-[Preflight] TCP connectivity
-nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
-TCP connection failed
-[self-heal] no change, stopping
-```
-
-## Remaining Issues
-- Proxy at mildlyawesome.com:49159 unreachable from environment; all network calls fail.
-- google-search vendored tool could not be fetched.
+## External Blockers
+- Final outbound proxy `mildlyawesome.com:49159` unreachable (network is unreachable)
+  - Remediation: verify egress routing or use alternate accessible proxy
 
 ## Final Status
-FAIL – network unable to reach proxy, so search2serp and web2md could not be verified end-to-end.
+FAIL – unable to reach outbound proxy; search2serp and web2md not exercised

--- a/tools/search2serp/index.js
+++ b/tools/search2serp/index.js
@@ -3,6 +3,7 @@ const { BrowserEngine } = require('../shared/BrowserEngine.mjs');
 const { buildGoogleUrl } = require('./url.js');
 const { parseSerp } = require('./parser.js');
 const { acceptConsent } = require('./consent.js');
+const { isCloudflareChallenge, persistedStatePath, shouldHeadful, markChallenge } = require('../shared/cf.mjs');
 
 async function search(q, opts={}){
   const htmlPath = opts.htmlPath || process.env.SEARCH2SERP_HTML_PATH;
@@ -11,17 +12,34 @@ async function search(q, opts={}){
     const results = parseSerp(html);
     return { query:q, results, proxy:{ enabled:false }, traceFile:null };
   }
-  const engine = await BrowserEngine.create();
-  const page = await engine.newPage();
+  let retries = 0;
   const url = buildGoogleUrl({ q, hl:opts.hl, gl:opts.gl, num:opts.num, start:opts.start });
-  await page.goto(url, { waitUntil:'domcontentloaded' });
-  await acceptConsent(page);
-  await page.waitForSelector('#search');
-  const html = await page.content();
-  const results = parseSerp(html);
-  const out = { query:q, url, results, proxy:engine.proxy, traceFile:engine.traceFile };
-  await engine.close();
-  return out;
+  while(retries < 3){
+    const headful = shouldHeadful(retries);
+    const jitter = retries === 2;
+    const engine = await BrowserEngine.create({ statePath: persistedStatePath, headless: !headful, jitter });
+    try {
+      const page = await engine.newPage();
+      await page.goto(url, { waitUntil:'domcontentloaded' });
+      await acceptConsent(page);
+      const html = await page.content();
+      if(isCloudflareChallenge(html)){
+        markChallenge();
+        await engine.close();
+        retries++; 
+        continue;
+      }
+      const results = parseSerp(html);
+      const out = { query:q, url, results, proxy:engine.proxy, traceFile:engine.traceFile };
+      await engine.close();
+      return out;
+    } catch(err){
+      await engine.close();
+      retries++;
+      if(retries>=3) throw err;
+    }
+  }
+  throw new Error('cloudflare_challenge');
 }
 
 module.exports = { search, buildGoogleUrl, parseSerp, acceptConsent };

--- a/tools/shared/BrowserEngine.mjs
+++ b/tools/shared/BrowserEngine.mjs
@@ -3,22 +3,25 @@ import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import os from 'os';
 import path from 'path';
 import { buildProxyFromEnv } from './proxy.mjs';
+import { realisticHeaders, fingerprintOptions } from './cf.mjs';
 
 chromium.use(StealthPlugin());
 
 class BrowserEngine{
   static async create(opts={}){
-    const { statePath } = opts;
+    const { statePath, headless=true, jitter=false } = opts;
     const { state:proxyState, config:proxyConfig } = buildProxyFromEnv();
-    const launchOpts = { headless:true };
+    const launchOpts = { headless };
     if(proxyConfig) launchOpts.proxy = proxyConfig;
+    const fp = fingerprintOptions(jitter);
+    launchOpts.args = ['--disable-blink-features=AutomationControlled'];
     const browser = await chromium.launch(launchOpts);
-    const ctxOpts = { ignoreHTTPSErrors:true };
+    const ctxOpts = { ignoreHTTPSErrors:true, ...fp };
     if(statePath) ctxOpts.storageState = statePath;
     const context = await browser.newContext(ctxOpts);
     const traceFile = path.join(os.tmpdir(), `trace-${Date.now()}.zip`);
     await context.tracing.start({ screenshots:true, snapshots:true });
-    const engine = new BrowserEngine(browser, context, proxyState, traceFile);
+    const engine = new BrowserEngine(browser, context, proxyState, traceFile, statePath);
     return engine;
   }
 
@@ -26,15 +29,21 @@ class BrowserEngine{
     return BrowserEngine.create({ ...opts, statePath: path });
   }
 
-  constructor(browser, context, proxy, traceFile){
+  constructor(browser, context, proxy, traceFile, statePath){
     this.browser = browser;
     this.context = context;
     this.proxy = proxy;
     this.traceFile = traceFile;
+    this.statePath = statePath;
   }
 
   async newPage(){
-    return await this.context.newPage();
+    const page = await this.context.newPage();
+    await page.setExtraHTTPHeaders(realisticHeaders());
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+    });
+    return page;
   }
 
   async saveState(file){
@@ -43,6 +52,7 @@ class BrowserEngine{
 
   async close(){
     await this.context.tracing.stop({ path: this.traceFile });
+    if(this.statePath) await this.saveState(this.statePath);
     await this.context.close();
     await this.browser.close();
   }

--- a/tools/shared/cf.mjs
+++ b/tools/shared/cf.mjs
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function isCloudflareChallenge(input){
+  if(!input) return false;
+  const body = typeof input === 'string' ? input : input.body || '';
+  const headers = typeof input === 'string' ? {} : input.headers || {};
+  const h = Object.fromEntries(Object.entries(headers).map(([k,v])=>[k.toLowerCase(), v]));
+  return (
+    /cf-mitigated:\s*challenge/i.test(body) ||
+    /__cf_bm/i.test(body) ||
+    /Just a moment/i.test(body) ||
+    /\/cdn-cgi\/challenge-platform\//i.test(body) ||
+    h['server'] === 'cloudflare'
+  );
+}
+
+function realisticHeaders(){
+  return {
+    'accept-language': 'en-US,en;q=0.9',
+    'user-agent': fingerprintOptions().userAgent,
+  };
+}
+
+function fingerprintOptions(jitter=false){
+  const baseUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+  const width = 1280 + (jitter ? Math.floor(Math.random()*20) : 0);
+  const height = 800 + (jitter ? Math.floor(Math.random()*20) : 0);
+  return { userAgent: baseUA, viewport:{ width, height } };
+}
+
+const persistedStatePath = path.join('tmp','pw-state.json');
+
+function shouldHeadful(retries){
+  return retries > 0;
+}
+
+function markChallenge(){
+  const file = path.join('tmp','cf-challenge.log');
+  fs.appendFileSync(file, `${new Date().toISOString()} challenge\n`);
+}
+
+export { isCloudflareChallenge, realisticHeaders, fingerprintOptions, persistedStatePath, shouldHeadful, markChallenge };

--- a/tools/shared/chain-proxy.mjs
+++ b/tools/shared/chain-proxy.mjs
@@ -1,0 +1,32 @@
+import { Server } from 'proxy-chain';
+import process from 'node:process';
+
+function req(name){
+  const v = process.env[name];
+  if(!v) throw new Error(`Missing ${name}`);
+  return v;
+}
+
+const PRE = req('PRE_HOP_PROXY');
+const TARGET = req('OUTBOUND_PROXY_URL');
+const USER = process.env.OUTBOUND_PROXY_USER || '';
+const PASS = process.env.OUTBOUND_PROXY_PASS || '';
+
+const targetWithAuth = (() => {
+  const u = new URL(TARGET);
+  if(USER) u.username = USER;
+  if(PASS) u.password = PASS;
+  return u.toString();
+})();
+
+const server = new Server({
+  port: 8899,
+  prepareRequestFunction: () => ({
+    upstreamProxyUrl: PRE,
+    customConnectServer: targetWithAuth,
+  }),
+});
+
+server.listen(() => {
+  console.log(`CHAIN_PROXY_URL=http://127.0.0.1:${server.port}`);
+});

--- a/tools/shared/proxy.mjs
+++ b/tools/shared/proxy.mjs
@@ -3,12 +3,12 @@ function truthy(value){
 }
 
 function buildProxyFromEnv(env = process.env){
-  if(!truthy(env.OUTBOUND_PROXY_ENABLED)){
-    return { state:{ enabled:false } };
-  }
-  let url = env.OUTBOUND_PROXY_URL;
+  let url = env.http_proxy || env.https_proxy || env.OUTBOUND_PROXY_URL;
   if(!url){
-    return { state:{ enabled:false, reason:'missing_url' } };
+    if(truthy(env.OUTBOUND_PROXY_ENABLED)){
+      return { state:{ enabled:false, reason:'missing_url' } };
+    }
+    return { state:{ enabled:false } };
   }
   if(!/^https?:\/\//.test(url)) url = 'http://' + url;
   const config = { server:url };


### PR DESCRIPTION
## Summary
- add two-hop chain proxy shim and Cloudflare helper utilities
- wire BrowserEngine, proxy agent, search2serp, and webpageToMarkdown to env proxy and challenge ladder
- document proxy audit and note outbound proxy unreachable

## Testing
- `curl -fsS https://www.gstatic.com/generate_204 -o /dev/null`
- `getent hosts mildlyawesome.com`
- `nc -vz mildlyawesome.com 49159 || echo '[tcp] FAIL'`
- `curl -sS -o /dev/null -w '%{http_code}' -x "$OUTBOUND_PROXY_URL" http://example.com --connect-timeout 8`
- `curl -sS -o /dev/null -w '%{http_code}' -x "$OUTBOUND_PROXY_URL" -U "$OUTBOUND_PROXY_USER:$OUTBOUND_PROXY_PASS" https://httpbin.org/ip --connect-timeout 12`


------
https://chatgpt.com/codex/tasks/task_e_6899bce3902c8330b16941d80ec80750