### PR TITLE
Ensure logo image transforms to AVIF and WebP

### DIFF
--- a/docs/knowledge/logo-image-transform-green.log
+++ b/docs/knowledge/logo-image-transform-green.log
@@ -1,0 +1,40 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 76 Wrote 112 files in 1.94 seconds (17.3ms each, v3.1.2)
+# Subtest: homepage hero and sections
+ok 1 - homepage hero and sections
+  ---
+  duration_ms: 2048.804469
+  type: 'test'
+  ...
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 76 Wrote 112 files in 2.21 seconds (19.7ms each, v3.1.2)
+# Subtest: logo image transforms to avif and webp
+ok 2 - logo image transforms to avif and webp
+  ---
+  duration_ms: 2300.471045
+  type: 'test'
+  ...
+1..2
+# tests 2
+# suites 0
+# pass 2
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 3330.432559

--- a/docs/knowledge/logo-image-transform-red.log
+++ b/docs/knowledge/logo-image-transform-red.log
@@ -1,0 +1,49 @@
+TAP version 13
+# [11ty] Problem writing Eleventy templates:
+# [11ty] 1. Having trouble writing to "./tmp/logo-image/index.html" from "./src/index.njk" (via EleventyTemplateError)
+# [11ty] 2. Transform `@11ty/eleventy/html-transformer` encountered an error when transforming ./src/index.njk. (via EleventyTransformError)
+# [11ty] 3. ENOENT: no such file or directory, stat 'src/assets/logo.png'
+# [11ty] 
+# [11ty] Original error stack trace: Error: ENOENT: no such file or directory, stat 'src/assets/logo.png'
+# [11ty]     at Object.statSync (node:fs:1739:25)
+# [11ty]     at Image.getInMemoryCacheKey (/workspace/effusion-labs/node_modules/@11ty/eleventy-img/src/image.js:140:32)
+# [11ty]     at Image.create (/workspace/effusion-labs/node_modules/@11ty/eleventy-img/src/image.js:872:19)
+# [11ty]     at createImage (/workspace/effusion-labs/node_modules/@11ty/eleventy-img/img.js:84:19)
+# [11ty]     at queueImage (/workspace/effusion-labs/node_modules/@11ty/eleventy-img/img.js:104:13)
+# [11ty]     at imageAttributesToPosthtmlNode (/workspace/effusion-labs/node_modules/@11ty/eleventy-img/src/image-attrs-to-posthtml-node.js:91:24)
+# [11ty]     at transformTag (/workspace/effusion-labs/node_modules/@11ty/eleventy-img/src/transform-plugin.js:109:10)
+# [11ty]     at /workspace/effusion-labs/node_modules/@11ty/eleventy-img/src/transform-plugin.js:187:25
+# [11ty]     at /workspace/effusion-labs/node_modules/posthtml/lib/api.js:91:45
+# [11ty]     at traverse (/workspace/effusion-labs/node_modules/posthtml/lib/api.js:105:26)
+# [11ty] Copied 8 Wrote 43 files in 1.71 seconds (39.7ms each, v3.1.2)
+# Subtest: logo image transforms to avif and webp
+not ok 1 - logo image transforms to avif and webp
+  ---
+  duration_ms: 1710.392933
+  type: 'test'
+  location: '/workspace/effusion-labs/test/integration/logo-image.spec.mjs:8:1'
+  failureType: 'testCodeFailure'
+  error: 'Having trouble writing to "./tmp/logo-image/index.html" from "./src/index.njk"'
+  code: 'ERR_TEST_FAILURE'
+  name: 'EleventyTemplateError'
+  stack: |-
+    file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:396:8
+    process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+    async Promise.all (index 13)
+    async Promise.all (index 1)
+    async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19)
+    async buildLean (file:///workspace/effusion-labs/test/helpers/eleventy-env.mjs:22:3)
+    async file:///workspace/effusion-labs/test/integration/logo-image.spec.mjs:9:18
+    async TestContext.<anonymous> (file:///workspace/effusion-labs/test/helpers/eleventy-env.mjs:30:14)
+    async Test.run (node:internal/test_runner/test:1054:7)
+    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 2692.079908

--- a/docs/reports/logo-image-transform-continue.md
+++ b/docs/reports/logo-image-transform-continue.md
@@ -1,0 +1,14 @@
+# Continuation – Logo Image Transform
+
+## Context Recap
+Logo image now transforms to AVIF and WebP via Eleventy image plugin and tests assert generated variants.
+
+## Outstanding Items
+1. Expand image transform coverage to additional assets.
+2. Verify responsive image widths in templates.
+
+## Execution Strategy
+Add further integration tests for other templates and ensure widths array suits assets.
+
+## Trigger Command
+node --test test/integration/logo-image.spec.mjs test/integration/homepage.spec.mjs

--- a/docs/reports/logo-image-transform-ledger.md
+++ b/docs/reports/logo-image-transform-ledger.md
@@ -1,0 +1,13 @@
+# logo-image-transform Ledger (1/1)
+
+## Criteria & Proofs
+- Failing check before fix (`docs/knowledge/logo-image-transform-red.log`, sha256: b789a5907469f62d86a183725fda0abef064fcaad0e2a9cd4a6788186bcae0f4).
+- Passing check after implementing image transform (`docs/knowledge/logo-image-transform-green.log`, sha256: 37b0cf5f80c74896d673a38e69d0c4bab4a6fdaddc28310b72e0580c5c10b067).
+
+## Delta Queue
+1. Expand image transform coverage to additional assets.
+2. Verify responsive image widths in templates.
+
+## Rollback
+- Last safe SHA: 7879a8f
+- `git reset --hard 7879a8f`

--- a/src/_data/branding.js
+++ b/src/_data/branding.js
@@ -1,6 +1,6 @@
 module.exports = {
   logoWidth: 112,
   logoHeight: 112,
-  logoSrc: '/assets/logo.png',
+  logoSrc: '/assets/static/logo.png',
   logoAlt: 'Effusion Labs logo'
 };

--- a/test/integration/homepage.spec.mjs
+++ b/test/integration/homepage.spec.mjs
@@ -31,7 +31,7 @@ test('homepage hero and sections', async () => {
 
   const logo = doc.querySelector('img.hero-logo');
   assert(logo);
-  assert.equal(logo.getAttribute('src'), '/assets/logo.png');
+  assert.equal(logo.getAttribute('src'), '/assets/static/logo.png');
   assert.equal(logo.getAttribute('width'), String(branding.logoWidth));
   assert.equal(logo.getAttribute('height'), String(branding.logoHeight));
   assert.equal(logo.getAttribute('loading'), 'eager');

--- a/test/integration/logo-image.spec.mjs
+++ b/test/integration/logo-image.spec.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, existsSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+import { withImages, buildLean } from '../helpers/eleventy-env.mjs';
+
+test('logo image transforms to avif and webp', withImages(async () => {
+  const imageDir = path.join('_site', 'assets', 'images');
+  rmSync(imageDir, { recursive: true, force: true });
+  const outDir = await buildLean('logo-image');
+  const html = readFileSync(path.join(outDir, 'index.html'), 'utf8');
+  const dom = new JSDOM(html);
+  const picture = dom.window.document.querySelector('picture');
+  assert(picture, 'picture element exists');
+  const sources = Array.from(picture.querySelectorAll('source'));
+  const types = sources.map(s => s.getAttribute('type'));
+  assert(types.includes('image/avif'));
+  assert(types.includes('image/webp'));
+  const img = picture.querySelector('img.hero-logo');
+  assert(img);
+  const files = sources.map(s => s.getAttribute('srcset').split(' ')[0]);
+  files.push(img.getAttribute('src'));
+  files.forEach(f => {
+    const p = path.join(imageDir, path.basename(f));
+    assert(existsSync(p), `${f} exists`);
+  });
+}));


### PR DESCRIPTION
## Summary
- add integration test verifying logo image is transformed to AVIF and WebP variants
- update branding to use static logo path compatible with image plugin
- align homepage test and image test helpers with generated paths

## Testing
- `node --test test/integration/logo-image.spec.mjs test/integration/homepage.spec.mjs`

------
https://chatgpt.com/codex/tasks/task_e_689ffc0fb3b4833088feac64147e1599