### PR TITLE
Fix build and server image tests

### DIFF
--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -13,7 +13,7 @@ test("Eleventy build generates expected assets and pages", () => {
   assert.ok(fs.existsSync("_site/archives/index.html"));
   assert.ok(
     fs.existsSync(
-      "_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--time-to-chill--figure--std--20221031/index.html",
+      "_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--time-to-chill--plush--std--20221031/index.html",
     ),
   );
 });


### PR DESCRIPTION
## Summary
- Serve built assets from a simple HTTP server for tests
- Update Eleventy build test to assert current product slug

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689da579ead08330962fb066e4b8d6df