### PR TITLE
feat(home/hero): editorial poster + provenance seam + lens cursor

### DIFF
--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -1,13 +1,7 @@
-<section class="flex flex-col items-center justify-center space-y-6 py-24 text-center">
-  <img src="/assets/static/logo.png" alt="Effusion Labs" class="mx-auto w-28" width="{{ branding.logoWidth }}" height="{{ branding.logoHeight }}" loading="eager" fetchpriority="high" decoding="async" />
-  <h1 class="font-heading text-5xl sm:text-6xl">Effusion Labs</h1>
-  <p class="text-lg text-gray-300">Art · Culture · Innovation</p>
-  <p class="mx-auto max-w-prose text-gray-400">Where experimental ideas meet practical prototypes.</p>
-  <p class="mx-auto max-w-prose text-gray-400">Explore the projects, concepts, and sparks shaping tomorrow’s creative technology.</p>
-  <a href="/projects/" class="inline-block rounded-md bg-primary px-8 py-4 font-heading text-bg-dark transition hover:bg-lapis focus:outline-none focus:ring">View Latest Work</a>
-  <div class="mx-auto max-w-prose text-gray-400">
-    <p class="font-semibold text-gray-300">Explore the Interactive Concept Map</p>
-    <p class="mt-1 text-sm">Navigate the living knowledge graph that links every spark, concept, and project in the lab. Trace ideas from first curiosity to polished prototype.</p>
-  </div>
-  <a href="/map/" class="inline-block rounded-md bg-primary px-8 py-4 font-heading text-bg-dark transition hover:bg-lapis focus:outline-none focus:ring">Launch the Map</a>
+<section class="relative flex flex-col items-center justify-center py-24 text-center text-paper bg-gradient-to-b from-ink to-electric cursor-crosshair">
+  <h1 class="font-heading font-black text-[96px] md:text-[128px]">EFFUSION LABS</h1>
+  <p class="font-body text-lg">Where experimental ideas meet practical prototypes.</p>
+  <p class="font-body text-lg">Explore the projects, concepts, and sparks shaping tomorrow’s creative technology.</p>
+  <a href="/projects/" class="mt-6 inline-block rounded-full bg-electric px-8 py-4 font-heading font-bold text-ink transition hover:bg-lime focus:outline-none">View Latest Work</a>
+  <div class="mt-8 w-full border-t border-paper/20 pt-2 font-mono text-xs">{{ build.branch }} · {{ build.hash }} · {{ build.builtAtIso }}</div>
 </section>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -12,11 +12,11 @@
   <link rel="stylesheet" href="/assets/css/app.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@10..48,300..900&family=Space+Grotesk:wght@300..700&family=JetBrains+Mono:wght@400;700&family=Spectral:wght@400..700&display=swap" rel="stylesheet">
   <script src="/assets/js/lucide.min.js"></script>
 </head>
 
-<body class="bg-background text-text font-body leading-relaxed text-[17px]">
+<body class="bg-ink text-paper font-body leading-relaxed text-[17px]">
   <a href="#main" class="skip-link">Skip to main content</a>
   {% include 'header.njk' %}
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -10,12 +10,19 @@ module.exports = {
         border: "rgb(var(--color-border) / <alpha-value>)",
         codebg: "rgb(var(--color-code-bg) / <alpha-value>)",
         codetext: "rgb(var(--color-code-text) / <alpha-value>)",
-        primary: "#0A84FF",
-        footnote: "hsl(var(--p) / <alpha-value>)"
+        primary: "#2D5BFF", // Electric Blue
+        footnote: "hsl(var(--p) / <alpha-value>)",
+        ink: "#0B0B0B",
+        paper: "#F6F6F6",
+        electric: "#2D5BFF",
+        lime: "#D8FF00",
+        alarm: "#FF2E2E"
       },
       fontFamily: {
-        heading: ["'Bebas Neue'", "sans-serif"],
-        body:    ["'Roboto'",     "sans-serif"]
+        heading: ["'Bricolage Grotesque Variable'", "sans-serif"],
+        body:    ["'Space Grotesk Variable'", "sans-serif"],
+        mono:    ["'JetBrains Mono'", "monospace"],
+        spectral:["'Spectral'", "serif"]
       }
     }
   },

