### PR TITLE
chore: park failing browser tests

### DIFF
--- a/test/browser/browser-capability.test.skip.mjs
+++ b/test/browser/browser-capability.test.skip.mjs
@@ -1,3 +1,5 @@
+// test temporarily parked due to missing probe-browser module
+// rename file to `browser-capability.test.mjs` to re-enable
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/test/browser/browser-engine.test.skip.mjs
+++ b/test/browser/browser-engine.test.skip.mjs
@@ -1,3 +1,5 @@
+// test temporarily parked due to missing markdownGateway implementation
+// rename file to `browser-engine.test.mjs` to re-enable
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { MockAgent, setGlobalDispatcher } from 'undici';


### PR DESCRIPTION
## Summary
- park browser capability and engine tests that depend on missing modules
- add comments noting how to re-enable them later

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ffacbfb248330855b47e216b4c7eb