### PR TITLE
chore: drop @vscode/ripgrep dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates
 - `npm run deps:playwright` – install the Chromium browser for Playwright.
 - `npm run deps:system` – install system dependencies for Playwright.
 - `npm run proxy:chain` – run the proxy chain helper.
-- `npm run prepare-docs` – ensure `rg` and `fd` are installed for repository search.
+- `npm run prepare-docs` – ensure `fd` is installed for repository search; `rg` must be installed separately.
 - `npm run docs:links` – check this README for broken links.
 
 ### Eleventy Plugins
@@ -59,7 +59,7 @@ git clone https://github.com/effusion-labs/effusion-labs.git
 cd effusion-labs
 npm install
 cp .env.example .env          # OUTBOUND_MARKDOWN_ENABLED, OUTBOUND_MARKDOWN_USER, OUTBOUND_MARKDOWN_PASS, OUTBOUND_MARKDOWN_URL, OUTBOUND_MARKDOWN_PORT, OUTBOUND_MARKDOWN_API_KEY, OUTBOUND_MARKDOWN_TIMEOUT
-npm run prepare-docs          # installs ripgrep & fd if missing
+npm run prepare-docs          # installs fd if missing
 npm run dev                   # Eleventy + live reload
 npm run build                 # production output in _site/
 npm test                      # run test suite

--- a/docs/knowledge/ripgrep/docs-validate.log
+++ b/docs/knowledge/ripgrep/docs-validate.log
@@ -1,0 +1,5 @@
+
+> effusion_labs_final@1.0.0 docs:validate
+> node tools/validate-docs.js
+
+docs validated

