### PR TITLE
chore(audit): add archive record audit

### DIFF
--- a/docs/reports/archive-normalization-audit.md
+++ b/docs/reports/archive-normalization-audit.md
@@ -1,0 +1,8 @@
+# Archive Normalization Audit
+
+| Path | Entity Guess | ID Fields | Body Length | Outgoing Links | Classification |
+|------|--------------|-----------|-------------|----------------|----------------|
+| _No misfit record Markdown files found in `src/`_ | — | — | — | — | — |
+
+Search patterns: `type`, `product_id`, `brand`, `line`, `character`, `series`, `form`, `release_date`.
+

--- a/docs/reports/archive-normalization-continue.md
+++ b/docs/reports/archive-normalization-continue.md
@@ -1,0 +1,14 @@
+# Continuation – Archive Normalization
+
+## Context Recap
+Ripgrep audit found no record-style Markdown files under `src/`.
+
+## Outstanding Items
+1. Implement global data loaders and define schemas.
+2. Generate pagination templates with stable permalinks.
+
+## Execution Strategy
+Proceed in small batches, converting legacy records to JSON and ensuring URL stability.
+
+## Trigger Command
+npm test && npm run build

--- a/docs/reports/archive-normalization-ledger.md
+++ b/docs/reports/archive-normalization-ledger.md
@@ -1,0 +1,11 @@
+# Archive Normalization Ledger
+
+- **Audit**: ripgrep search across `src/` found zero Markdown records with archive front matter fields.
+
+Status: 1/1 items captured.
+
+Delta Queue:
+1. Add global loaders and schemas.
+2. Create pagination templates with stable permalinks.
+
+Rollback: git revert 0ae0d7d428ecb463e6509e8fd20c26105b14465a


### PR DESCRIPTION
## Summary
- add audit report for archive normalization
- start ledger and continuation docs for archive work

## Testing
- `npm test` *(fails: Command failed: npx @11ty/eleventy --input=src --output=tmp/runner-spec)*
- `npm run build` *(fails: Cannot find module '@mozilla/readability')*


------
https://chatgpt.com/codex/tasks/task_e_689f8c83ba308330a1d4d024ca1b139b