### PR TITLE
Fix test runner to execute full suite when no test files changed

### DIFF
--- a/tools/test-changed.mjs
+++ b/tools/test-changed.mjs
@@ -14,9 +14,9 @@ function collectTests(dir, out) {
   }
 }
 
-function listAllTests() {
+function listAllTests(dirs = TEST_DIRS) {
   const files = [];
-  for (const dir of TEST_DIRS) {
+  for (const dir of dirs) {
     if (fs.existsSync(dir)) collectTests(dir, files);
   }
   return files;
@@ -79,7 +79,12 @@ function runPw(files) {
 }
 
 async function run(files) {
-  const { pw, nodeFiles } = categorize(files);
+  let pw = [], nodeFiles = [];
+  if (files.length === 0) {
+    ({ nodeFiles } = categorize(listAllTests(["test"])));
+  } else {
+    ({ pw, nodeFiles } = categorize(files));
+  }
   const codes = [];
   if (nodeFiles.length) codes.push(await runNode(nodeFiles));
   if (pw.length) codes.push(await runPw(pw));


### PR DESCRIPTION
## Summary
- ensure `npm test` runs all node tests when no targeted files changed
- only collect default `test` directory in full runs to avoid executing heavy specs

## Testing
- `CI=1 npm test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d932059648330b119826a31f5cfa0