--- a/docs/knowledge/ripgrep/test-failure.log
+++ b/docs/knowledge/ripgrep/test-failure.log
@@ -1,0 +1,215 @@
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+node:internal/modules/esm/resolve:274
+    throw new ERR_MODULE_NOT_FOUND(
+          ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/effusion-labs/test/tools/shared/probe-browser.mjs' imported from /workspace/effusion-labs/test/browser/browser-capability.test.mjs
+    at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+    at moduleResolve (node:internal/modules/esm/resolve:859:10)
+    at defaultResolve (node:internal/modules/esm/resolve:983:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+  code: 'ERR_MODULE_NOT_FOUND',
+  url: 'file:///workspace/effusion-labs/test/tools/shared/probe-browser.mjs'
+}
+
+Node.js v22.18.0
+[31m✖ test/browser/browser-capability.test.mjs [90m(273.85719ms)[39m[39m
+node:internal/modules/esm/resolve:274
+    throw new ERR_MODULE_NOT_FOUND(
+          ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/effusion-labs/test/lib/markdownGateway.js' imported from /workspace/effusion-labs/test/browser/browser-engine.test.mjs
+    at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+    at moduleResolve (node:internal/modules/esm/resolve:859:10)
+    at defaultResolve (node:internal/modules/esm/resolve:983:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+  code: 'ERR_MODULE_NOT_FOUND',
+  url: 'file:///workspace/effusion-labs/test/lib/markdownGateway.js'
+}
+
+Node.js v22.18.0
+[31m✖ test/browser/browser-engine.test.mjs [90m(285.403547ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.39 seconds (30.2ms each, v3.1.2)
+[32m✔ archive nav exposes child counts [90m(3390.050569ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.23 seconds (28.8ms each, v3.1.2)
+[32m✔ layout exposes build timestamp [90m(3230.403749ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.73 seconds (24.4ms each, v3.1.2)
+[32m✔ code blocks expose copy control [90m(2891.870742ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.05 seconds (27.2ms each, v3.1.2)
+[32m✔ collection pages expose section metadata [90m(3052.002916ms)[39m[39m
+[32m✔ concept map JSON-LD export generates @context and @graph [90m(3.773763ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.14 seconds (28.0ms each, v3.1.2)
+[32m✔ feed exposes build metadata [90m(3144.247116ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.06 seconds (27.3ms each, v3.1.2)
+[32m✔ home page header includes primary nav landmark [90m(3065.121052ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.75 seconds (24.5ms each, v3.1.2)
+[32m✔ homepage hero and sections [90m(2880.587629ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.29 seconds (29.4ms each, v3.1.2)
+[32m✔ markdown headings include anchor ids [90m(3292.164447ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.09 seconds (27.6ms each, v3.1.2)
+[32m✔ monsters hub lists products and cross-links product and character pages [90m(3095.154097ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.11 seconds (27.8ms each, v3.1.2)
+[32m✔ main nav marks current page and is labelled [90m(3110.267106ms)[39m[39m
+[32m✔ navigation items are sequentially ordered [90m(1.670706ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.13 seconds (27.9ms each, v3.1.2)
+[32m✔ buildLean sets env and output directory [90m(3131.787287ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.05 seconds (27.3ms each, v3.1.2)
+[32m✔ spark listings reveal status text [90m(3057.21553ms)[39m[39m
+[32m✔ docs:links reports no broken links [90m(1056.691902ms)[39m[39m
+[32m✔ package-lock.json defines lockfileVersion [90m(4.643158ms)[39m[39m
+node:internal/modules/package_json_reader:255
+  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
+        ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@lvce-editor/ripgrep' imported from /workspace/effusion-labs/test/unit/ripgrep.test.mjs
+    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:255:9)
+    at packageResolve (node:internal/modules/esm/resolve:767:81)
+    at moduleResolve (node:internal/modules/esm/resolve:853:18)
+    at defaultResolve (node:internal/modules/esm/resolve:983:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+  code: 'ERR_MODULE_NOT_FOUND'
+}
+
+Node.js v22.18.0
+[31m✖ test/unit/ripgrep.test.mjs [90m(259.017765ms)[39m[39m
+[34mℹ tests 19[39m
+[34mℹ suites 0[39m
+[34mℹ pass 16[39m
+[34mℹ fail 3[39m
+[34mℹ cancelled 0[39m
+[34mℹ skipped 0[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms 18788.702849[39m
+
+[31m✖ failing tests:[39m
+
+test at test/browser/browser-capability.test.mjs:1:1
+[31m✖ test/browser/browser-capability.test.mjs [90m(273.85719ms)[39m[39m
+  'test failed'
+
+test at test/browser/browser-engine.test.mjs:1:1
+[31m✖ test/browser/browser-engine.test.mjs [90m(285.403547ms)[39m[39m
+  'test failed'
+
+test at test/unit/ripgrep.test.mjs:1:1
+[31m✖ test/unit/ripgrep.test.mjs [90m(259.017765ms)[39m[39m
+  'test failed'
+Executed 18 tests
+
+=============================== Coverage summary ===============================
+Statements   : 83.5% ( 1109/1328 )
+Branches     : 80.17% ( 182/227 )
+Functions    : 75% ( 60/80 )
+Lines        : 83.5% ( 1109/1328 )
+================================================================================

--- a/docs/knowledge/ripgrep/test-success.log
+++ b/docs/knowledge/ripgrep/test-success.log
@@ -1,0 +1,22 @@
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[32m✔ devDependencies omit @vscode/ripgrep [90m(1.018439ms)[39m[39m
+[32m✔ prepare-docs avoids ripgrep install [90m(0.148982ms)[39m[39m
+[34mℹ tests 2[39m
+[34mℹ suites 0[39m
+[34mℹ pass 2[39m
+[34mℹ fail 0[39m
+[34mℹ cancelled 0[39m
+[34mℹ skipped 0[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms 265.23742[39m
+Executed 1 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.69% ( 83/98 )
+Branches     : 68.42% ( 13/19 )
+Functions    : 100% ( 5/5 )
+Lines        : 84.69% ( 83/98 )
+================================================================================

--- a/docs/reports/ripgrep-fix-continue.md
+++ b/docs/reports/ripgrep-fix-continue.md
@@ -1,0 +1,14 @@
+# Continuation: ripgrep-fix
+
+## Context Recap
+`@vscode/ripgrep` caused GitHub 403 errors during `npm ci`. The dependency was removed and docs updated.
+
+## Outstanding Items
+1. Optionally provide cross-platform ripgrep acquisition script.
+2. Investigate failing browser tests.
+
+## Execution Strategy
+Implement optional ripgrep detection script using local binaries; stabilize browser tests with required dependencies.
+
+## Trigger Command
+`npm test`

--- a/docs/reports/ripgrep-fix-ledger.md
+++ b/docs/reports/ripgrep-fix-ledger.md
@@ -1,0 +1,21 @@
+# ripgrep-fix Ledger
+
+## Criteria
+1. Remove `@vscode/ripgrep` dev dependency to avoid GitHub download failures.
+2. `prepare-docs` script no longer auto-installs ripgrep.
+3. README reflects manual ripgrep requirement.
+
+## Proofs
+- `test/unit/ripgrep.test.mjs` checks absence of `@vscode/ripgrep` and script content.
+- `docs/knowledge/ripgrep/test-success.log` shows passing tests.
+- `docs/knowledge/ripgrep/docs-validate.log` records successful docs validation.
+
+## Index
+3/3 criteria satisfied.
+
+## Delta Queue
+- none
+
+## Rollback
+Last safe commit: `7cdbb005636873796df6d63c5d2040dd19ef6b75`
+Rollback command: `git reset --hard 7cdbb005636873796df6d63c5d2040dd19ef6b75`

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@tailwindcss/typography": "^0.5.16",
-        "@vscode/ripgrep": "^1.15.14",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "c8": "10.1.3",
@@ -1462,6 +1461,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.12.tgz",
@@ -1597,19 +1656,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@vscode/ripgrep": {
-      "version": "1.15.14",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.14.tgz",
-      "integrity": "sha512-/G1UJPYlm+trBWQ6cMO3sv6b8D1+G16WaJH1/DSqw32JOVlzgZbLkDxRyzIpTpv30AcYGMkCf5tUqGlW6HbDWw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "https-proxy-agent": "^7.0.2",
-        "proxy-from-env": "^1.1.0",
-        "yauzl": "^2.9.2"
       }
     },
     "node_modules/a-sync-waterfall": {
@@ -1947,16 +1993,6 @@
       },
       "engines": {
         "node": ">= 10.16.0"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/c8": {
@@ -2790,16 +2826,6 @@
       "license": "MIT",
       "bin": {
         "fd": "dist/fd"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -4806,13 +4832,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6317,17 +6336,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "deps:playwright": "npx playwright install chromium || true",
     "deps:system": "npx playwright install-deps || true",
     "proxy:chain": "node tools/shared/chain-proxy.mjs",
-    "prepare-docs": "npx rg --version >/dev/null 2>&1 || npm install --save-dev @vscode/ripgrep; npx fd --version >/dev/null 2>&1 || npm install --save-dev fd-find || true",
+    "prepare-docs": "npm exec fd --version >/dev/null 2>&1 || npm install --save-dev fd-find || true",
     "docs:links": "markdown-link-check -c link-check.config.json README.md"
   },
   "engines": {
@@ -47,7 +47,6 @@
     "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/typography": "^0.5.16",
-    "@vscode/ripgrep": "^1.15.14",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "c8": "10.1.3",

--- a/test/unit/ripgrep.test.mjs
+++ b/test/unit/ripgrep.test.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url)));
+
+// Acceptance example: repository does not depend on @vscode/ripgrep
+await test('devDependencies omit @vscode/ripgrep', () => {
+  assert.ok(!pkg.devDependencies || !pkg.devDependencies['@vscode/ripgrep'],
+    'should not depend on @vscode/ripgrep');
+});
+
+// Property/contract: prepare-docs script does not auto-install ripgrep
+await test('prepare-docs avoids ripgrep install', () => {
+  const script = pkg.scripts['prepare-docs'] || '';
+  assert.ok(!script.includes('@vscode/ripgrep'), 'prepare-docs should not install ripgrep');
+});


### PR DESCRIPTION
## Summary
- remove @vscode/ripgrep to avoid GitHub download failures during npm install
- simplify doc tooling script and document manual ripgrep requirement
- record test and docs validation outputs in knowledge base

## Testing
- `npm test` *(fails: test/browser/browser-capability.test.mjs, test/browser/browser-engine.test.mjs)*
- `node --test test/unit/ripgrep.test.mjs`
- `npm run docs:validate`


------
https://chatgpt.com/codex/tasks/task_e_689ff4a997b083308ad139f07727838c