### PR TITLE
Slugify image filenames for SEO

### DIFF
--- a/docs/knowledge/image-filename-seo-green.log
+++ b/docs/knowledge/image-filename-seo-green.log
@@ -1,0 +1,25 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 76 Wrote 112 files in 2.25 seconds (20.1ms each, v3.1.2)
+# Subtest: transformed images have slugified filenames
+ok 1 - transformed images have slugified filenames
+  ---
+  duration_ms: 2259.596941
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 2872.307027

--- a/docs/knowledge/image-filename-seo-install.log
+++ b/docs/knowledge/image-filename-seo-install.log
@@ -1,0 +1,8 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+up to date, audited 481 packages in 874ms
+
+123 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities

--- a/docs/knowledge/image-filename-seo-red.log
+++ b/docs/knowledge/image-filename-seo-red.log
@@ -1,0 +1,38 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 76 Wrote 112 files in 2.37 seconds (21.2ms each, v3.1.2)
+# Subtest: transformed images have slugified filenames
+not ok 1 - transformed images have slugified filenames
+  ---
+  duration_ms: 2372.741685
+  type: 'test'
+  location: '/workspace/effusion-labs/test/integration/image-filename.spec.mjs:7:1'
+  failureType: 'testCodeFailure'
+  error: 'logo images were generated with slugified filenames'
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: true
+  actual: false
+  operator: '=='
+  stack: |-
+    file:///workspace/effusion-labs/test/integration/image-filename.spec.mjs:13:3
+    async TestContext.<anonymous> (file:///workspace/effusion-labs/test/helpers/eleventy-env.mjs:30:14)
+    async Test.run (node:internal/test_runner/test:1054:7)
+    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 3029.96874

--- a/docs/reports/image-filename-seo-continue.md
+++ b/docs/reports/image-filename-seo-continue.md
@@ -1,0 +1,14 @@
+# Continuation – Image Filename SEO
+
+## Context Recap
+Eleventy image transform now produces slugified filenames and writes to the configured output directory.
+
+## Outstanding Items
+1. Evaluate responsive width generation for small images.
+2. Extend slugified naming to additional asset types.
+
+## Execution Strategy
+Adjust width configuration or introduce upscaling policy and add further integration tests covering more assets.
+
+## Trigger Command
+node --test test/integration/image-filename.spec.mjs

--- a/docs/reports/image-filename-seo-ledger.md
+++ b/docs/reports/image-filename-seo-ledger.md
@@ -1,0 +1,14 @@
+# image-filename-seo Ledger (1/1)
+
+## Criteria & Proofs
+- Failing test before slugified naming (`docs/knowledge/image-filename-seo-red.log`, sha256: 387889f08869dbd9e736848d9168664cf9ad751241f58010f7be7466b03eb260).
+- Installation log for slugify (`docs/knowledge/image-filename-seo-install.log`, sha256: c5bf29d68696066bf83800bc721f07507bd747187604afeebad6c7408d5ec723).
+- Passing test after implementing slugified naming (`docs/knowledge/image-filename-seo-green.log`, sha256: ae2f51be9f6388dac73879d5a2f36987aa8b4f2b9834477dbe44d4ad78b1aa18).
+
+## Delta Queue
+1. Evaluate responsive width generation for small images.
+2. Extend slugified naming to additional asset types.
+
+## Rollback
+- Last safe SHA: 3f84c57
+- `git reset --hard 3f84c57`

--- a/lib/eleventy/register.js
+++ b/lib/eleventy/register.js
@@ -2,6 +2,9 @@ const markdownItFootnote = require('markdown-it-footnote');
 const markdownItAttrs = require('markdown-it-attrs');
 const markdownItAnchor = require('markdown-it-anchor');
 const { eleventyImageTransformPlugin } = require('@11ty/eleventy-img');
+const path = require('node:path');
+const slugify = require('slugify');
+const { dirs } = require('../config');
 
 const getPlugins = require('../plugins');
 const filters = require('../filters');
@@ -70,7 +73,7 @@ module.exports = function register(eleventyConfig) {
   if (!isTest || allowImages) {
     eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
       urlPath: '/assets/images/',
-      outputDir: '_site/assets/images/',
+      outputDir: path.join(dirs.output, 'assets/images/'),
       formats: ['avif', 'webp', 'auto'],
       widths: [320, 640, 960, 1200, 1800, 'auto'],
       htmlOptions: {
@@ -79,6 +82,11 @@ module.exports = function register(eleventyConfig) {
           decoding: 'async'
         },
         pictureAttributes: {}
+      },
+      filenameFormat: (id, src, width, format) => {
+        const { name } = path.parse(src);
+        const slug = slugify(name, { lower: true, strict: true });
+        return `${slug}-${width}.${format}`;
       }
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "prismjs": "^1.30.0",
         "proxy-chain": "^2.5.0",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
+        "slugify": "1.6.6",
         "tailwindcss": "^4.1.11"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "prismjs": "^1.30.0",
     "proxy-chain": "^2.5.0",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
+    "slugify": "1.6.6",
     "tailwindcss": "^4.1.11"
   }
 }

--- a/test/integration/image-filename.spec.mjs
+++ b/test/integration/image-filename.spec.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readdirSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { withImages, buildLean } from '../helpers/eleventy-env.mjs';
+
+test('transformed images have slugified filenames', withImages(async () => {
+  rmSync(path.join('_site', 'assets', 'images'), { recursive: true, force: true });
+  const outDir = await buildLean('image-filename');
+  const imageDir = path.join(outDir, 'assets', 'images');
+  const files = readdirSync(imageDir);
+  const logoFiles = files.filter(f => f.startsWith('logo-'));
+  assert(logoFiles.length > 0, 'logo images were generated with slugified filenames');
+  logoFiles.forEach(f => {
+    assert.match(f, /^logo-\d+\.(avif|webp|png)$/);
+  });
+}));


### PR DESCRIPTION
## Summary
- use slugified filenames for images and write to Eleventy output directory
- add integration test covering slugified image names

## Testing
- `node --test test/integration/image-filename.spec.mjs`

------
https://chatgpt.com/codex/tasks/task_e_689ffea848c083309f01cddcf4307a32