### PR TITLE
refactor: scaffold Eleventy test runner utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Thumbs.db
 .env
 tools/google-search/
 tools/search2serp/package-lock.json
+tmp/

--- a/docs/reports/eleventy-runner-continue.md
+++ b/docs/reports/eleventy-runner-continue.md
@@ -1,0 +1,15 @@
+# Continuation Plan
+
+## Context Recap
+- Added initial Eleventy test runner and spec.
+
+## Outstanding Items
+- Refactor existing tests to use runner.
+- Complete test ledger for all tests.
+
+## Execution Strategy
+- Replace direct Eleventy invocations with runEleventy utility.
+- Update tools/test-ledger.json entries accordingly.
+
+## Trigger Command
+`npm test`

--- a/docs/reports/eleventy-runner-ledger.md
+++ b/docs/reports/eleventy-runner-ledger.md
@@ -1,0 +1,5 @@
+# Eleventy Runner Ledger
+
+- tests/runner.spec.mjs — verifies test runner env setup.
+
+Status: 1/1 items captured.

--- a/logs/full-after-runner.log
+++ b/logs/full-after-runner.log
@@ -1,0 +1,338 @@
+
+> effusion_labs_final@1.0.0 test
+> node tools/test-changed.mjs
+
+No targeted tests found; running full suite
+TAP version 13
+# Subtest: heading renders anchor link
+ok 1 - heading renders anchor link
+  ---
+  duration_ms: 8.951304
+  type: 'test'
+  ...
+# Subtest: registerArchiveCollections discovers line collections
+ok 2 - registerArchiveCollections discovers line collections
+  ---
+  duration_ms: 10.000494
+  type: 'test'
+  ...
+# Subtest: archive-docs captures manifest
+ok 3 - archive-docs captures manifest
+  ---
+  duration_ms: 1253.667999
+  type: 'test'
+  ...
+# Subtest: buildArchiveNav reflects directory structure
+ok 4 - buildArchiveNav reflects directory structure
+  ---
+  duration_ms: 5.826131
+  type: 'test'
+  ...
+# Subtest: block-ledger concept entry exists with heading
+ok 5 - block-ledger concept entry exists with heading
+  ---
+  duration_ms: 1.248432
+  type: 'test'
+  ...
+# npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+# 🚀 Eleventy build starting with enhanced footnote system...
+# [11ty] Writing ./_site/concept-map.json from ./src/concept-map.json.njk
+# [11ty] Writing ./_site/feed.xml from ./src/feed.njk
+# [11ty] Writing ./_site/content/sparks/carbon-handshake/index.html from ./src/content/sparks/carbon-handshake.md (njk)
+# [11ty] Writing ./_site/map/index.html from ./src/map.njk
+# [11ty] Writing ./_site/404.html from ./src/404.njk
+# [11ty] Writing ./_site/archives/index.html from ./src/archives/index.njk
+# [11ty] Writing ./_site/meta/index.html from ./src/content/meta/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+# [11ty] Writing ./_site/archives/collectables/index.html from ./src/archives/collectables/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/labubu/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--best-of-luck--plush--std--20231230--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/angel-in-clouds-v2/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/index.html from ./src/index.njk
+# [11ty] Writing ./_site/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+# [11ty] Writing ./_site/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+# [11ty] Writing ./_site/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+# [11ty] Writing ./_site/content/concepts/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+# [11ty] Writing ./_site/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+# [11ty] Writing ./_site/content/concepts/core-concept/index.html from ./src/content/concepts/core-concept.md (njk)
+# [11ty] Writing ./_site/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+# [11ty] Writing ./_site/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+# [11ty] Writing ./_site/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+# [11ty] Writing ./_site/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+# [11ty] Writing ./_site/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+# [11ty] Writing ./_site/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+# [11ty] Writing ./_site/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+# [11ty] Writing ./_site/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+# [11ty] Writing ./_site/content/meta/anchor-demo/index.html from ./src/content/meta/anchor-demo.md (njk)
+# [11ty] Writing ./_site/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+# [11ty] Writing ./_site/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+# [11ty] Writing ./_site/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+# [11ty] Writing ./_site/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+# [11ty] Writing ./_site/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+# [11ty] Writing ./_site/content/projects/project-aurora/index.html from ./src/content/projects/project-aurora.md (njk)
+# [11ty] Writing ./_site/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+# [11ty] Writing ./_site/content/projects/project-lichen/index.html from ./src/content/projects/project-lichen.md (njk)
+# [11ty] Writing ./_site/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+# [11ty] Writing ./_site/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+# [11ty] Writing ./_site/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+# [11ty] Writing ./_site/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+# [11ty] Writing ./_site/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+# [11ty] Writing ./_site/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+# [11ty] Writing ./_site/content/sparks/raw-socket-report/index.html from ./src/content/sparks/raw-socket-report.md (njk)
+# [11ty] Writing ./_site/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+# [11ty] Writing ./_site/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+# [11ty] Writing ./_site/concepts/index.html from ./src/content/concepts/index.njk
+# [11ty] Writing ./_site/projects/index.html from ./src/content/projects/index.njk
+# [11ty] Writing ./_site/sparks/index.html from ./src/content/sparks/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/mokoko/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box--single--20250425/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/best-of-luck/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/zimomo/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box-set--sealed--20250425/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/big-into-energy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box--single--20250124/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/blue-diamond/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box-set--sealed--20250124/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/close-to-sweet-v1/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--dress-be-latte--plush--std--20231026/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/coca-cola/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box--single--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/dress-be-latte/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box-set--sealed--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/exciting-macaron/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--pendant--std--17cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-in-wild/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--plush-doll--std--40cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-into-spring/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--flip-with-me--plush--std--40cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/flip-with-me/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--forest-fairy-tale-china--figure--std--20250526--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/forest-fairy-tale-china/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--good-lucky-to-you-thailand--figure--std--20241220--reg-th/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/good-lucky-to-you-thailand/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--happy-halloween-party-sitting-pumpkin--pendant--sitting-pumpkin--20241025/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/happy-halloween-party-sitting-pumpkin/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box--single--15cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/have-a-seat/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box-set--sealed--15cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/hide-and-seek-in-singapore/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--hide-and-seek-in-singapore--figure--std--17.5cm--reg-sg/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/i-found-you-v1/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--jump-for-joy--plush--std--20230525/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/jump-for-joy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--pendant--std--17cm--20250207/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/lets-checkmate/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--plush-doll--std--37cm--20250207/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/magic-of-pumpkin/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-be-fancy-now--plush--std--20240315/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-be-fancy-now/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fantasy--plush--std--20241004/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fantasy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fortune--pendant--std--20241004/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fortune/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--time-to-chill--plush--std--20221031/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/time-to-chill/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--wacky-mart-china--figure--std--20250612--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/twinkly-fairy-tale/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--walk-by-fortune--plush--std--20231229/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/wacky-mart-china/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--blue-diamond--pendant--std--17cm--20240618/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/walk-by-fortune/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--pendant--std--17cm/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--plush--std/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--pendant--std--17cm--20240308/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--plush--std--20240308/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--magic-of-pumpkin--pendant--std--17cm--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--twinkly-fairy-tale--pendant--std--17cm--20241128/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--angel-in-clouds-v2--plush--std--58cm--20241025/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--i-found-you-v1--plush--std--58cm--20231215/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# ✅ Eleventy build completed. Generated 112 files.
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 76 Wrote 112 files in 2.38 seconds (21.3ms each, v3.1.2)
+# Subtest: Eleventy build generates expected assets and pages
+ok 6 - Eleventy build generates expected assets and pages
+  ---
+  duration_ms: 3802.114439
+  type: 'test'
+  ...
+# Subtest: no old class names remain
+ok 7 - no old class names remain
+  ---
+  duration_ms: 0.886322
+  type: 'test'
+  ...
+# Subtest: acceptConsent clicks button when present
+ok 8 - acceptConsent clicks button when present
+  ---
+  duration_ms: 1.149543
+  type: 'test'
+  ...
+# Subtest: acceptConsent returns false when absent
+ok 9 - acceptConsent returns false when absent
+  ---
+  duration_ms: 6.898325
+  type: 'test'
+  ...
+# Subtest: content area constants are defined
+ok 10 - content area constants are defined
+  ---
+  duration_ms: 1.017
+  type: 'test'
+  ...
+# Subtest: content areas have at least three entries
+ok 11 - content areas have at least three entries
+  ---
+  duration_ms: 1.287141
+  type: 'test'
+  ...
+# Subtest: downwind plugin removed from package
+ok 12 - downwind plugin removed from package
+  ---
+  duration_ms: 1.915688
+  type: 'test'
+  ...
+# Subtest: compiled CSS uses native decoration utilities
+ok 13 - compiled CSS uses native decoration utilities
+  ---
+  duration_ms: 8.068939
+  type: 'test'
+  ...
+# npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+# 🚀 Eleventy build starting with enhanced footnote system...
+# [11ty] Writing ./_site/concept-map.json from ./src/concept-map.json.njk
+# [11ty] Writing ./_site/feed.xml from ./src/feed.njk
+# [11ty] Writing ./_site/content/sparks/carbon-handshake/index.html from ./src/content/sparks/carbon-handshake.md (njk)
+# [11ty] Writing ./_site/map/index.html from ./src/map.njk
+# [11ty] Writing ./_site/404.html from ./src/404.njk
+# [11ty] Writing ./_site/archives/index.html from ./src/archives/index.njk
+# [11ty] Writing ./_site/archives/collectables/index.html from ./src/archives/collectables/index.njk
+# [11ty] Writing ./_site/meta/index.html from ./src/content/meta/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/labubu/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--best-of-luck--plush--std--20231230--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/angel-in-clouds-v2/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/index.html from ./src/index.njk
+# [11ty] Writing ./_site/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+# [11ty] Writing ./_site/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+# [11ty] Writing ./_site/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+# [11ty] Writing ./_site/content/concepts/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+# [11ty] Writing ./_site/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+# [11ty] Writing ./_site/content/concepts/core-concept/index.html from ./src/content/concepts/core-concept.md (njk)
+# [11ty] Writing ./_site/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+# [11ty] Writing ./_site/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+# [11ty] Writing ./_site/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+# [11ty] Writing ./_site/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+# [11ty] Writing ./_site/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+# [11ty] Writing ./_site/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+# [11ty] Writing ./_site/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+# [11ty] Writing ./_site/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+# [11ty] Writing ./_site/content/meta/anchor-demo/index.html from ./src/content/meta/anchor-demo.md (njk)
+# [11ty] Writing ./_site/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+# [11ty] Writing ./_site/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+# [11ty] Writing ./_site/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+# [11ty] Writing ./_site/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+# [11ty] Writing ./_site/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+# [11ty] Writing ./_site/content/projects/project-aurora/index.html from ./src/content/projects/project-aurora.md (njk)
+# [11ty] Writing ./_site/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+# [11ty] Writing ./_site/content/projects/project-lichen/index.html from ./src/content/projects/project-lichen.md (njk)
+# [11ty] Writing ./_site/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+# [11ty] Writing ./_site/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+# [11ty] Writing ./_site/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+# [11ty] Writing ./_site/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+# [11ty] Writing ./_site/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+# [11ty] Writing ./_site/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+# [11ty] Writing ./_site/content/sparks/raw-socket-report/index.html from ./src/content/sparks/raw-socket-report.md (njk)
+# [11ty] Writing ./_site/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+# [11ty] Writing ./_site/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+# [11ty] Writing ./_site/concepts/index.html from ./src/content/concepts/index.njk
+# [11ty] Writing ./_site/projects/index.html from ./src/content/projects/index.njk
+# [11ty] Writing ./_site/sparks/index.html from ./src/content/sparks/index.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/mokoko/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box--single--20250425/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/best-of-luck/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/zimomo/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box-set--sealed--20250425/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/big-into-energy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box--single--20250124/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/blue-diamond/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box-set--sealed--20250124/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/close-to-sweet-v1/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--dress-be-latte--plush--std--20231026/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/coca-cola/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box--single--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/dress-be-latte/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box-set--sealed--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/exciting-macaron/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--pendant--std--17cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-in-wild/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--plush-doll--std--40cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-into-spring/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--flip-with-me--plush--std--40cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/flip-with-me/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--forest-fairy-tale-china--figure--std--20250526--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/forest-fairy-tale-china/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--good-lucky-to-you-thailand--figure--std--20241220--reg-th/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/good-lucky-to-you-thailand/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--happy-halloween-party-sitting-pumpkin--pendant--sitting-pumpkin--20241025/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/happy-halloween-party-sitting-pumpkin/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box--single--15cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/have-a-seat/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box-set--sealed--15cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/hide-and-seek-in-singapore/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--hide-and-seek-in-singapore--figure--std--17.5cm--reg-sg/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/i-found-you-v1/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--jump-for-joy--plush--std--20230525/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/jump-for-joy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--pendant--std--17cm--20250207/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/lets-checkmate/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--plush-doll--std--37cm--20250207/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/magic-of-pumpkin/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-be-fancy-now--plush--std--20240315/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-be-fancy-now/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fantasy--plush--std--20241004/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fantasy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fortune--pendant--std--20241004/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fortune/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--time-to-chill--plush--std--20221031/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/time-to-chill/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--wacky-mart-china--figure--std--20250612--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/twinkly-fairy-tale/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--walk-by-fortune--plush--std--20231229/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/wacky-mart-china/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--blue-diamond--pendant--std--17cm--20240618/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/walk-by-fortune/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--pendant--std--17cm/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--plush--std/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--pendant--std--17cm--20240308/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--plush--std--20240308/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--magic-of-pumpkin--pendant--std--17cm--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--twinkly-fairy-tale--pendant--std--17cm--20241128/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--angel-in-clouds-v2--plush--std--58cm--20241025/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# [11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--i-found-you-v1--plush--std--58cm--20231215/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+# ✅ Eleventy build completed. Generated 112 files.
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 76 Wrote 112 files in 2.47 seconds (22.1ms each, v3.1.2)
+# Subtest: RSS feed capped at 20 items
+ok 14 - RSS feed capped at 20 items
+  ---
+  duration_ms: 3781.224132
+  type: 'test'
+  ...

