### PR TITLE
refactor: simplify section indexes

### DIFF
--- a/src/_includes/components/list-item.njk
+++ b/src/_includes/components/list-item.njk
@@ -1,0 +1,12 @@
+{% macro listItem(item) %}
+<a href="{{ item.url }}" aria-label="{{ item.data.title }}" class="block rounded-lg border border-white/10 p-4 transition hover:bg-white/5 focus:outline-none focus:ring">
+  <h3 class="font-heading text-lg text-gray-100">{{ item.data.title }}</h3>
+  {% if item.data.description %}
+  <p class="mt-1 text-sm text-gray-300">{{ item.data.description }}</p>
+  {% endif %}
+  <div class="mt-2 flex items-center justify-between text-xs text-gray-400">
+    {% if item.data.type %}<span class="capitalize">{{ item.data.type }}</span>{% endif %}
+    {% if item.date %}<time datetime="{{ item.date | htmlDateString }}">{{ item.date | readableDate }}</time>{% endif %}
+  </div>
+</a>
+{% endmacro %}

--- a/src/content/concepts/index.njk
+++ b/src/content/concepts/index.njk
@@ -6,11 +6,11 @@ eleventyNavigation:
   key: Concepts
   parent: Showcase
 ---
-{% from "components/tile.njk" import tile %}
+{% from "components/list-item.njk" import listItem %}
 
 <p>This is the central hub for all individual concepts explored within the lab.</p>
-<ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+<ul class="space-y-4">
 {% for item in collections.concepts %}
-  {% if item.url != page.url %}<li>{{ tile(item) }}</li>{% endif %}
+  {% if item.url != page.url %}<li>{{ listItem(item) }}</li>{% endif %}
 {% endfor %}
 </ul>

--- a/src/content/meta/index.njk
+++ b/src/content/meta/index.njk
@@ -6,11 +6,11 @@ eleventyNavigation:
   key: Meta
   parent: Showcase # Adjust parent as needed for your navigation
 ---
-{% from "components/tile.njk" import tile %}
+{% from "components/list-item.njk" import listItem %}
 
 <p>This section contains information about the lab itself, its purpose, and related administrative details.</p>
-<ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+<ul class="space-y-4">
 {% for item in collections.meta %}
-  {% if item.url != page.url %}<li>{{ tile(item) }}</li>{% endif %}
+  {% if item.url != page.url %}<li>{{ listItem(item) }}</li>{% endif %}
 {% endfor %}
 </ul>

--- a/src/content/projects/index.njk
+++ b/src/content/projects/index.njk
@@ -6,11 +6,11 @@ eleventyNavigation:
   key: Projects
   parent: Showcase # If you use parent for navigation hierarchy
 ---
-{% from "components/tile.njk" import tile %}
+{% from "components/list-item.njk" import listItem %}
 
 <p>This is the central hub for all projects explored within the lab.</p>
-<ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+<ul class="space-y-4">
 {% for item in collections.projects %}
-  {% if item.url != page.url %}<li>{{ tile(item) }}</li>{% endif %}
+  {% if item.url != page.url %}<li>{{ listItem(item) }}</li>{% endif %}
 {% endfor %}
 </ul>

--- a/src/content/sparks/index.njk
+++ b/src/content/sparks/index.njk
@@ -6,11 +6,11 @@ eleventyNavigation:
   key: Sparks
   parent: Showcase # Adjust parent as needed for your navigation
 ---
-{% from "components/tile.njk" import tile %}
+{% from "components/list-item.njk" import listItem %}
 
 <p>Here you'll find nascent ideas, quick notes, and experimental fragments that may one day ignite into full concepts or projects.</p>
-<ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+<ul class="space-y-4">
 {% for item in collections.sparks %}
-  {% if item.url != page.url %}<li>{{ tile(item) }}</li>{% endif %}
+  {% if item.url != page.url %}<li>{{ listItem(item) }}</li>{% endif %}
 {% endfor %}
 </ul>

--- a/src/index.njk
+++ b/src/index.njk
@@ -5,7 +5,7 @@ showTitle: false
 ---
 
 {% from "components/section.njk" import section %}
-{% from "components/tile.njk" import tile %}
+{% from "components/list-item.njk" import listItem %}
 {% from "components/pathway.njk" import pathway %}
 {% from "components/kpis.njk" import kpis %}
 
@@ -17,7 +17,7 @@ showTitle: false
   {% call section('Featured', null) %}
     <div class="grid gap-6 sm:grid-cols-3">
       {% for item in featured %}
-        {{ tile(item) }}
+        {{ listItem(item) }}
       {% endfor %}
     </div>
   {% endcall %}
@@ -27,7 +27,7 @@ showTitle: false
     {% call section('Today at the Lab', '/meta/') %}
       <div class="grid gap-6 sm:grid-cols-3">
         {% for item in today %}
-          {{ tile(item) }}
+          {{ listItem(item) }}
         {% endfor %}
       </div>
     {% endcall %}
@@ -37,7 +37,7 @@ showTitle: false
     {% call section('Try It Now', '/projects/') %}
       <div class="grid gap-6 sm:grid-cols-3">
         {% for item in tryNow %}
-          {{ tile(item) }}
+          {{ listItem(item) }}
         {% endfor %}
       </div>
     {% endcall %}
@@ -67,7 +67,7 @@ showTitle: false
     {% call section('Lab Notebook', '/sparks/') %}
       <div class="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
         {% for item in notebook %}
-          {{ tile(item) }}
+          {{ listItem(item) }}
         {% endfor %}
       </div>
     {% endcall %}

--- a/test/section-index.test.js
+++ b/test/section-index.test.js
@@ -21,9 +21,9 @@ function render(section) {
 }
 
 ['projects','concepts','sparks','meta'].forEach(section => {
-  test(`${section} index uses tile grid`, () => {
+  test(`${section} index uses list layout`, () => {
     const html = render(section);
-    assert.match(html, /<ul class="grid/);
-    assert.match(html, /class="tile/);
+    assert.match(html, /<ul class="space-y-4">/);
+    assert.match(html, /class="block rounded-lg/);
   });
 });


### PR DESCRIPTION
## Summary
- replace image-based tiles with text cards for a cleaner aesthetic
- apply new list layout across Projects, Concepts, Sparks, Meta, and homepage sections
- update tests for revised section index markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aa19da8b883309336fde3c860e24c