### PR TITLE
Add Markdown Gateway service using FlareSolverr

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ The `dev` command watches templates, Markdown and styles, recompiling Tailwind t
 
 No lint or format scripts are defined.
 
+## Markdown Gateway Service
+
+### Configuration
+Copy `.env.example` to `.env` and set a secure, random `GATEWAY_API_KEY`.
+
+### Deployment
+Run `docker compose up --build -d` from the `markdown_gateway` directory.
+
+### Usage
+```bash
+curl -X POST http://localhost:49159/convert \
+     -H "Content-Type: application/json" \
+     -H "X-Api-Key: YOUR_SECRET_KEY_FROM_.ENV_FILE" \
+     -d '{"url": "https://example.com"}'
+```
+
 ## Configuration
 
 - **Content directories**: Markdown lives under `src/content/{sparks,concepts,projects,meta}`【F:lib/constants.js†L7-L13】

--- a/docs/reports/markdown-gateway-20250815-000000.md
+++ b/docs/reports/markdown-gateway-20250815-000000.md
@@ -1,0 +1,7 @@
+# Markdown Gateway Build Report (2025-08-15 00:00:00)
+
+- `docker compose build` failed: `docker` executable not found.
+
+```
+bash: command not found: docker
+```

--- a/docs/reports/markdown-gateway-20250815-000001.md
+++ b/docs/reports/markdown-gateway-20250815-000001.md
@@ -1,0 +1,7 @@
+# Markdown Gateway Build Report (2025-08-15 00:00:01)
+
+- `docker compose build` attempted after implementing gateway; Docker unavailable.
+
+```
+bash: command not found: docker
+```

--- a/docs/reports/markdown-gateway-continue.md
+++ b/docs/reports/markdown-gateway-continue.md
@@ -1,0 +1,18 @@
+# Continuation — markdown-gateway
+
+## Context Recap
+- test: added acceptance scaffold.
+- ci: recorded missing Docker during build.
+- feat: implemented gateway service and Dockerfile.
+- refactor: centralised solver URL constant.
+- docs: ledger and continuation added.
+
+## Outstanding Items
+1. Re-run `docker compose build` in an environment with Docker installed.
+
+## Execution Strategy
+1. Install or enable Docker.
+2. Execute `docker compose build` and capture output for provenance.
+
+## Trigger Command
+cd markdown_gateway && docker compose build

--- a/docs/reports/markdown-gateway-ledger.md
+++ b/docs/reports/markdown-gateway-ledger.md
@@ -1,0 +1,14 @@
+# Ledger — markdown-gateway
+
+## Index
+0/1
+
+## Entries
+1. Build gateway and solver images via docker compose — pending
+   - Proof: `docker compose build` command not available
+
+## Delta queue
+1. Re-run `docker compose build` in an environment with Docker installed
+
+## Rollback slot
+e25a870

--- a/markdown_gateway/.env.example
+++ b/markdown_gateway/.env.example
@@ -1,0 +1,5 @@
+# Port to expose the Markdown Gateway on the host machine
+GATEWAY_PORT=49159
+
+# A long, random, secret key for API access. Change this!
+GATEWAY_API_KEY=your-secret-key-goes-here

--- a/markdown_gateway/.github/workflows/build.yml
+++ b/markdown_gateway/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build and Test Docker Image
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: markdown_gateway
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: docker compose build

--- a/markdown_gateway/Dockerfile
+++ b/markdown_gateway/Dockerfile
@@ -1,0 +1,16 @@
+# builder stage
+FROM python:3.12 AS builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip wheel --wheel-dir /wheels -r requirements.txt
+
+# final stage
+FROM python:3.12-slim AS final
+WORKDIR /app
+COPY --from=builder /wheels /wheels
+COPY requirements.txt .
+RUN pip install --no-cache-dir --no-index --find-links=/wheels -r requirements.txt && rm -rf /wheels
+RUN useradd --create-home appuser
+COPY app.py .
+USER appuser
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]

--- a/markdown_gateway/app.py
+++ b/markdown_gateway/app.py
@@ -1,0 +1,65 @@
+import os
+from functools import wraps
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from flask import Flask, Response, jsonify, request
+from markdownify import markdownify
+from readability import Document
+
+app = Flask(__name__)
+API_KEY = os.environ.get("GATEWAY_API_KEY")
+SOLVER_URL = "http://solver:8191/v1"
+
+
+def require_api_key(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not API_KEY or request.headers.get("X-Api-Key") != API_KEY:
+            return jsonify({"error": "unauthorized"}), 401
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "healthy"}), 200
+
+
+@app.route("/convert", methods=["POST"])
+@require_api_key
+def convert():
+    data = request.get_json(silent=True) or {}
+    url = data.get("url")
+    if not url:
+        return jsonify({"error": "url is required"}), 400
+
+    payload = {"cmd": "request.get", "url": url}
+    try:
+        solver_resp = requests.post(SOLVER_URL, json=payload, timeout=120)
+
+        solver_resp.raise_for_status()
+        body = solver_resp.json()
+        if body.get("status") != "ok":
+            return jsonify({"error": "solver error"}), 502
+        html = body.get("solution", {}).get("response")
+        if not html:
+            return jsonify({"error": "empty response"}), 502
+    except requests.RequestException as exc:
+        return jsonify({"error": str(exc)}), 502
+
+    doc = Document(html)
+    cleaned_html = doc.summary()
+    soup = BeautifulSoup(cleaned_html, "lxml")
+    for tag in soup.find_all(href=True):
+        tag["href"] = urljoin(url, tag["href"])
+    for tag in soup.find_all(src=True):
+        tag["src"] = urljoin(url, tag["src"])
+    markdown = markdownify(str(soup))
+    return Response(markdown, mimetype="text/markdown; charset=utf-8")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/markdown_gateway/docker-compose.yml
+++ b/markdown_gateway/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.9"
+
+services:
+  gateway:
+    build: .
+    ports:
+      - "${GATEWAY_PORT:-49159}:5000"
+    environment:
+      - GATEWAY_API_KEY=${GATEWAY_API_KEY}
+    depends_on:
+      solver:
+        condition: service_healthy
+
+  solver:
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    # shm_size: 2gb  # Uncomment if shared memory is needed on your host
+    # security_opt:
+    #   - seccomp=unconfined  # Uncomment if seccomp interferes on your host
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-X", "POST", "http://localhost:8191/v1", "-H", "Content-Type: application/json", "-d", "{\"cmd\":\"request.get\",\"url\":\"https://example.com\"}"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+networks:
+  default:
+    name: markdown_gateway_network

--- a/markdown_gateway/requirements.txt
+++ b/markdown_gateway/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+gunicorn
+requests
+readability-lxml
+markdownify
+beautifulsoup4
+lxml


### PR DESCRIPTION
## Summary
- add containerized Flask gateway that converts web pages to Markdown via FlareSolverr
- include Docker and GitHub Actions setup for gateway/solver stack
- document configuration, deployment and usage

## Testing
- `npm test`
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e499604f8833088fe32a69dd64ca1