### PR TITLE
Fix logo image transform test

### DIFF
--- a/test/integration/logo-image.spec.mjs
+++ b/test/integration/logo-image.spec.mjs
@@ -1,14 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { readFileSync, existsSync, rmSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { withImages, buildLean } from '../helpers/eleventy-env.mjs';
 
 test('logo image transforms to avif and webp', withImages(async () => {
-  const imageDir = path.join('_site', 'assets', 'images');
-  rmSync(imageDir, { recursive: true, force: true });
   const outDir = await buildLean('logo-image');
+  const imageDir = path.join(outDir, 'assets', 'images');
   const html = readFileSync(path.join(outDir, 'index.html'), 'utf8');
   const dom = new JSDOM(html);
   const picture = dom.window.document.querySelector('picture');


### PR DESCRIPTION
## Summary
- verify transformed images exist in the build output directory

## Testing
- `npm test`
- `npm run test:all`


------
https://chatgpt.com/codex/tasks/task_e_68a014d5f6288330830f63824956bdb6