### PR TITLE
feat: integrate markdown heading anchors

### DIFF
--- a/docs/reports/markdown-anchors-20250815-000000.md
+++ b/docs/reports/markdown-anchors-20250815-000000.md
@@ -1,0 +1,9 @@
+# Markdown Anchors Test Report (2025-08-15 00:00:00)
+
+- `node --test tests/markdown-anchor.spec.mjs` failed.
+- Expected `<h2 id="section-heading">` but heading lacked `id` attribute.
+
+```
+not ok 1 - markdown headings include anchor ids
+  error: The input did not match the regular expression /<h2 id="section-heading">Section Heading<\/h2>/.
+```

--- a/docs/reports/markdown-anchors-continue.md
+++ b/docs/reports/markdown-anchors-continue.md
@@ -1,0 +1,19 @@
+# Continuation — markdown-anchors
+
+## Context Recap
+- test: added anchor demo and failing test.
+- ci: recorded failing anchor test.
+- feat: added markdown-it-anchor plugin.
+- refactor: centralized plugin in markdown extensions.
+- docs: ledger and continuation added.
+
+## Outstanding Items
+1. Add anchor link icons to headings
+2. Expose anchored headings in table of contents
+
+## Execution Strategy
+1. Implement shortcode or CSS to reveal anchor icons next to headings; verify via DOM test.
+2. Generate per-page table of contents using heading anchors; assert links match id attributes.
+
+## Trigger Command
+node --test tests/markdown-anchor.spec.mjs

--- a/docs/reports/markdown-anchors-ledger.md
+++ b/docs/reports/markdown-anchors-ledger.md
@@ -1,0 +1,16 @@
+# Ledger — markdown-anchors
+
+## Index
+1/1
+
+## Entries
+1. Automatic ids for markdown headings via plugin — done
+   - Proof: `node --test tests/markdown-anchor.spec.mjs` chunk a58dc6
+   - Proof: `npm run build` chunk f878b0
+
+## Delta queue
+1. Add anchor link icons to headings
+2. Expose anchored headings in table of contents
+
+## Rollback slot
+ce61495

--- a/lib/markdown/index.js
+++ b/lib/markdown/index.js
@@ -1,9 +1,15 @@
 const { hybridFootnoteDefinitions, footnotePopover, collectFootnoteTokens, connectFootnoteBlockquotes, disableFootnoteTail } = require('./footnotes');
 const { audioEmbed, qrEmbed } = require('./inlineMacros');
 const { externalLinks } = require('./links');
+const markdownItAnchor = require('markdown-it-anchor');
+
+function anchors(md) {
+  md.use(markdownItAnchor);
+}
 
 /** Array of markdown-it extension functions to apply */
 const mdItExtensions = [
+  anchors,
   hybridFootnoteDefinitions,
   footnotePopover,
   collectFootnoteTokens,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lucide": "^0.534.0",
         "luxon": "^3.6.1",
         "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "9.2.0",
         "markdown-it-footnote": "^4.0.0",
         "turndown": "^7.2.0",
         "undici": "^7.13.0"
@@ -1364,6 +1365,31 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -3358,6 +3384,16 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.2.0.tgz",
+      "integrity": "sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
       }
     },
     "node_modules/markdown-it-attrs": {

--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
     "@11ty/eleventy-plugin-rss": "^2.0.4",
     "@mozilla/readability": "^0.6.0",
     "@photogabble/eleventy-plugin-interlinker": "^1.1.0",
-    "undici": "^7.13.0",
     "jsdom": "^26.1.0",
     "lucide": "^0.534.0",
     "luxon": "^3.6.1",
     "markdown-it": "^14.1.0",
+    "markdown-it-anchor": "9.2.0",
     "markdown-it-footnote": "^4.0.0",
-    "turndown": "^7.2.0"
+    "turndown": "^7.2.0",
+    "undici": "^7.13.0"
   },
   "devDependencies": {
     "@11ty/eleventy-img": "^6.0.4",
@@ -56,8 +57,8 @@
     "prettier": "^3.3.3",
     "prism-themes": "^1.9.0",
     "prismjs": "^1.30.0",
+    "proxy-chain": "^2.5.0",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
-    "tailwindcss": "^4.1.11",
-    "proxy-chain": "^2.5.0"
+    "tailwindcss": "^4.1.11"
   }
 }

--- a/src/content/meta/anchor-demo.md
+++ b/src/content/meta/anchor-demo.md
@@ -1,0 +1,15 @@
+---
+title: "Anchor Demo"
+layout: "layout.njk"
+status: draft
+date: 2025-08-15
+tags: [meta]
+---
+
+This page demonstrates automatic heading anchors.
+
+Refer to [Section Heading](#section-heading) below.
+
+## Section Heading
+
+This section shows a heading that becomes an anchor.

--- a/tests/markdown-anchor.spec.mjs
+++ b/tests/markdown-anchor.spec.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { rmSync, readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+const outDir = 'tmp/test-build';
+
+rmSync(outDir, { recursive: true, force: true });
+
+// Build the site and verify markdown headings include anchor ids.
+test('markdown headings include anchor ids', () => {
+  execSync('npx @11ty/eleventy --quiet --input=src --output=' + outDir, { stdio: 'inherit' });
+  const htmlPath = path.join(outDir, 'content', 'meta', 'anchor-demo', 'index.html');
+  const html = readFileSync(htmlPath, 'utf8');
+  assert.match(html, /<h2 id="section-heading"/);
+});


### PR DESCRIPTION
## Summary
- add markdown-it-anchor and centralize in markdown pipeline
- demonstrate anchors via new `anchor-demo` meta page
- scaffold tests for anchor id generation

## Testing
- `node --test tests/markdown-anchor.spec.mjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d38bbb8b483309e4f5f456271ef22