--- a/logs/runner-fail-2.log
+++ b/logs/runner-fail-2.log
@@ -1,0 +1,32 @@
+TAP version 13
+# file:///workspace/effusion-labs/tests/utils/run-eleventy.mjs:2
+#   throw new Error('runEleventy not implemented');
+#         ^
+# Error: runEleventy not implemented
+#     at runEleventy (file:///workspace/effusion-labs/tests/utils/run-eleventy.mjs:2:9)
+#     at file:///workspace/effusion-labs/tests/runner.spec.mjs:9:16
+#     at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
+#     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)
+#     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
+# Node.js v22.18.0
+# Subtest: tests/runner.spec.mjs
+not ok 1 - tests/runner.spec.mjs
+  ---
+  duration_ms: 95.716305
+  type: 'test'
+  location: '/workspace/effusion-labs/tests/runner.spec.mjs:1:1'
+  failureType: 'testCodeFailure'
+  exitCode: 1
+  signal: ~
+  error: 'test failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 105.475875

--- a/logs/runner-fail.log
+++ b/logs/runner-fail.log
@@ -1,0 +1,32 @@
+TAP version 13
+# file:///workspace/effusion-labs/tests/utils/run-eleventy.mjs:2
+#   throw new Error('runEleventy not implemented');
+#         ^
+# Error: runEleventy not implemented
+#     at runEleventy (file:///workspace/effusion-labs/tests/utils/run-eleventy.mjs:2:9)
+#     at file:///workspace/effusion-labs/tests/runner.spec.mjs:9:16
+#     at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
+#     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)
+#     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
+# Node.js v22.18.0
+# Subtest: tests/runner.spec.mjs
+not ok 1 - tests/runner.spec.mjs
+  ---
+  duration_ms: 93.41534
+  type: 'test'
+  location: '/workspace/effusion-labs/tests/runner.spec.mjs:1:1'
+  failureType: 'testCodeFailure'
+  exitCode: 1
+  signal: ~
+  error: 'test failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 102.927444

