### PR TITLE
Expose build metadata in RSS feed

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,7 @@ const register = require("./lib/eleventy/register");
 const { dirs } = require("./lib/config");
 const seeded = require("./lib/seeded");
 const registerArchiveCollections = require("./lib/eleventy/archive-collections");
+const { getBuildInfo } = require("./lib/build-info");
 
 module.exports = function (eleventyConfig) {
   register(eleventyConfig);
@@ -57,6 +58,8 @@ module.exports = function (eleventyConfig) {
     questions: 3,
     notebook: 3,
   });
+  const build = getBuildInfo();
+  eleventyConfig.addGlobalData("build", build);
 
   return {
     dir: dirs,

--- a/docs/adr/20250814-feed-build-metadata.md
+++ b/docs/adr/20250814-feed-build-metadata.md
@@ -1,0 +1,14 @@
+# 20250814-feed-build-metadata
+
+## Status
+Accepted
+
+## Context
+The RSS feed lacked explicit provenance, limiting transparency and cache friendliness.
+
+## Decision
+Expose commit hash and build timestamp via Eleventy global data and render them within the feed template.
+
+## Consequences
+- Reveals build origin for consumers and debuggers.
+- Enables deterministic feed metadata for external caches.

--- a/docs/reports/feed-build-meta-continue.md
+++ b/docs/reports/feed-build-meta-continue.md
@@ -1,0 +1,16 @@
+# Continuation Plan — feed-build-meta
+
+## Context Recap
+- Added build hash and timestamp to RSS feed via global data and template comment.
+- Failing tests captured and passing tests verified.
+
+## Outstanding Items
+1. Expand feed metadata to include generator link
+2. Create snapshot tests for RSS feed structure
+
+## Execution Strategy
+- *Expand feed metadata*: modify plugin config and feed template to emit generator tag.
+- *Create snapshot tests*: capture feed.xml and compare against stored snapshot.
+
+## Trigger Command
+npm test

--- a/docs/reports/feed-build-meta-ledger.md
+++ b/docs/reports/feed-build-meta-ledger.md
@@ -1,0 +1,16 @@
+# Ledger — feed-build-meta
+
+## Index
+1/1
+
+## Entries
+1. Expose build hash and time in RSS feed — done
+   - Proof: `node --test tests/feed-build-meta.spec.mjs` chunk a3348e
+   - Proof: `npm test` chunk 874e38
+
+## Delta queue
+1. Expand feed metadata to include generator link
+2. Create snapshot tests for RSS feed structure
+
+## Rollback slot
+3e14486

--- a/lib/build-info.js
+++ b/lib/build-info.js
@@ -1,0 +1,10 @@
+const { execSync } = require('node:child_process');
+
+function getBuildInfo() {
+  const hash = execSync('git rev-parse --short HEAD').toString().trim();
+  const date = new Date(Number(execSync('git log -1 --format=%ct').toString().trim()) * 1000);
+  return { hash, date };
+}
+
+module.exports = { getBuildInfo };
+

--- a/logs/feed-build-meta/run-1.log
+++ b/logs/feed-build-meta/run-1.log
@@ -1,0 +1,66 @@
+TAP version 13
+# npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+# 🚀 Eleventy build starting with enhanced footnote system...
+# ✅ Eleventy build completed. Generated 107 files.
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 75 Wrote 107 files in 2.65 seconds (24.7ms each, v3.1.2)
+# Subtest: feed exposes build metadata
+not ok 1 - feed exposes build metadata
+  ---
+  duration_ms: 4164.553082
+  type: 'test'
+  location: '/workspace/effusion-labs/tests/feed-build-meta.spec.mjs:15:1'
+  failureType: 'testCodeFailure'
+  error: |-
+    The input did not match the regular expression /<!-- build: bede5ec -->/. Input:
+    
+    '\n' +
+      '<?xml version="1.0" encoding="utf-8"?>\n' +
+      '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">\n' +
+      '  <channel>\n' +
+      '    <title>Effusion Labs</title>\n' +
+      '    <link>https://effusionlabs.com/</link>\n' +
+      '    <atom:link href="https://effusionlabs.com/feed.xml" rel="self" type="application/rss+xml" />\n' +
+      '    <description>Recent updates from Effusion Labs</description>\n' +
+      '    <language>en</language>\n' +
+      '  </channel>\n' +
+      '</rss>\n'
+    
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected:
+  actual: |-
+    
+    <?xml version="1.0" encoding="utf-8"?>
+    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+      <channel>
+        <title>Effusion Labs</title>
+        <link>https://effusionlabs.com/</link>
+        <atom:link href="https://effusionlabs.com/feed.xml" rel="self" type="application/rss+xml" />
+        <description>Recent updates from Effusion Labs</description>
+        <language>en</language>
+      </channel>
+    </rss>
+    
+  operator: 'match'
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/tests/feed-build-meta.spec.mjs:21:10)
+    Test.runInAsyncScope (node:async_hooks:214:14)
+    Test.run (node:internal/test_runner/test:1047:25)
+    Test.start (node:internal/test_runner/test:944:17)
+    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 4349.377306

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -12,6 +12,7 @@
 ---
 {% set posts = collections.nodes | slice(0, 20) %}
 <?xml version="1.0" encoding="utf-8"?>
+<!-- build: {{ build.hash }} -->
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ metadata.title }}</title>
@@ -19,6 +20,7 @@
     <atom:link href="{{ permalink | htmlBaseUrl(metadata.base) }}" rel="self" type="application/rss+xml" />
     <description>{{ metadata.description }}</description>
     <language>{{ metadata.language }}</language>
+    <lastBuildDate>{{ build.date | dateToRfc822 }}</lastBuildDate>
     {%- for post in posts %}
     {%- set absUrl = post.url | htmlBaseUrl(metadata.base) %}
     <item>

--- a/tests/feed-build-meta.spec.mjs
+++ b/tests/feed-build-meta.spec.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { rmSync, readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const dateToRfc822 = require('@11ty/eleventy-plugin-rss/src/dateRfc822.js');
+
+const outDir = 'tmp/test-feed-build';
+
+rmSync(outDir, { recursive: true, force: true });
+
+test('feed exposes build metadata', () => {
+  execSync(`npx @11ty/eleventy --quiet --input=src --output=${outDir}`, { stdio: 'inherit' });
+  const xml = readFileSync(path.join(outDir, 'feed.xml'), 'utf8');
+  const hash = execSync('git rev-parse --short HEAD').toString().trim();
+  const ts = Number(execSync('git log -1 --format=%ct').toString().trim()) * 1000;
+  const expectedDate = dateToRfc822(ts);
+  assert.match(xml, new RegExp(`<!-- build: ${hash} -->`));
+  assert.match(xml, new RegExp(`<lastBuildDate>${expectedDate}</lastBuildDate>`));
+});


### PR DESCRIPTION
## Summary
- surface the build hash and timestamp via global Eleventy data and render them in the RSS feed.
- ensure feed metadata is exercised through a dedicated test.

## Testing
- `node --test tests/feed-build-meta.spec.mjs`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d2888764483309ac52cd76635acb6