### PR TITLE
Expose archive child counts with hard-edged list

### DIFF
--- a/docs/reports/entropy-garden-continue.md
+++ b/docs/reports/entropy-garden-continue.md
@@ -1,0 +1,13 @@
+# entropy-garden Continuation
+
+## Context Recap
+Implemented child counts in archive navigation and added test coverage.
+
+## Outstanding Items
+- None
+
+## Execution Strategy
+- N/A
+
+## Trigger Command
+npm test

--- a/docs/reports/entropy-garden-ledger.md
+++ b/docs/reports/entropy-garden-ledger.md
@@ -1,0 +1,17 @@
+# entropy-garden Ledger
+
+## Acceptance Criteria 1/1
+- [x] Archive navigation shows child directory counts in UI.
+
+### Proof
+- tests/archive-nav-count.spec.mjs
+- logs/entropy-garden/run-3.log (sha256 f1d0793665f95212dd9b0e8355d2ecebd5f5c0d1d8ac8108ff15feb04ebad3e5)
+
+## Delta Queue
+- None
+
+## Stability
+- run-3.log sha256 f1d0793665f95212dd9b0e8355d2ecebd5f5c0d1d8ac8108ff15feb04ebad3e5
+
+## Rollback
+- last safe commit: 2ebfb51119f72e00749b6223e09e4c4cb1353e4e

--- a/lib/archive-nav.js
+++ b/lib/archive-nav.js
@@ -14,6 +14,10 @@ function titleize(name) {
     .join(' ');
 }
 