--- a/test/hero-image-priority.test.mjs
+++ b/test/hero-image-priority.test.mjs
@@ -4,18 +4,12 @@ import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { JSDOM } from 'jsdom';
 
-test('hero logo eager loads with high priority and explicit size', () => {
+test('hero renders without logo and with poster headline', () => {
   spawnSync('npx', ['@11ty/eleventy'], { stdio: 'ignore' });
   const html = fs.readFileSync('_site/index.html', 'utf8');
   const dom = new JSDOM(html);
   const img = dom.window.document.querySelector('img[alt="Effusion Labs"]');
-  assert.ok(img);
-  assert.equal(img.getAttribute('loading'), 'eager');
-  assert.equal(img.getAttribute('fetchpriority'), 'high');
-  const width = parseInt(img.getAttribute('width'), 10);
-  const height = parseInt(img.getAttribute('height'), 10);
-  assert.ok(width > 0 && height > 0);
-  assert.equal(width, 112);
-  assert.equal(height, 112);
-  assert.equal(width, height);
+  assert.ok(!img, 'hero logo should be absent');
+  const h1 = dom.window.document.querySelector('h1');
+  assert.equal(h1.textContent.trim(), 'EFFUSION LABS');
 });

--- a/tests/homepage.spec.mjs
+++ b/tests/homepage.spec.mjs
@@ -17,7 +17,7 @@ function walk(dir, files = []) {
   return files;
 }
 
-test('homepage integrates copy and sections', () => {
+test('homepage hero and sections', () => {
   rmSync(outDir, { recursive: true, force: true });
   execSync(`npx @11ty/eleventy --quiet --input=src --output=${outDir}`, { stdio: 'inherit' });
   const htmlPath = path.join(outDir, 'index.html');
@@ -25,18 +25,20 @@ test('homepage integrates copy and sections', () => {
   const dom = new JSDOM(html);
   const doc = dom.window.document;
 
-  // Copy integration
-  assert.match(html, /Art · Culture · Innovation/);
+  // Hero
+  const h1 = doc.querySelector('h1');
+  assert.equal(h1.textContent.trim(), 'EFFUSION LABS');
   assert.match(html, /Where experimental ideas meet practical prototypes\./);
   assert.match(html, /Explore the projects, concepts, and sparks shaping tomorrow’s creative technology\./);
-  assert.match(html, /Explore the Interactive Concept Map/);
-  assert.match(html, /Navigate the living knowledge graph that links every spark, concept, and project in the lab\./);
 
-  // CTAs
+  // Provenance seam
+  const prov = Array.from(doc.querySelectorAll('div')).find(d => /·/.test(d.textContent) && d.classList.contains('font-mono'));
+  assert(prov);
+  assert.match(prov.textContent.trim(), /^[^·]+ · [0-9a-f]{7} · \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+
+  // CTA
   const latest = Array.from(doc.querySelectorAll('a[href="/projects/"]')).find(a => a.textContent.trim() === 'View Latest Work');
   assert(latest);
-  const map = Array.from(doc.querySelectorAll('a[href="/map/"]')).find(a => a.textContent.trim() === 'Launch the Map');
-  assert(map);
 
   // Section checks
   const headers = Array.from(doc.querySelectorAll('main h2')).map(h => h.textContent.trim());


### PR DESCRIPTION
## Summary
- Reworked homepage hero into a poster-style block with crosshair cursor and provenance seam showing branch, short SHA, and build timestamp.
- Introduced high-contrast brutalist palette and variable fonts (Bricolage Grotesque, Space Grotesk, JetBrains Mono, Spectral) via Tailwind config and layout imports.
- Updated tests to validate poster headline, absence of legacy logo, and presence of provenance line.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da50925ec8330945a37e38499e98b