### PR TITLE
Fix homepage latest entries display

### DIFF
--- a/docs/reports/homepage-latest-entries-continue.md
+++ b/docs/reports/homepage-latest-entries-continue.md
@@ -1,0 +1,14 @@
+# Continuation: homepage-latest-entries
+
+## Context Recap
+Homepage now displays latest entries per section.
+
+## Outstanding Items
+1. Resolve failing browser tests.
+2. Improve homepage styling for feed items.
+
+## Execution Strategy
+Run `npm test` after adjustments.
+
+## Trigger Command
+`node test/integration/homepage-latest.spec.mjs`

--- a/docs/reports/homepage-latest-entries-ledger.md
+++ b/docs/reports/homepage-latest-entries-ledger.md
@@ -1,0 +1,12 @@
+# Ledger: homepage-latest-entries
+
+## Criteria
+- ensure homepage sections list latest entries (1-3 items)
+
+## Proof
+- test: `test/integration/homepage-latest.spec.mjs`
+- failing log: `logs/homepage-latest-red.log`
+- passing log: `logs/homepage-latest-green.log`
+
+## Rollback
+- `git revert --no-edit 1d1b77f bc8cafb 7e4bb2b 8fa389a`

--- a/logs/homepage-latest-green.log
+++ b/logs/homepage-latest-green.log
@@ -1,0 +1,17 @@
+TAP version 13
+[11ty] Copied 76 Wrote 112 files in 1.62 seconds (14.4ms each, v3.1.2)
+# Subtest: homepage lists latest entries per section
+ok 1 - homepage lists latest entries per section
+  ---
+  duration_ms: 1709.899761
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 1715.60584