+function subdirs(p) {
+  return fs.readdirSync(p, { withFileTypes: true }).filter((e) => e.isDirectory());
+}
+
 /**
  * Build a map of archive navigation entries keyed by their URL.
  * @param {string} dir absolute directory to scan
@@ -22,13 +26,13 @@ function titleize(name) {
  * @returns {Object} map of url -> nav items
  */
 function buildMap(dir, url, acc = {}) {
-  const entries = fs
-    .readdirSync(dir, { withFileTypes: true })
-    .filter((e) => e.isDirectory());
+  const entries = subdirs(dir);
 
   acc[url] = entries.map((e) => {
+    const nextDir = path.join(dir, e.name);
     const childUrl = path.posix.join(url, e.name) + '/';
-    return { title: titleize(e.name), url: childUrl };
+    const count = subdirs(nextDir).length;
+    return { title: titleize(e.name), url: childUrl, count };
   });
 
   entries.forEach((e) => {

--- a/logs/entropy-garden/run-1.log
+++ b/logs/entropy-garden/run-1.log
@@ -1,0 +1,335 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> node tools/test-changed.mjs tests/archive-nav-count.spec.mjs
+
+TAP version 13
+# npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+# 🚀 Eleventy build starting with enhanced footnote system...
+# ✅ Eleventy build completed. Generated 107 files.
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 75 Wrote 107 files in 1.85 seconds (17.3ms each, v3.1.2)
+# Subtest: archive nav exposes child counts
+not ok 1 - archive nav exposes child counts
+  ---
+  duration_ms: 2850.562504
+  type: 'test'
+  location: '/workspace/effusion-labs/tests/archive-nav-count.spec.mjs:11:1'
+  failureType: 'testCodeFailure'
+  error: |-
+    The input did not match the regular expression />POP MART \(1\)</. Input:
+    
+    '\n' +
+      '<!DOCTYPE html>\n' +
+      '<html lang="en" data-theme="dark" class="scroll-pt-16 dark">\n' +
+      '<head>\n' +
+      '  <meta charset="UTF-8">\n' +
+      '  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
+      '  <title>Designer Toys | Effusion Labs</title>\n' +
+      '\n' +
+      '  <meta name="color-scheme" content="dark light">\n' +
+      '  <script>(function(){\n' +
+      "  const storageKey = 'theme';\n" +
+      '  const doc = document.documentElement;\n' +
+      '  const stored = localStorage.getItem(storageKey);\n' +
+      `  const meta = document.querySelector('meta[name="color-scheme"]') || (function(){\n` +
+      "    const m = document.createElement('meta');\n" +
+      "    m.name = 'color-scheme';\n" +
+      '    document.head.appendChild(m);\n' +
+      '    return m;\n' +
+      '  })();\n' +
+      '  let theme = stored;\n' +
+      "  if (theme !== 'dark' && theme !== 'light') {\n" +
+      "    theme = 'dark';\n" +
+      '  }\n' +
+      '  doc.dataset.theme = theme;\n' +
+      "  doc.classList.toggle('dark', theme === 'dark');\n" +
+      "  meta.content = theme === 'light' ? 'light dark' : 'dark light';\n" +
+      '})();\n' +
+      '</script>\n' +
+      '\n' +
+      '  <link rel="stylesheet" href="/assets/css/app.css">\n' +
+      '  <link rel="preconnect" href="https://fonts.googleapis.com">\n' +
+      '  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">\n' +
+      '  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">\n' +
+      '  <script src="/assets/js/lucide.min.js"></script>\n' +
+      '</head>\n' +
+      '\n' +
+      '<body class="bg-background text-text font-body leading-relaxed text-[17px]">\n' +
+      '  <a href="#main" class="skip-link">Skip to main content</a>\n' +
+      '  <header class="sticky top-0 z-40 w-full bg-base-100/90 backdrop-blur shadow">\n' +
+      '  <div class="navbar mx-auto max-w-screen-2xl px-6">\n' +
+      '    <div class="flex-1">\n' +
+      '      <a href="/" class="flex items-center gap-2 font-heading text-3xl text-primary">\n' +
+      '        <i data-lucide="flask-conical" class="w-6 h-6"></i><span>Effusion Labs</span>\n' +
+      '      </a>\n' +
+      '    </div>\n' +
+      '    <div class="flex-none lg:hidden">\n' +
+      '      <div class="dropdown dropdown-end">\n' +
+      '        <label tabindex="0" class="btn btn-ghost btn-square">\n' +
+      '          <i data-lucide="menu" class="w-6 h-6"></i>\n' +
+      '        </label>\n' +
+      '        <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-40">\n' +
+      '          \n' +
+      '          <li><a href="/">Showcase</a></li>\n' +
+      '          \n' +
+      '          <li><a href="/sparks/">Sparks</a></li>\n' +
+      '          \n' +
+      '          <li><a href="/concepts/">Concepts</a></li>\n' +
+      '          \n' +
+      '          <li><a href="/projects/">Projects</a></li>\n' +
+      '          \n' +
+      '          <li><a href="/archives/">Archives</a></li>\n' +
+      '          \n' +
+      '          <li><a href="/meta/">Meta</a></li>\n' +
+      '          \n' +
+      '          <li><a href="/map/">Map</a></li>\n' +
+      '          \n' +
+      '        </ul>\n' +
+      '      </div>\n' +
+      '    </div>\n' +
+      '    <div class="flex-none flex items-center gap-2">\n' +
+      '      <button id="theme-toggle" class="btn btn-ghost btn-square" aria-label="Switch to light theme" aria-pressed="true">\n' +
+      '        <span class="sr-only">Toggle theme</span>\n' +
+      '        <i data-lucide="sun" class="w-6 h-6 hidden"></i>\n' +
+      '        <i data-lucide="moon" class="w-6 h-6"></i>\n' +
+      '      </button>\n' +
+      '    </div>\n' +
+      '    <nav class="flex-none hidden lg:flex">\n' +
+      '      <ul class="menu menu-horizontal px-1">\n' +
+      '        \n' +
+      '        <li><a href="/" class="hover:text-primary">Showcase</a></li>\n' +
+      '        \n' +
+      '        <li><a href="/sparks/" class="hover:text-primary">Sparks</a></li>\n' +
+      '        \n' +
+      '        <li><a href="/concepts/" class="hover:text-primary">Concepts</a></li>\n' +
+      '        \n' +
+      '        <li><a href="/projects/" class="hover:text-primary">Projects</a></li>\n' +
+      '        \n' +
+      '        <li><a href="/archives/" class="hover:text-primary">Archives</a></li>\n' +
+      '        \n' +
+      '        <li><a href="/meta/" class="hover:text-primary">Meta</a></li>\n' +
+      '        \n' +
+      '        <li><a href="/map/" class="hover:text-primary">Map</a></li>\n' +
+      '        \n' +
+      '      </ul>\n' +
+      '    </nav>\n' +
+      '  </div>\n' +
+      '</header>\n' +
+      '\n' +
+      '\n' +
+      '  <div class="mx-auto max-w-screen-2xl px-6">\n' +
+      '    \n' +
+      '    \n' +
+      '\n' +
+      '    <main id="main" class="\n' +
+      '      xl:grid xl:gap-10 xl:grid-cols-[1fr_16rem]\n' +
+      '       mt-12\n' +
+      '    ">\n' +
+      '      <article class="prose dark:prose-invert max-w-none m-0\n' +
+      '         xl:col-span-1 \n' +
+      '      ">\n' +
+      '        \n' +
+      '          <header class="mb-8">\n' +
+      '            <h1 class="font-heading text-primary text-4xl tracking-wider">Designer Toys</h1>\n' +
+      '          </header>\n' +
+      '        \n' +
+      '        <h1 class="text-2xl font-bold mb-4">Designer Toys</h1>\n' +
+      '\n' +
+      '\n' +
+      '  \n' +
+      '  \n' +
+      '  <ul>\n' +
+      '    \n' +
+      '    <li><a href="/archives/collectables/designer-toys/pop-mart/">Pop Mart</a></li>\n' +
+      '    \n' +
+      '  </ul>\n' +
+      '  \n' +
+      '\n' +
+      '\n' +
+      '      </article>\n' +
+      '\n' +
+      '      \n' +
+      '    </main>\n' +
+      '\n' +
+      '    <footer class="mt-16 p-8 text-center text-sm text-text/60">\n' +
+      '      &copy; 2025 Effusion Labs. A space for creative synthesis.\n' +
+      '    </footer>\n' +
+      '  </div>\n' +
+      '\n' +
+      '  <script>lucide.createIcons();</script>\n' +
+      '  <script src="/assets/js/theme-toggle.js" defer=""></script>\n' +
+      '  <script src="/assets/js/footnote-nav.js" defer=""></script>\n' +
+      '</body>\n' +
+      '</html>\n'
+    
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected:
+  actual: |-
+    
+    <!DOCTYPE html>
+    <html lang="en" data-theme="dark" class="scroll-pt-16 dark">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Designer Toys | Effusion Labs</title>
+    
+      <meta name="color-scheme" content="dark light">
+      <script>(function(){
+      const storageKey = 'theme';
+      const doc = document.documentElement;
+      const stored = localStorage.getItem(storageKey);
+      const meta = document.querySelector('meta[name="color-scheme"]') || (function(){
+        const m = document.createElement('meta');
+        m.name = 'color-scheme';
+        document.head.appendChild(m);
+        return m;
+      })();
+      let theme = stored;
+      if (theme !== 'dark' && theme !== 'light') {
+        theme = 'dark';
+      }
+      doc.dataset.theme = theme;
+      doc.classList.toggle('dark', theme === 'dark');
+      meta.content = theme === 'light' ? 'light dark' : 'dark light';
+    })();
+    </script>
+    
+      <link rel="stylesheet" href="/assets/css/app.css">
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+      <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+      <script src="/assets/js/lucide.min.js"></script>
+    </head>
+    
+    <body class="bg-background text-text font-body leading-relaxed text-[17px]">
+      <a href="#main" class="skip-link">Skip to main content</a>
+      <header class="sticky top-0 z-40 w-full bg-base-100/90 backdrop-blur shadow">
+      <div class="navbar mx-auto max-w-screen-2xl px-6">
+        <div class="flex-1">
+          <a href="/" class="flex items-center gap-2 font-heading text-3xl text-primary">
+            <i data-lucide="flask-conical" class="w-6 h-6"></i><span>Effusion Labs</span>
+          </a>
+        </div>
+        <div class="flex-none lg:hidden">
+          <div class="dropdown dropdown-end">
+            <label tabindex="0" class="btn btn-ghost btn-square">
+              <i data-lucide="menu" class="w-6 h-6"></i>
+            </label>
+            <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-40">
+              
+              <li><a href="/">Showcase</a></li>
+              
+              <li><a href="/sparks/">Sparks</a></li>
+              
+              <li><a href="/concepts/">Concepts</a></li>
+              
+              <li><a href="/projects/">Projects</a></li>
+              
+              <li><a href="/archives/">Archives</a></li>
+              
+              <li><a href="/meta/">Meta</a></li>
+              
+              <li><a href="/map/">Map</a></li>
+              
+            </ul>
+          </div>
+        </div>
+        <div class="flex-none flex items-center gap-2">
+          <button id="theme-toggle" class="btn btn-ghost btn-square" aria-label="Switch to light theme" aria-pressed="true">
+            <span class="sr-only">Toggle theme</span>
+            <i data-lucide="sun" class="w-6 h-6 hidden"></i>
+            <i data-lucide="moon" class="w-6 h-6"></i>
+          </button>
+        </div>
+        <nav class="flex-none hidden lg:flex">
+          <ul class="menu menu-horizontal px-1">
+            
+            <li><a href="/" class="hover:text-primary">Showcase</a></li>
+            
+            <li><a href="/sparks/" class="hover:text-primary">Sparks</a></li>
+            
+            <li><a href="/concepts/" class="hover:text-primary">Concepts</a></li>
+            
+            <li><a href="/projects/" class="hover:text-primary">Projects</a></li>
+            
+            <li><a href="/archives/" class="hover:text-primary">Archives</a></li>
+            
+            <li><a href="/meta/" class="hover:text-primary">Meta</a></li>
+            
+            <li><a href="/map/" class="hover:text-primary">Map</a></li>
+            
+          </ul>
+        </nav>
+      </div>
+    </header>
+    
+    
+      <div class="mx-auto max-w-screen-2xl px-6">
+        
+        
+    
+        <main id="main" class="
+          xl:grid xl:gap-10 xl:grid-cols-[1fr_16rem]
+           mt-12
+        ">
+          <article class="prose dark:prose-invert max-w-none m-0
+             xl:col-span-1 
+          ">
+            
+              <header class="mb-8">
+                <h1 class="font-heading text-primary text-4xl tracking-wider">Designer Toys</h1>
+              </header>
+            
+            <h1 class="text-2xl font-bold mb-4">Designer Toys</h1>
+    
+    
+      
+      
+      <ul>
+        
+        <li><a href="/archives/collectables/designer-toys/pop-mart/">Pop Mart</a></li>
+        
+      </ul>
+      
+    
+    
+          </article>
+    
+          
+        </main>
+    
+        <footer class="mt-16 p-8 text-center text-sm text-text/60">
+          &copy; 2025 Effusion Labs. A space for creative synthesis.
+        </footer>
+      </div>
+    
+      <script>lucide.createIcons();</script>
+      <script src="/assets/js/theme-toggle.js" defer=""></script>
+      <script src="/assets/js/footnote-nav.js" defer=""></script>
+    </body>
+    </html>
+    
+  operator: 'match'
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/tests/archive-nav-count.spec.mjs:15:10)
+    Test.runInAsyncScope (node:async_hooks:214:14)
+    Test.run (node:internal/test_runner/test:1047:25)
+    Test.start (node:internal/test_runner/test:944:17)
+    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 2990.091105

--- a/logs/entropy-garden/run-2.log
+++ b/logs/entropy-garden/run-2.log
@@ -1,0 +1,31 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> node tools/test-changed.mjs tests/archive-nav-count.spec.mjs
+
+TAP version 13
+# npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+# 🚀 Eleventy build starting with enhanced footnote system...
+# ✅ Eleventy build completed. Generated 107 files.
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 75 Wrote 107 files in 1.88 seconds (17.6ms each, v3.1.2)
+# Subtest: archive nav exposes child counts
+ok 1 - archive nav exposes child counts
+  ---
+  duration_ms: 2877.827737
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 3008.66618

--- a/logs/entropy-garden/run-3.log
+++ b/logs/entropy-garden/run-3.log
@@ -1,0 +1,31 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> node tools/test-changed.mjs tests/archive-nav-count.spec.mjs
+
+TAP version 13
+# npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+# 🚀 Eleventy build starting with enhanced footnote system...
+# ✅ Eleventy build completed. Generated 107 files.
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 75 Wrote 107 files in 1.93 seconds (18.1ms each, v3.1.2)
+# Subtest: archive nav exposes child counts
+ok 1 - archive nav exposes child counts
+  ---
+  duration_ms: 2930.13639
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 3054.920154

--- a/src/_includes/archive-nav.njk
+++ b/src/_includes/archive-nav.njk
@@ -1,9 +1,9 @@
 {% macro archiveNav(path, nav) %}
   {% set items = nav[path] or [] %}
   {% if items.length %}
-  <ul>
+  <ul class="list-none pl-0">
     {% for item in items %}
-    <li><a href="{{ item.url }}">{{ item.title }}</a></li>
+    <li class="border-l-4 border-current pl-2"><a href="{{ item.url }}">{{ item.title }}</a> <span class="font-mono text-xs">({{ item.count }})</span></li>
     {% endfor %}
   </ul>
   {% endif %}

--- a/tests/archive-nav-count.spec.mjs
+++ b/tests/archive-nav-count.spec.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { rmSync, readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+const outDir = 'tmp/test-build';
+
+rmSync(outDir, { recursive: true, force: true });
+
+test('archive nav exposes child counts', () => {
+  execSync('npx @11ty/eleventy --quiet --input=src --output=' + outDir, { stdio: 'inherit' });
+  const htmlPath = path.join(outDir, 'archives', 'collectables', 'designer-toys', 'index.html');
+  const html = readFileSync(htmlPath, 'utf8');
+  assert.match(html, /Pop Mart/);
+  assert.match(html, /font-mono text-xs\">\(1\)/);
+});


### PR DESCRIPTION
## Summary
- Display child directory counts beside archive links and render list with a stark border-left aesthetic.
- Compute deterministic child counts when building the archive navigation map.
- Guard behavior with a Node test verifying the count rendering.

## Testing
- `npm test tests/archive-nav-count.spec.mjs tests/collection-layout.spec.mjs`

------
https://chatgpt.com/codex/tasks/task_e_689d2888764483309ac52cd76635acb6