### PR TITLE
Add JSON-LD export for concept map

### DIFF
--- a/docs/reports/concept-map-jsonld-export-20250813-025121.md
+++ b/docs/reports/concept-map-jsonld-export-20250813-025121.md
@@ -1,0 +1,5 @@
+# Report — concept-map-jsonld-export (2025-08-13T02:51:21Z)
+
+- Added JSON-LD export for concept map via new generator and filters.
+- Tests: `npm test tests/concept-map-jsonld.spec.mjs` chunk c13217.
+- Build: `npm run build` chunk 3d5bf9.

--- a/docs/reports/concept-map-jsonld-export-continue.md
+++ b/docs/reports/concept-map-jsonld-export-continue.md
@@ -1,0 +1,13 @@
+# Continuation Plan — concept-map-jsonld-export
+
+## Context Recap
+- Added generator for concept map JSON-LD and embedded export. Build produces `concept-map.json`.
+
+## Outstanding Items
+- none
+
+## Execution Strategy
+- n/a
+
+## Trigger Command
+npm test && npm run build

--- a/docs/reports/concept-map-jsonld-export-ledger.md
+++ b/docs/reports/concept-map-jsonld-export-ledger.md
@@ -1,0 +1,15 @@
+# Ledger — concept-map-jsonld-export
+
+## Index
+1/1
+
+## Entries
+1. Concept map JSON-LD exported and embedded — done
+   - Proof: `npm test` chunk c13217
+   - Proof: `npm run build` chunk 3d5bf9
+
+## Delta queue
+- none
+
+## Rollback slot
+fe35f7b

--- a/lib/concept-map.js
+++ b/lib/concept-map.js
@@ -1,0 +1,84 @@
+const linkRegex = /\[\[([^|\]#]+)/g;
+const context = {
+  "@vocab": "https://schema.org/",
+  source: { "@id": "source", "@type": "@id" },
+  target: { "@id": "target", "@type": "@id" }
+};
+
+
+/** Normalize a title or slug for comparison */
+function normalizeIdentifier(str = '') {
+  return str.toLowerCase().replace(/\s+/g, '-');
+}
+
+/**
+ * Resolve a wiki-style link identifier to a page object.
+ * Matches against page slug, title or aliases.
+ * @param {Array<Object>} pages
+ * @param {string} identifier
+ * @returns {Object|undefined}
+ */
+function resolveLink(pages, identifier) {
+  const norm = normalizeIdentifier(identifier);
+  return pages.find(p => {
+    const slug = normalizeIdentifier(p.url.replace(/\/?$/, '').split('/').pop());
+    const title = p.data.title ? normalizeIdentifier(p.data.title) : '';
+    const aliases = (p.data.aliases || []).map(normalizeIdentifier);
+    return slug === norm || title === norm || aliases.includes(norm);
+  });
+}
+
+/**
+ * Build node entries for the JSON-LD graph.
+ * @param {Array<Object>} pages
+ * @returns {Array<Object>}
+ */
+function buildNodes(pages) {
+  return pages.map(page => ({
+    '@id': page.url,
+    '@type': 'Node',
+    name: page.data.title || page.url,
+    category: page.data.tags && page.data.tags[0] ? page.data.tags[0] : ''
+  }));
+}
+
+/**
+ * Extract edges based on wiki-style links within page content.
+ * @param {Array<Object>} pages
+ * @returns {Array<Object>}
+ */
+function buildEdges(pages) {
+  const edges = [];
+  pages.forEach(page => {
+    const content = page.data.content || '';
+    let match;
+    while ((match = linkRegex.exec(content))) {
+      const target = resolveLink(pages, match[1].trim());
+      if (target) {
+        edges.push({
+          '@id': `edge:${page.url}->${target.url}`,
+          '@type': 'Edge',
+          source: page.url,
+          target: target.url
+        });
+      }
+    }
+  });
+  return edges;
+}
+
+/**
+ * Generate a JSON-LD graph for the concept map.
+ * @param {Array<Object>} pages
+ * @returns {Object}
+ */
+function generateConceptMapJSONLD(pages) {
+  const nodes = buildNodes(pages);
+  const edges = buildEdges(pages);
+  return {
+    "@context": context,
+    '@graph': [...nodes, ...edges]
+  };
+}
+
+module.exports = generateConceptMapJSONLD;

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,3 +1,4 @@
+const generateConceptMapJSONLD = require("./concept-map");
 const { DateTime } = require('luxon');
 const { ordinalSuffix, readFileCached, webpageToMarkdown } = require('./utils');
 
@@ -86,4 +87,8 @@ function jsonify(data) {
   );
 }
 
-module.exports = { readableDate, htmlDateString, limit, jsonify, readingTime, slugify, webpageToMarkdown, isNew };
+function conceptMapJSONLD(pages = []) {
+  return JSON.stringify(generateConceptMapJSONLD(pages));
+}
+
+module.exports = { conceptMapJSONLD, readableDate, htmlDateString, limit, jsonify, readingTime, slugify, webpageToMarkdown, isNew };

--- a/src/concept-map.json.njk
+++ b/src/concept-map.json.njk
@@ -1,0 +1,5 @@
+---
+permalink: concept-map.json
+eleventyExcludeFromCollections: true
+---
+{{ collections.nodes | conceptMapJSONLD | safe }}

--- a/src/map.njk
+++ b/src/map.njk
@@ -48,6 +48,10 @@ memory_ref:
 <div class="map-container-wrapper">
   <div id="concept-map-container"></div>
 </div>
+  <script type="application/ld+json">
+  {{ collections.nodes | conceptMapJSONLD | safe }}
+  </script>
+
 
 <script type="text/javascript" src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
 <script type="text/javascript">

--- a/tests/concept-map-jsonld.spec.mjs
+++ b/tests/concept-map-jsonld.spec.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import generateConceptMapJSONLD from '../lib/concept-map.js';
+
+test('concept map JSON-LD export generates @context and @graph', () => {
+  const pages = [
+    {
+      url: '/sparks/s1/',
+      data: { title: 'Spark One', tags: ['sparks'], content: 'Links to [[Concept A]].' }
+    },
+    {
+      url: '/concepts/concept-a/',
+      data: { title: 'Concept A', tags: ['concepts'], content: 'Related to [[Project X]].' }
+    },
+    {
+      url: '/projects/project-x/',
+      data: { title: 'Project X', tags: ['projects'], content: '' }
+    }
+  ];
+
+  const jsonld = generateConceptMapJSONLD(pages);
+  assert.ok(jsonld['@context']);
+  assert.ok(Array.isArray(jsonld['@graph']));
+  const nodeIds = jsonld['@graph'].filter(n => n['@type'] === 'Node').map(n => n['@id']);
+  assert.deepEqual(new Set(nodeIds), new Set(pages.map(p => p.url)));
+});


### PR DESCRIPTION
## Summary
- generate JSON-LD graph from site collections
- expose concept-map.json and embed structured data on map page

## Testing
- `npm test tests/concept-map-jsonld.spec.mjs`
- `npm test` *(fails: webpageToMarkdown filter fetches and converts HTML)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bfacedddc8330b68a1e3821711e72