--- a/logs/homepage-latest-red.log
+++ b/logs/homepage-latest-red.log
@@ -1,0 +1,220 @@
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+node:internal/modules/esm/resolve:274
+    throw new ERR_MODULE_NOT_FOUND(
+          ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/effusion-labs/test/tools/shared/probe-browser.mjs' imported from /workspace/effusion-labs/test/browser/browser-capability.test.mjs
+    at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+    at moduleResolve (node:internal/modules/esm/resolve:859:10)
+    at defaultResolve (node:internal/modules/esm/resolve:983:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+  code: 'ERR_MODULE_NOT_FOUND',
+  url: 'file:///workspace/effusion-labs/test/tools/shared/probe-browser.mjs'
+}
+
+Node.js v22.18.0
+[31m✖ test/browser/browser-capability.test.mjs [90m(274.225598ms)[39m[39m
+node:internal/modules/esm/resolve:274
+    throw new ERR_MODULE_NOT_FOUND(
+          ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/effusion-labs/test/lib/markdownGateway.js' imported from /workspace/effusion-labs/test/browser/browser-engine.test.mjs
+    at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+    at moduleResolve (node:internal/modules/esm/resolve:859:10)
+    at defaultResolve (node:internal/modules/esm/resolve:983:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+  code: 'ERR_MODULE_NOT_FOUND',
+  url: 'file:///workspace/effusion-labs/test/lib/markdownGateway.js'
+}
+
+Node.js v22.18.0
+[31m✖ test/browser/browser-engine.test.mjs [90m(272.227081ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.66 seconds (32.7ms each, v3.1.2)
+[32m✔ archive nav exposes child counts [90m(3663.143589ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.50 seconds (31.3ms each, v3.1.2)
+[32m✔ layout exposes build timestamp [90m(3504.308571ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[11ty] Copied 76 Wrote 112 files in 3.05 seconds (27.3ms each, v3.1.2)
+[32m✔ code blocks expose copy control [90m(3214.827409ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.30 seconds (29.5ms each, v3.1.2)
+[32m✔ collection pages expose section metadata [90m(3301.690317ms)[39m[39m
+[32m✔ concept map JSON-LD export generates @context and @graph [90m(4.631736ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.50 seconds (31.3ms each, v3.1.2)
+[32m✔ feed exposes build metadata [90m(3506.035938ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.48 seconds (31.1ms each, v3.1.2)
+[32m✔ home page header includes primary nav landmark [90m(3480.336703ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.91 seconds (26.0ms each, v3.1.2)
+[31m✖ homepage lists latest entries per section [90m(3023.914466ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.98 seconds (26.6ms each, v3.1.2)
+[32m✔ homepage hero and sections [90m(3128.583453ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.31 seconds (29.6ms each, v3.1.2)
+[32m✔ markdown headings include anchor ids [90m(3315.895812ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.37 seconds (30.1ms each, v3.1.2)
+[32m✔ monsters hub lists products and cross-links product and character pages [90m(3375.581562ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.36 seconds (30.0ms each, v3.1.2)
+[32m✔ main nav marks current page and is labelled [90m(3361.021872ms)[39m[39m
+[32m✔ navigation items are sequentially ordered [90m(1.04048ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.46 seconds (30.9ms each, v3.1.2)
+[32m✔ buildLean sets env and output directory [90m(3461.651917ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.89 seconds (25.8ms each, v3.1.2)
+[32m✔ spark listings reveal status text [90m(2889.021069ms)[39m[39m
+[32m✔ docs:links reports no broken links [90m(1303.472387ms)[39m[39m
+[32m✔ package-lock.json defines lockfileVersion [90m(7.698665ms)[39m[39m
+[34mℹ tests 19[39m
+[34mℹ suites 0[39m
+[34mℹ pass 16[39m
+[34mℹ fail 3[39m
+[34mℹ cancelled 0[39m
+[34mℹ skipped 0[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms 22742.231192[39m
+
+[31m✖ failing tests:[39m
+
+test at test/browser/browser-capability.test.mjs:1:1
+[31m✖ test/browser/browser-capability.test.mjs [90m(274.225598ms)[39m[39m
+  'test failed'
+
+test at test/browser/browser-engine.test.mjs:1:1
+[31m✖ test/browser/browser-engine.test.mjs [90m(272.227081ms)[39m[39m
+  'test failed'
+
+test at test/integration/homepage-latest.spec.mjs:8:1
+[31m✖ homepage lists latest entries per section [90m(3023.914466ms)[39m[39m
+  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
+  
+    assert(items.length >= 1 && items.length <= 3)
+  
+      at file:///workspace/effusion-labs/test/integration/homepage-latest.spec.mjs:17:5
+      at Array.forEach (<anonymous>)
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage-latest.spec.mjs:13:12)
+      at async Test.run (node:internal/test_runner/test:1054:7)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '=='
+  }
+Executed 18 tests
+
+=============================== Coverage summary ===============================
+Statements   : 83.5% ( 1109/1328 )
+Branches     : 80.17% ( 182/227 )
+Functions    : 75% ( 60/80 )
+Lines        : 83.5% ( 1109/1328 )
+================================================================================

--- a/src/index.11tydata.js
+++ b/src/index.11tydata.js
@@ -1,10 +1,12 @@
-module.exports = (data = {}) => {
-  const collections = data.collections || {};
-  const pick = (arr = []) => arr.slice(0, 3);
-  return {
-    projects: pick(collections.projects),
-    concepts: pick(collections.concepts),
-    sparks: pick(collections.sparks),
-    meta: pick(collections.meta),
-  };
+function pick(collection, n = 3) {
+  return (collection || []).slice(0, n);
+}
+
+module.exports = {
+  eleventyComputed: {
+    projects: data => pick(data.collections.projects),
+    concepts: data => pick(data.collections.concepts),
+    sparks: data => pick(data.collections.sparks),
+    meta: data => pick(data.collections.meta)
+  }
 };

--- a/test/integration/homepage-latest.spec.mjs
+++ b/test/integration/homepage-latest.spec.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+import { buildLean } from '../helpers/eleventy-env.mjs';
+
+test('homepage lists latest entries per section', async () => {
+  const outDir = await buildLean('homepage-latest');
+  const html = readFileSync(path.join(outDir, 'index.html'), 'utf8');
+  const doc = new JSDOM(html).window.document;
+  const sections = ['Projects', 'Concepts', 'Sparks', 'Meta'];
+  sections.forEach(name => {
+    const h2 = Array.from(doc.querySelectorAll('main h2')).find(h => h.textContent.trim() === name);
+    const list = h2.closest('section').querySelector('ul');
+    const items = list.querySelectorAll('li');
+    assert(items.length >= 1 && items.length <= 3);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure index data uses eleventyComputed so homepage renders latest entries rows
- add integration test verifying each section lists 1-3 items
- document provenance and test logs

## Testing
- `node test/integration/homepage-latest.spec.mjs`
- `npm test` *(fails: test/browser/browser-capability.test.mjs, test/browser/browser-engine.test.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_689ff4f2258483308bde14221e613413