--- a/tests/runner.spec.mjs
+++ b/tests/runner.spec.mjs
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import runEleventy from './utils/run-eleventy.mjs';
+
+// Acceptance: runEleventy sets ELEVENTY_ENV and creates a clean output directory
+// Property: output directory exists and is recreated for each run
+
+test('runEleventy sets env and output directory', () => {
+  const outDir = runEleventy('runner-spec');
+  assert.equal(process.env.ELEVENTY_ENV, 'test');
+  assert.ok(fs.existsSync(outDir));
+});

--- a/tests/utils/run-eleventy.mjs
+++ b/tests/utils/run-eleventy.mjs
@@ -1,0 +1,24 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export default function runEleventy(testName, { input = 'src', log = true } = {}) {
+  const outDir = path.join('tmp', testName);
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  process.env.ELEVENTY_ENV = 'test';
+  process.env.CI = 'true';
+  process.env.COMMIT_SHA = process.env.COMMIT_SHA || 'local';
+
+  const env = { ...process.env };
+  const stdio = log ? 'inherit' : 'pipe';
+  const cmd = `npx @11ty/eleventy --quiet --input=${input} --output=${outDir}`;
+  try {
+    execSync(cmd, { stdio, env });
+  } catch (err) {
+    if (!log && err.stderr) process.stderr.write(err.stderr);
+    throw err;
+  }
+  return outDir;
+}

--- a/tools/test-ledger.json
+++ b/tools/test-ledger.json
@@ -1,0 +1,7 @@
+[
+  {
+    "file": "tests/runner.spec.mjs",
+    "labels": ["shells-eleventy"],
+    "disposition": "kept"
+  }
+]


### PR DESCRIPTION
## Summary
- add failing spec and ledger for Eleventy runner
- implement deterministic `runEleventy` utility and demo spec
- document ledger and continuation plan

## Testing
- `node --test tests/runner.spec.mjs`


------
https://chatgpt.com/codex/tasks/task_e_689dc0335a9083309846dfcd0bbe58a8