### PR TITLE
feat: harden LLM-safe testing guardrails (v2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - run: bash scripts/llm-bootstrap.sh
       - run: echo "BASH_ENV=$PWD/.llm-bash-env" >> "$GITHUB_ENV"
       - run: npm ci
-      - run: npm test 2>&1 | tee test.log
+      - run: LLM_HEARTBEAT_SECS=10 LLM_MAX_MINS=30 LLM_SHELL_HEARTBEAT=1 npm test 2>&1 | tee test.log
       - run: scripts/warn-gate.sh test.log
       - uses: actions/upload-artifact@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ This repository operates in an **internal prototype / R&D** mode. Prefer solutio
 - **Experimental Expansion:** Adding new public Node.js/npm libraries to expand capabilities is encouraged. Prefer **additive** changes over rewrites unless a rewrite is required for a core acceptance criterion.
 - **Web Ingestion:** When `OUTBOUND_MARKDOWN_ENABLED` is truthy (`1|true|yes`, case-insensitive), use the repo’s helper tool for capture/normalization and follow the system prompt’s **NETWORK I/O** and **PROVENANCE, LEDGER, CONTINUATION** rules.
 
-Tests must run through the default npm scripts or repo `bin` shims; avoid `npm test > file && tail`. The first `SIGINT` is logged and ignored, the second exits with code `130`. Tune heartbeat and timeout with `LLM_HEARTBEAT_SECS` and `LLM_MAX_MINS`; set `LLM_HIJACK_DISABLE=1` to bypass temporarily.
+Always run tests via the default scripts or `node --test` (shims active). The pattern `npm test > file && tail …` is forbidden and auto-rewritten to a streaming `tee` pipeline. The first Ctrl+C (SIGINT) is ignored and logged; the second exits with code `130`. Configure via `LLM_HEARTBEAT_SECS` and `LLM_MAX_MINS`. Temporary bypass for debugging: `LLM_HIJACK_DISABLE=1` (never set this in CI).
 
 ---
 

--- a/bin/node
+++ b/bin/node
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
-# Repo-local node shim: inject keepalive when running tests.
+# Repo-local node shim: inject keepalive only for direct node --test invocations.
 set -euo pipefail
 
-if [[ "${LLM_HIJACK_DISABLE:-}" != "1" ]]; then
-  case "${*:-}" in
-    *"tools/runner.mjs"*|*" --test "*)
-      extras="--import=./test/setup/http.mjs --import=./test/setup/llm-keepalive.mjs"
-      export NODE_OPTIONS="${NODE_OPTIONS:-} ${extras}"
-    ;;
-  esac
+shim_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$shim_dir/.." && pwd)"
+source "$repo_root/scripts/llm-constants.sh"
+
+if [[ "${LLM_HIJACK_DISABLE:-}" != "1" ]] && [[ "${LLM_KEEPALIVE_INJECTED:-}" != "1" ]]; then
+  for arg in "$@"; do
+    if [[ "$arg" == "--test" ]]; then
+      export NODE_OPTIONS="${NODE_OPTIONS:-} ${LLM_KEEPALIVE_IMPORTS}"
+      export LLM_KEEPALIVE_INJECTED=1
+      break
+    fi
+  done
 fi
 
-shim_dir="$(cd "$(dirname "$0")" && pwd)"
 IFS=':' read -r -a path_parts <<< "$PATH"
 real=""
 for d in "${path_parts[@]}"; do

--- a/bin/npm
+++ b/bin/npm
@@ -1,14 +1,7 @@
 #!/usr/bin/env bash
-# Repo-local npm shim: inject keepalive for npm test invocations.
+# Repo-local npm shim: transparent pass-through.
 set -euo pipefail
 orig_args=("$@")
-
-if [[ "${LLM_HIJACK_DISABLE:-}" != "1" ]]; then
-  if [[ "${1:-}" == "test" ]] || { [[ "${1:-}" == "run" ]] && [[ "${2:-}" == test* ]]; }; then
-    extras="--import=./test/setup/http.mjs --import=./test/setup/llm-keepalive.mjs"
-    export NODE_OPTIONS="${NODE_OPTIONS:-} ${extras}"
-  fi
-fi
 
 shim_dir="$(cd "$(dirname "$0")" && pwd)"
 IFS=':' read -r -a path_parts <<< "$PATH"

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "This is a digital studio and knowledge base for Effusion Labs, built with Eleventy and the powerful `@photogabble/eleventy-plugin-interlinker`.",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --import=./test/setup/http.mjs --import=./test/setup/llm-keepalive.mjs\" c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs",
-    "test:all": "NODE_OPTIONS=\"$NODE_OPTIONS --import=./test/setup/http.mjs --import=./test/setup/llm-keepalive.mjs\" c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs --all",
-    "test:browser": "NODE_OPTIONS=\"$NODE_OPTIONS --import=./test/setup/http.mjs --import=./test/setup/llm-keepalive.mjs\" node --test \"test/browser/**/*.test.mjs\" --test-reporter=spec",
+    "prepare": "bash scripts/llm-bootstrap.sh || true",
+    "test": "c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs",
+    "test:all": "c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs --all",
+    "test:browser": "node --test \"test/browser/**/*.test.mjs\" --test-reporter=spec",
     "coverage:report": "c8 report --reporter=text-summary --reporter=lcov",
     "build": "npx @11ty/eleventy",
     "dev": "npx @11ty/eleventy --serve",
@@ -20,7 +21,6 @@
     "prepare-docs": "npm exec fd --version >/dev/null 2>&1 || npm install --save-dev fd-find || true",
     "docs:links": "markdown-link-check -c link-check.config.json README.md"
   },
