### PR TITLE
Eager-load hero logo with explicit dimensions

### DIFF
--- a/docs/adr/20250813-hero-image-perf.md
+++ b/docs/adr/20250813-hero-image-perf.md
@@ -1,0 +1,13 @@
+# 20250813-hero-image-perf
+
+## Status
+Accepted
+
+## Context
+Hero logo used default lazy loading which delayed first paint.
+
+## Decision
+Load logo eagerly with high fetch priority and explicit 112px dimensions; centralize values in branding data.
+
+## Consequences
+Improves initial render performance; tests guard the attributes for future changes.

--- a/docs/knowledge/hero-image-perf/index-hero-snippet.html
+++ b/docs/knowledge/hero-image-perf/index-hero-snippet.html
@@ -1,0 +1,1 @@
+  <picture><source type="image/avif" srcset="/assets/images/6_k3tM1Xi6-112.avif 112w"><source type="image/webp" srcset="/assets/images/6_k3tM1Xi6-112.webp 112w"><img loading="eager" decoding="async" src="/assets/images/6_k3tM1Xi6-112.png" alt="Effusion Labs" class="mx-auto w-28" width="112" height="112" fetchpriority="high"></picture>

--- a/docs/knowledge/hero-image-perf/index-hero-snippet.sha256
+++ b/docs/knowledge/hero-image-perf/index-hero-snippet.sha256
@@ -1,0 +1,1 @@
+35b50f5b7ee214ae53f7914b2d4d99fcf02012124b26dafc5dc0e46b15bf3638  docs/knowledge/hero-image-perf/index-hero-snippet.html

--- a/docs/reports/hero-image-perf-20250813-000000.md
+++ b/docs/reports/hero-image-perf-20250813-000000.md
@@ -1,0 +1,12 @@
+# hero-image-perf Report (2025-08-13)
+
+## Scenes
+1. spec-scaffold — added hero-image-priority.test.mjs
+2. red — failing test captured in run-1.log
+3. green — eager loading & fetchpriority added
+4. refactor — logo dimensions centralized
+5. provenance — ledger and continuation updated
+
+## Proof
+- logs/hero-image-perf/run-2.log
+- docs/knowledge/hero-image-perf/index-hero-snippet.html

--- a/docs/reports/hero-image-perf-continue.md
+++ b/docs/reports/hero-image-perf-continue.md
@@ -1,0 +1,16 @@
+# Continuation Plan
+
+## Context Recap
+- Spec: test ensures hero logo loads eagerly with high priority and explicit size
+- Red: failing run stored in logs/hero-image-perf/run-1.log
+- Green: attributes applied and tests/build pass
+- Refactor: dimensions centralized in branding data
+
+## Outstanding Items
+- none
+
+## Execution Strategy
+- n/a
+
+## Trigger Command
+node tools/test-changed.mjs test/hero-image-priority.test.mjs

--- a/docs/reports/hero-image-perf-ledger.md
+++ b/docs/reports/hero-image-perf-ledger.md
@@ -1,0 +1,7 @@
+# hero-image-perf Ledger
+
+| Criterion | Proof | Status |
+| --- | --- | --- |
+| Hero logo eager loads with high priority and explicit 112x112 size | test/hero-image-priority.test.mjs; logs/hero-image-perf/run-2.log | ✅ |
+
+Index: 1/1 criteria satisfied.

--- a/logs/hero-image-perf/run-1.log
+++ b/logs/hero-image-perf/run-1.log
@@ -1,0 +1,30 @@
+TAP version 13
+# Subtest: hero logo eager loads with high priority and explicit size
+not ok 1 - hero logo eager loads with high priority and explicit size
+  ---
+  duration_ms: 4233.073448
+  type: 'test'
+  location: '/workspace/effusion-labs/test/hero-image-priority.test.mjs:7:1'
+  failureType: 'testCodeFailure'
+  error: "'lazy' == 'eager'"
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: 'eager'
+  actual: 'lazy'
+  operator: '=='
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/test/hero-image-priority.test.mjs:13:10)
+    Test.runInAsyncScope (node:async_hooks:214:14)
+    Test.run (node:internal/test_runner/test:1047:25)
+    Test.start (node:internal/test_runner/test:944:17)
+    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 4973.810638

