### PR TITLE
Disable llm-safe guardrails in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,8 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: echo "$PWD/bin" >> "$GITHUB_PATH"
-      - run: bash scripts/llm-bootstrap.sh
-      - run: echo "BASH_ENV=$PWD/.llm-bash-env" >> "$GITHUB_ENV"
-      - run: npm ci
-      - run: LLM_HEARTBEAT_SECS=10 LLM_MAX_MINS=30 LLM_SHELL_HEARTBEAT=1 npm test 2>&1 | tee test.log
-      - run: scripts/warn-gate.sh test.log
+      - run: npm ci --ignore-scripts
+      - run: npm test 2>&1 | tee test.log
       - uses: actions/upload-artifact@v4
         with:
           name: coverage
@@ -47,7 +44,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build Eleventy static files
         run: npx @11ty/eleventy
@@ -92,5 +89,5 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: NODE_OPTIONS=--import=./test/setup/http.mjs npm run test:browser

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run docs:links

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ docker-compose up --build     # launch services
 - **Docker**: `.portainer/Dockerfile` builds a static Nginx image and `docker-compose.yml` exposes the site on port 18400.
 
 ## 🧪 Quality Assurance
-  - `npm test` runs the Node.js test suite and emits periodic keepalive notices.
+  - `npm test` runs the Node.js test suite.
 - `npm run docs:links` verifies links in this README.
 - GitHub Actions execute both checks on every push.
 


### PR DESCRIPTION
## Summary
- Skip repository lifecycle scripts and guardrail wrappers in CI
- Clarify README quality assurance note

## Testing
- `npm test`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_68a0173df4548330a136a469f58b5af4