-  "prepare": "bash scripts/llm-bootstrap.sh || true",
   "engines": {
     "node": ">=20"
   },

--- a/scripts/llm-constants.sh
+++ b/scripts/llm-constants.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Constants for LLM-safe test guardrails.
+# Exported so shims and hijack share a single source of truth.
+export LLM_KEEPALIVE_IMPORTS='--import=./test/setup/http.mjs --import=./test/setup/llm-keepalive.mjs'

--- a/scripts/llm-hijack.sh
+++ b/scripts/llm-hijack.sh
@@ -1,33 +1,64 @@
 #!/usr/bin/env bash
 # Repo-scoped hijack to maintain test liveness.
 
-# Skip if disabled or outside repo.
-root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-[[ -d "$root_dir/.git" ]] || return 0
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+[[ -d "$repo_root/.git" ]] || return 0
 [[ "${LLM_HIJACK_DISABLE:-}" == "1" ]] && return 0
 
-# Low-frequency shell heartbeat.
-hb_interval=$(( ${LLM_HEARTBEAT_SECS:-15} * 4 ))
-llm_shell_hb() {
-  while true; do
-    printf '::notice:: LLM-safe: shell alive @ %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >&2
-    sleep "$hb_interval"
-  done
-}
-llm_shell_hb &
-_llm_hb_pid=$!
-trap 'kill "$_llm_hb_pid" 2>/dev/null' EXIT
+source "$repo_root/scripts/llm-constants.sh"
 
-# DEBUG trap to rewrite silent npm test pattern.
+hb_interval=$(( ${LLM_HEARTBEAT_SECS:-15} * 4 ))
+(( hb_interval < 30 )) && hb_interval=30
+if [[ "${CI:-}" == "true" || "${LLM_SHELL_HEARTBEAT:-}" == "1" ]]; then
+  llm_shell_hb() {
+    while true; do
+      printf '::notice:: LLM-safe: shell alive @ %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >&2
+      sleep "$hb_interval"
+    done
+  }
+  llm_shell_hb &
+  _llm_hb_pid=$!
+  trap 'kill "$_llm_hb_pid" 2>/dev/null' EXIT
+fi
+
 _llm_hijack() {
+  [[ "${_LLM_REWRITE_ACTIVE:-}" == "1" ]] && return 0
   local cmd="$BASH_COMMAND"
-  if [[ "$cmd" == "npm test >"* && "$cmd" == *"&& tail"* ]]; then
-    local file="${cmd#npm test > }"
-    file="${file%% && tail*}"
-    printf '::notice:: LLM-safe: rewrote npm test redirect -> tee %s\n' "$file" >&2
-    eval "npm test | tee -i \"$file\""
-    return 1
+  read -r -a toks <<<"$cmd"
+  [[ "${toks[0]}" == npm ]] || return 0
+  local idx=0
+  local extra=()
+  local outfile=""
+  if [[ "${toks[1]}" == test ]]; then
+    idx=2
+  elif [[ "${toks[1]}" == run && "${toks[2]}" == test ]]; then
+    idx=3
+  else
+    return 0
   fi
+  while (( idx < ${#toks[@]} )); do
+    local token="${toks[idx]}"
+    if [[ "$token" == "2>&1" ]]; then
+      ((idx++))
+      continue
+    elif [[ "$token" == ">" || "$token" == "1>" ]]; then
+      outfile="${toks[idx+1]}"
+      idx=$((idx+2))
+      break
+    else
+      extra+=("$token")
+      ((idx++))
+    fi
+  done
+  [[ -n "$outfile" ]] || return 0
+  printf '::notice:: LLM-safe: rewrote "%s" -> tee\n' "$cmd" >&2
+  export _LLM_REWRITE_ACTIVE=1
+  export LLM_KEEPALIVE_INJECTED=1
+  local qfile
+  qfile=$(printf '%q' "$outfile")
+  eval "npm test ${extra[*]} 2>&1 | tee -i $qfile"
+  BASH_COMMAND=:
+  unset _LLM_REWRITE_ACTIVE
+  return 0
 }
 trap _llm_hijack DEBUG
-

--- a/tools/runner.mjs
+++ b/tools/runner.mjs
@@ -27,13 +27,19 @@ async function main() {
     return;
   }
 
-  const extraImports = '--import=./test/setup/http.mjs --import=./test/setup/llm-keepalive.mjs';
+  const extraImports =
+    process.env.LLM_KEEPALIVE_IMPORTS ||
+    '--import=./test/setup/http.mjs --import=./test/setup/llm-keepalive.mjs';
   const envNodeOptions = process.env.NODE_OPTIONS
     ? `${process.env.NODE_OPTIONS} ${extraImports}`
     : extraImports;
   const child = spawn(process.execPath, ['--test', '--test-reporter=spec', ...execute], {
     stdio: 'inherit',
-    env: { ...process.env, NODE_OPTIONS: envNodeOptions },
+    env: {
+      ...process.env,
+      NODE_OPTIONS: envNodeOptions,
+      LLM_KEEPALIVE_INJECTED: '1',
+    },
   });
 
   child.on('exit', code => {


### PR DESCRIPTION
## Summary
- centralize keepalive import flags and inject once via runner or node shim
- harden hijack script with token parsing, heartbeat gating and rewrite notices
- streamline CI test workflow and document guardrail policy

## Testing
- `npm test > /tmp/t.log && tail -n 5 /tmp/t.log`


------
https://chatgpt.com/codex/tasks/task_e_68a0117155448330aa4c0cda06e8feca