### PR TITLE
chore: wire CHAIN proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ Thumbs.db
 
 # Misc
 .env
+tools/google-search/
+tools/search2serp/package-lock.json

--- a/lib/proxyAgent.js
+++ b/lib/proxyAgent.js
@@ -1,31 +1,14 @@
-const { setGlobalDispatcher, ProxyAgent } = require('undici');
-
-function truthy(value){
-  return ['1','true','TRUE'].includes(String(value));
-}
+const { setGlobalDispatcher, ProxyAgent, Agent } = require('undici');
 
 async function configureProxyFromEnv(env = process.env){
-  let server = env.http_proxy || env.https_proxy || env.OUTBOUND_PROXY_URL;
-  if(!server){
-    if(truthy(env.OUTBOUND_PROXY_ENABLED)){
-      return { enabled:false, reason:'missing_url' };
-    }
+  const url = env.CHAIN_PROXY_URL;
+  if(url){
+    setGlobalDispatcher(new ProxyAgent(url));
+    return { enabled:true, server:new URL(url).host };
+  } else {
+    setGlobalDispatcher(new Agent());
     return { enabled:false };
   }
-  if(!/^https?:\/\//.test(server)) server = 'http://' + server;
-  const url = new URL(server);
-  let auth = 'absent';
-  if(env.OUTBOUND_PROXY_USER){
-    url.username = env.OUTBOUND_PROXY_USER;
-    if(env.OUTBOUND_PROXY_PASS){
-      url.password = env.OUTBOUND_PROXY_PASS;
-      auth = 'present';
-    } else {
-      auth = 'username_only';
-    }
-  }
-  setGlobalDispatcher(new ProxyAgent(url.toString()));
-  return { enabled:true, server:url.host, auth };
 }
 
 module.exports = { configureProxyFromEnv };

--- a/proxy_audit_report.md
+++ b/proxy_audit_report.md
@@ -2,57 +2,47 @@
 
 ## Environment Snapshot
 - Node: v22.18.0
-- npm: 10.9.3
+- npm: 11.4.2
 - Playwright: 1.54.2
-- HTTP_PROXY: http://proxy:8080
-- HTTPS_PROXY: http://proxy:8080
-- OUTBOUND_PROXY_URL: http://mildlyawesome.com:49159
-- OUTBOUND_PROXY_USER: toxic
-- OUTBOUND_PROXY_PASS: ******
-- NODE_EXTRA_CA_CERTS: (unset)
+- CHAIN_PROXY_URL: http://127.0.0.1:8899 (shim exits with ECONNRESET)
 
 ## Baseline Reachability
 ```
 [baseline] OK
 ```
 
-## DNS & TCP Gate
+## DNS Resolution
 ```
 172.96.160.178  mildlyawesome.com
-nc: connect to mildlyawesome.com (172.96.160.178) port 49159 (tcp) failed: Network is unreachable
 ```
 
-## Proxy Preflight
-### Unauthenticated
+## Proxy Hop Proofs
+### Pre-hop
 ```
-curl: (7) Failed to connect to example.com port 80 after 44 ms: Couldn't connect to server
-000
+[pre-hop] OK
 ```
-### Authenticated CONNECT
+### Second hop unauthenticated
 ```
-curl: (7) Failed to connect to httpbin.org port 443 after 51 ms: Couldn't connect to server
-000
+200
+```
+### Second hop authenticated
+```
+200
 ```
 
-## Chain-Shim
-- Not started: TCP gate failed
+## Chain Shim Proof
+```
+HTTP/1.1 595 ECONNRESET
+```
 
-## Cloudflare Detections
-- Not attempted
+## Test Attempts
+```
+npm test
+pass 1
+```
 
-## Dependency Installs
-- `npm install` (added proxy-chain)
-
-## Code Changes
-- Added chain proxy shim and CF mitigation helpers
-- Wired BrowserEngine, proxy agent, search2serp, and webpageToMarkdown to env proxy and CF ladder
-
-## E2E Attempts
-- Not executed: outbound proxy unreachable
-
-## External Blockers
-- Final outbound proxy `mildlyawesome.com:49159` unreachable (network is unreachable)
-  - Remediation: verify egress routing or use alternate accessible proxy
+## External Blocker
+- chain-proxy.mjs unable to establish upstream tunnel: `ECONNRESET`
 
 ## Final Status
-FAIL – unable to reach outbound proxy; search2serp and web2md not exercised
+FAIL – chain proxy 595 ECONNRESET; search2serp and web2md not exercised

--- a/tools/shared/BrowserEngine.mjs
+++ b/tools/shared/BrowserEngine.mjs
@@ -2,7 +2,6 @@ import { chromium } from 'playwright-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import os from 'os';
 import path from 'path';
-import { buildProxyFromEnv } from './proxy.mjs';
 import { realisticHeaders, fingerprintOptions } from './cf.mjs';
 
 chromium.use(StealthPlugin());
@@ -10,9 +9,13 @@ chromium.use(StealthPlugin());
 class BrowserEngine{
   static async create(opts={}){
     const { statePath, headless=true, jitter=false } = opts;
-    const { state:proxyState, config:proxyConfig } = buildProxyFromEnv();
     const launchOpts = { headless };
-    if(proxyConfig) launchOpts.proxy = proxyConfig;
+    let proxyState = { enabled:false };
+    const server = process.env.CHAIN_PROXY_URL;
+    if(server){
+      launchOpts.proxy = { server };
+      proxyState = { enabled:true, server };
+    }
     const fp = fingerprintOptions(jitter);
     launchOpts.args = ['--disable-blink-features=AutomationControlled'];
     const browser = await chromium.launch(launchOpts);

--- a/tools/shared/chain-proxy.mjs
+++ b/tools/shared/chain-proxy.mjs
@@ -1,4 +1,4 @@
-import { Server } from 'proxy-chain';
+import { Server, createTunnel } from 'proxy-chain';
 import process from 'node:process';
 
 function req(name){
@@ -12,18 +12,18 @@ const TARGET = req('OUTBOUND_PROXY_URL');
 const USER = process.env.OUTBOUND_PROXY_USER || '';
 const PASS = process.env.OUTBOUND_PROXY_PASS || '';
 
-const targetWithAuth = (() => {
-  const u = new URL(TARGET);
-  if(USER) u.username = USER;
-  if(PASS) u.password = PASS;
-  return u.toString();
+const targetUrl = new URL(TARGET);
+const tunnel = await createTunnel(PRE, `${targetUrl.hostname}:${targetUrl.port}`);
+const upstreamProxyUrl = (() => {
+  const auth = USER ? `${encodeURIComponent(USER)}:${encodeURIComponent(PASS)}@` : '';
+  return `http://${auth}${tunnel}`;
 })();
 
 const server = new Server({
   port: 8899,
+  verbose: true,
   prepareRequestFunction: () => ({
-    upstreamProxyUrl: PRE,
-    customConnectServer: targetWithAuth,
+    upstreamProxyUrl,
   }),
 });
 

--- a/tools/web2md/index.js
+++ b/tools/web2md/index.js
@@ -1,6 +1,7 @@
 const { JSDOM } = require('jsdom');
 const { Readability } = require('@mozilla/readability');
 const TurndownService = require('turndown');
+const { configureProxyFromEnv } = require('../../lib/proxyAgent');
 
 function stripTracking(u){
   const url = new URL(u);
@@ -10,8 +11,8 @@ function stripTracking(u){
   return url.toString();
 }
 
-function normalizeHTML(html,url){
-  const dom = new JSDOM(html,{url});
+function normalizeHTML(html, url){
+  const dom = new JSDOM(html, { url });
   const doc = dom.window.document;
   const links = doc.querySelectorAll('a[href]');
   links.forEach(a=>{ try{ a.href = stripTracking(a.href); }catch{} });
@@ -23,16 +24,44 @@ function normalizeHTML(html,url){
   return md;
 }
 
-async function fetchWithBrowser(url){
-  const { BrowserEngine } = await import('../shared/BrowserEngine.mjs');
-  const engine = await BrowserEngine.create();
-  const page = await engine.newPage();
-  await page.goto(url, { waitUntil:'networkidle' });
-  const html = await page.content();
-  const markdown = normalizeHTML(html,url);
-  const result = { html, markdown, proxy: engine.proxy, traceFile: engine.traceFile };
-  await engine.close();
-  return result;
+async function fetchWithFallback(url){
+  await configureProxyFromEnv();
+  const { isCloudflareChallenge, realisticHeaders, persistedStatePath, shouldHeadful, markChallenge } = await import('../shared/cf.mjs');
+  let res = await fetch(url, { headers: realisticHeaders() });
+  let html = await res.text();
+  if(isCloudflareChallenge({ headers: Object.fromEntries(res.headers), body: html })){
+    markChallenge();
+    let retries = 0;
+    while(retries < 3){
+      const headful = shouldHeadful(retries);
+      const jitter = retries === 2;
+      const { BrowserEngine } = await import('../shared/BrowserEngine.mjs');
+      const engine = await BrowserEngine.create({ statePath: persistedStatePath, headless: !headful, jitter });
+      try{
+        const page = await engine.newPage();
+        await page.goto(url, { waitUntil:'networkidle' });
+        html = await page.content();
+        if(isCloudflareChallenge(html)){
+          markChallenge();
+          await engine.close();
+          retries++;
+          continue;
+        }
+        const markdown = normalizeHTML(html, url);
+        const result = { html, markdown, proxy: engine.proxy, traceFile: engine.traceFile };
+        await engine.close();
+        return result;
+      }catch(err){
+        await engine.close();
+        retries++;
+        if(retries >= 3) throw err;
+      }
+    }
+    throw new Error('cloudflare_challenge');
+  }
+  const markdown = normalizeHTML(html, url);
+  return { html, markdown, proxy:{ enabled:!!process.env.CHAIN_PROXY_URL, server: process.env.CHAIN_PROXY_URL || null }, traceFile:null };
 }
 
-module.exports = { fetchWithBrowser, fetchWithFallback: fetchWithBrowser };
+module.exports = { fetchWithFallback, fetchWithBrowser: fetchWithFallback, normalizeHTML };
+


### PR DESCRIPTION
## Summary
- attempt tunnel-based chain proxy forcing pre-hop and authenticated upstream
- run Playwright tests via dedicated runner in test harness
- document proxy audit with ECONNRESET chain failure

## Testing
- `npm test`
- `scripts/e2e-serp-proxy-check.sh` *(fails: CONNECT tunnel failed, response 595)*

------
https://chatgpt.com/codex/tasks/task_e_6899bf9d9dc483309a355bede4917181