### PR TITLE
fix: avoid unintended proxy usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ OUTBOUND_PROXY_PASS=...
 ```
 
 Set `OUTBOUND_PROXY_ENABLED` to any other value to disable proxying. Credentials are optional.
+System `http_proxy`/`https_proxy` variables are ignored; specify `OUTBOUND_PROXY_URL` explicitly when enabling.
 
 ### search2serp CLI
 

--- a/test/browser-proxy.test.mjs
+++ b/test/browser-proxy.test.mjs
@@ -20,10 +20,18 @@ test('BrowserEngine passes proxy settings to launch', async () => {
   let received;
   chromium.launch = async opts => { received = opts; return new FakeBrowser(); };
   const { BrowserEngine } = await import('../tools/shared/BrowserEngine.mjs');
+  const originalEnabled = process.env.OUTBOUND_PROXY_ENABLED;
+  const originalUrl = process.env.OUTBOUND_PROXY_URL;
+  const originalChain = process.env.CHAIN_PROXY_URL;
+  delete process.env.CHAIN_PROXY_URL;
   process.env.OUTBOUND_PROXY_ENABLED='1';
   process.env.OUTBOUND_PROXY_URL='http://proxy:8080';
   const engine = await BrowserEngine.create();
   assert.equal(received.proxy.server, 'http://proxy:8080');
   await engine.close();
   chromium.launch = originalLaunch;
+  process.env.OUTBOUND_PROXY_ENABLED = originalEnabled;
+  if(originalUrl !== undefined) process.env.OUTBOUND_PROXY_URL = originalUrl;
+  else delete process.env.OUTBOUND_PROXY_URL;
+  if(originalChain !== undefined) process.env.CHAIN_PROXY_URL = originalChain;
 });

--- a/test/proxy.test.mjs
+++ b/test/proxy.test.mjs
@@ -8,6 +8,11 @@ test('proxy disabled returns disabled state', () => {
   assert.equal(config, undefined);
 });
 
+test('http_proxy ignored when not explicitly enabled', () => {
+  const { state } = buildProxyFromEnv({ http_proxy:'http://example:8080' });
+  assert.equal(state.enabled, false);
+});
+
 test('proxy enabled without auth', () => {
   const env = { OUTBOUND_PROXY_ENABLED:'1', OUTBOUND_PROXY_URL:'http://example:8080' };
   const { state, config } = buildProxyFromEnv(env);

--- a/tools/shared/BrowserEngine.mjs
+++ b/tools/shared/BrowserEngine.mjs
@@ -3,6 +3,7 @@ import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import os from 'os';
 import path from 'path';
 import { realisticHeaders, fingerprintOptions } from './cf.mjs';
+import { buildProxyFromEnv } from './proxy.mjs';
 
 chromium.use(StealthPlugin());
 
@@ -10,11 +11,9 @@ class BrowserEngine{
   static async create(opts={}){
     const { statePath, headless=true, jitter=false } = opts;
     const launchOpts = { headless };
-    let proxyState = { enabled:false };
-    const server = process.env.CHAIN_PROXY_URL;
-    if(server){
-      launchOpts.proxy = { server };
-      proxyState = { enabled:true, server };
+    const { state: proxyState, config: proxyConfig } = buildProxyFromEnv();
+    if(proxyState.enabled){
+      launchOpts.proxy = { server: proxyConfig.server };
     }
     const fp = fingerprintOptions(jitter);
     launchOpts.args = ['--disable-blink-features=AutomationControlled'];

--- a/tools/shared/proxy.mjs
+++ b/tools/shared/proxy.mjs
@@ -3,12 +3,12 @@ function truthy(value){
 }
 
 function buildProxyFromEnv(env = process.env){
-  let url = env.http_proxy || env.https_proxy || env.OUTBOUND_PROXY_URL;
-  if(!url){
-    if(truthy(env.OUTBOUND_PROXY_ENABLED)){
-      return { state:{ enabled:false, reason:'missing_url' } };
-    }
+  if(!truthy(env.OUTBOUND_PROXY_ENABLED)){
     return { state:{ enabled:false } };
+  }
+  let url = env.CHAIN_PROXY_URL || env.OUTBOUND_PROXY_URL;
+  if(!url){
+    return { state:{ enabled:false, reason:'missing_url' } };
   }
   if(!/^https?:\/\//.test(url)) url = 'http://' + url;
   const config = { server:url };


### PR DESCRIPTION
## Summary
- require explicit `OUTBOUND_PROXY_ENABLED` and URL before enabling outbound proxies
- wire `BrowserEngine` to shared proxy helper and ignore stray `http_proxy` variables
- document proxy opt-in and cover behavior with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a9c51668883308a9746bda710bc46