--- a/logs/hero-image-perf/run-2.log
+++ b/logs/hero-image-perf/run-2.log
@@ -1,0 +1,140 @@
+TAP version 13
+# Subtest: hero logo eager loads with high priority and explicit size
+ok 1 - hero logo eager loads with high priority and explicit size
+  ---
+  duration_ms: 4242.332333
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 4996.30938
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 build
+> npx @11ty/eleventy
+
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+🚀 Eleventy build starting with enhanced footnote system...
+[11ty] Writing ./_site/feed.xml from ./src/feed.njk
+[11ty/eleventy-img] Processing ./src/assets/static/logo.png (transform)
+[11ty] Writing ./_site/map/index.html from ./src/map.njk
+[11ty] Writing ./_site/404.html from ./src/404.njk
+[11ty] Writing ./_site/archives/index.html from ./src/archives/index.njk
+[11ty] Writing ./_site/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing ./_site/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/labubu/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--best-of-luck--plush--std--20231230--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/angel-in-clouds-v2/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing ./_site/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing ./_site/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing ./_site/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing ./_site/content/concepts/core-concept/index.html from ./src/content/concepts/core-concept.md (njk)
+[11ty] Writing ./_site/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing ./_site/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing ./_site/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing ./_site/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing ./_site/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing ./_site/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing ./_site/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing ./_site/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing ./_site/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing ./_site/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing ./_site/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing ./_site/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing ./_site/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing ./_site/content/projects/project-aurora/index.html from ./src/content/projects/project-aurora.md (njk)
+[11ty] Writing ./_site/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing ./_site/content/projects/project-lichen/index.html from ./src/content/projects/project-lichen.md (njk)
+[11ty] Writing ./_site/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing ./_site/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing ./_site/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing ./_site/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing ./_site/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing ./_site/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing ./_site/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing ./_site/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing ./_site/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing ./_site/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing ./_site/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/mokoko/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box--single--20250425/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/best-of-luck/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/zimomo/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box-set--sealed--20250425/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/big-into-energy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box--single--20250124/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/blue-diamond/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box-set--sealed--20250124/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/close-to-sweet-v1/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--dress-be-latte--plush--std--20231026/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/coca-cola/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box--single--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/dress-be-latte/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box-set--sealed--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/exciting-macaron/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--pendant--std--17cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-in-wild/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--plush-doll--std--40cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-into-spring/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--flip-with-me--plush--std--40cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/flip-with-me/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--forest-fairy-tale-china--figure--std--20250526--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/forest-fairy-tale-china/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--good-lucky-to-you-thailand--figure--std--20241220--reg-th/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/good-lucky-to-you-thailand/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--happy-halloween-party-sitting-pumpkin--pendant--sitting-pumpkin--20241025/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/happy-halloween-party-sitting-pumpkin/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box--single--15cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/have-a-seat/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box-set--sealed--15cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/hide-and-seek-in-singapore/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--hide-and-seek-in-singapore--figure--std--17.5cm--reg-sg/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/i-found-you-v1/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--jump-for-joy--plush--std--20230525/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/jump-for-joy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--pendant--std--17cm--20250207/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/lets-checkmate/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--plush-doll--std--37cm--20250207/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/magic-of-pumpkin/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-be-fancy-now--plush--std--20240315/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-be-fancy-now/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fantasy--plush--std--20241004/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fantasy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fortune--pendant--std--20241004/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fortune/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--time-to-chill--figure--std--20221031/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/time-to-chill/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--wacky-mart-china--figure--std--20250612--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/twinkly-fairy-tale/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--walk-by-fortune--plush--std--20231229/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/wacky-mart-china/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--blue-diamond--pendant--std--17cm--20240618/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/walk-by-fortune/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--pendant--std--17cm/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--plush--std/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--pendant--std--17cm--20240308/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--plush--std--20240308/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--magic-of-pumpkin--pendant--std--17cm--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--twinkly-fairy-tale--pendant--std--17cm--20241128/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--angel-in-clouds-v2--plush--std--58cm--20241025/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--i-found-you-v1--plush--std--58cm--20231215/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/index.html from ./src/index.njk
+✅ Eleventy build completed. Generated 107 files.
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty/eleventy-img] 1 image optimized (1 cached)
+[11ty] Copied 75 Wrote 107 files in 2.67 seconds (24.9ms each, v3.1.2)

--- a/logs/hero-image-perf/run-2.sha256
+++ b/logs/hero-image-perf/run-2.sha256
@@ -1,0 +1,1 @@
+57772383239d8496d44218eec01abbef2f5f075b826f6ac0cf2bdde633c1ef49  logs/hero-image-perf/run-2.log

--- a/src/_data/branding.js
+++ b/src/_data/branding.js
@@ -1,0 +1,4 @@
+module.exports = {
+  logoWidth: 112,
+  logoHeight: 112
+};

--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -1,5 +1,5 @@
 <section class="flex flex-col items-center justify-center space-y-6 py-24 text-center">
-  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-28" />
+  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-28" width="{{ branding.logoWidth }}" height="{{ branding.logoHeight }}" loading="eager" fetchpriority="high" decoding="async" />
   <h1 class="font-heading text-5xl sm:text-6xl">Effusion Labs</h1>
   <p class="text-lg text-gray-300">Art · Culture · Innovation</p>
   <p class="mx-auto max-w-prose text-gray-400">Building a data-driven digital garden of experimental ideas and practical prototypes for 2025.</p>

--- a/test/hero-image-priority.test.mjs
+++ b/test/hero-image-priority.test.mjs
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { JSDOM } from 'jsdom';
+
+test('hero logo eager loads with high priority and explicit size', () => {
+  spawnSync('npx', ['@11ty/eleventy'], { stdio: 'ignore' });
+  const html = fs.readFileSync('_site/index.html', 'utf8');
+  const dom = new JSDOM(html);
+  const img = dom.window.document.querySelector('img[alt="Effusion Labs"]');
+  assert.ok(img);
+  assert.equal(img.getAttribute('loading'), 'eager');
+  assert.equal(img.getAttribute('fetchpriority'), 'high');
+  const width = parseInt(img.getAttribute('width'), 10);
+  const height = parseInt(img.getAttribute('height'), 10);
+  assert.ok(width > 0 && height > 0);
+  assert.equal(width, 112);
+  assert.equal(height, 112);
+  assert.equal(width, height);
+});


### PR DESCRIPTION
## Summary
- ensure hero logo loads eagerly with high fetch priority and explicit 112x112 dimensions
- centralize logo dimensions in branding data
- test hero image attributes and record provenance

## Testing
- `node tools/test-changed.mjs test/hero-image-priority.test.mjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d2ecf15d48330831850c07e901b1e