### PR TITLE
Add eagerly loaded hero logo

### DIFF
--- a/docs/knowledge/homepage-logo-green.log
+++ b/docs/knowledge/homepage-logo-green.log
@@ -1,0 +1,25 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 76 Wrote 112 files in 1.60 seconds (14.3ms each, v3.1.2)
+# Subtest: homepage hero and sections
+ok 1 - homepage hero and sections
+  ---
+  duration_ms: 1696.367944
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 2726.460493

--- a/docs/knowledge/homepage-logo-red.log
+++ b/docs/knowledge/homepage-logo-red.log
@@ -1,0 +1,41 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 76 Wrote 112 files in 1.55 seconds (13.8ms each, v3.1.2)
+# Subtest: homepage hero and sections
+not ok 1 - homepage hero and sections
+  ---
+  duration_ms: 1642.78699
+  type: 'test'
+  location: '/workspace/effusion-labs/test/integration/homepage.spec.mjs:19:1'
+  failureType: 'testCodeFailure'
+  error: |-
+    The expression evaluated to a falsy value:
+    
+      assert(logo)
+    
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: true
+  actual: ~
+  operator: '=='
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage.spec.mjs:33:3)
+    async Test.run (node:internal/test_runner/test:1054:7)
+    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 2712.3762

--- a/docs/reports/homepage-logo-continue.md
+++ b/docs/reports/homepage-logo-continue.md
@@ -1,0 +1,14 @@
+# Continuation – Homepage Logo
+
+## Context Recap
+Hero now displays a branded logo image loaded eagerly with centralized metadata.
+
+## Outstanding Items
+1. Expand hero logo coverage to secondary pages.
+2. Assert alt text from branding data in tests.
+
+## Execution Strategy
+Extend integration tests and propagate branding data where needed.
+
+## Trigger Command
+NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs

--- a/docs/reports/homepage-logo-ledger.md
+++ b/docs/reports/homepage-logo-ledger.md
@@ -1,0 +1,13 @@
+# homepage-logo Ledger (1/1)
+
+## Criteria & Proofs
+- Failing check before fix (`docs/knowledge/homepage-logo-red.log`, sha256: bf862ed285c5b404df991e5fc0a2f85cfba08ee30673914744ee2d21fb52fe27).
+- Passing check after implementing logo (`docs/knowledge/homepage-logo-green.log`, sha256: f05ffc128c3d84eaa25c2fdebf0e3d287dbb1b3e9452d5393c8b8bf38176442f).
+
+## Delta Queue
+1. Expand hero logo coverage to secondary pages.
+2. Assert alt text from branding data in tests.
+
+## Rollback
+- Last safe SHA: a391d94
+- `git reset --hard a391d94`

--- a/src/_data/branding.js
+++ b/src/_data/branding.js
@@ -1,4 +1,6 @@
 module.exports = {
   logoWidth: 112,
-  logoHeight: 112
+  logoHeight: 112,
+  logoSrc: '/assets/logo.png',
+  logoAlt: 'Effusion Labs logo'
 };

--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -1,4 +1,13 @@
 <section class="relative flex flex-col items-center justify-center py-24 text-center text-paper bg-gradient-to-b from-ink to-electric cursor-crosshair">
+  <img
+    class="hero-logo mb-6"
+    src="{{ branding.logoSrc }}"
+    alt="{{ branding.logoAlt }}"
+    width="{{ branding.logoWidth }}"
+    height="{{ branding.logoHeight }}"
+    loading="eager"
+    fetchpriority="high"
+  />
   <h1 class="font-heading font-black text-[96px] md:text-[128px]">EFFUSION LABS</h1>
   <p class="font-body text-lg">Where experimental ideas meet practical prototypes.</p>
   <p class="font-body text-lg">Explore the projects, concepts, and sparks shaping tomorrow’s creative technology.</p>

--- a/test/integration/homepage.spec.mjs
+++ b/test/integration/homepage.spec.mjs
@@ -4,6 +4,7 @@ import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { buildLean } from '../helpers/eleventy-env.mjs';
+import branding from '../../src/_data/branding.js';
 
 function walk(dir, files = []) {
   for (const entry of readdirSync(dir)) {
@@ -27,6 +28,14 @@ test('homepage hero and sections', async () => {
   assert.equal(h1.textContent.trim(), 'EFFUSION LABS');
   assert.match(html, /Where experimental ideas meet practical prototypes\./);
   assert.match(html, /Explore the projects, concepts, and sparks shaping tomorrow’s creative technology\./);
+
+  const logo = doc.querySelector('img.hero-logo');
+  assert(logo);
+  assert.equal(logo.getAttribute('src'), '/assets/logo.png');
+  assert.equal(logo.getAttribute('width'), String(branding.logoWidth));
+  assert.equal(logo.getAttribute('height'), String(branding.logoHeight));
+  assert.equal(logo.getAttribute('loading'), 'eager');
+  assert.equal(logo.getAttribute('fetchpriority'), 'high');
 
   // Skip link
   const skip = doc.querySelector('a.skip-link');


### PR DESCRIPTION
## Summary
- render Effusion Labs logo on homepage hero and centralize branding metadata
- guard hero logo attributes in homepage integration test
- document provenance for homepage logo fix

## Testing
- `NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_689ff4e00d1c8330b800d6542953df89