### PR TITLE
feat: add homepage work filters and lab seal badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates and Tailwind CSS. Markdown content in `src/content` feeds Eleventy's collections to generate a fully static site. Node.js 20 powers the build pipeline, and the resulting `_site/` directory can be served directly or packaged into a lightweight Nginx container. GitHub Actions drive tests and deployments to GitHub Container Registry.
 
 ## ✨ Key Features
+- Home page presents a unified Work feed with filter toolbar and animated lab seal flourish.
 ### npm Scripts
 - `npm run dev` – start Eleventy with live reload.
 - `npm run build` – compile the production site to `_site/`.

--- a/docs/knowledge/homepage-hero-green.log
+++ b/docs/knowledge/homepage-hero-green.log
@@ -1,165 +1,40 @@
-npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
-
-> effusion_labs_final@1.0.0 test
-> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
-
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.44 seconds (30.7ms each, v3.1.2)
-✔ archive nav exposes child counts (3462.569449ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.43 seconds (30.6ms each, v3.1.2)
-✔ layout exposes build timestamp (3445.918779ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 2.89 seconds (25.8ms each, v3.1.2)
-✔ code blocks expose copy control (3067.486978ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.32 seconds (29.6ms each, v3.1.2)
-✔ collection pages expose section metadata (3333.70603ms)
-✔ concept map JSON-LD export generates @context and @graph (3.031283ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.36 seconds (30.0ms each, v3.1.2)
-✔ feed exposes build metadata (3372.327597ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.52 seconds (31.5ms each, v3.1.2)
-✔ home page header includes primary nav landmark (3543.420463ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 2.92 seconds (26.1ms each, v3.1.2)
-✔ homepage lists latest entries per section (3053.792968ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 2.92 seconds (26.1ms each, v3.1.2)
-✔ homepage hero and sections (3088.484619ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.26 seconds (29.1ms each, v3.1.2)
-✔ markdown headings include anchor ids (3270.892598ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.27 seconds (29.2ms each, v3.1.2)
-✔ monsters hub lists products and cross-links product and character pages (3293.648513ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.21 seconds (28.6ms each, v3.1.2)
-✔ main nav marks current page and is labelled (3222.823347ms)
-✔ navigation items are sequentially ordered (1.242504ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.24 seconds (28.9ms each, v3.1.2)
-✔ buildLean sets env and output directory (3255.818667ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 2.89 seconds (25.8ms each, v3.1.2)
-✔ spark listings reveal status text (2905.209563ms)
-✔ deploy workflow does not trigger on pull_request (1.174728ms)
-✔ build job runs only on push events (0.199587ms)
-✔ docs:links reports no broken links (1098.139454ms)
-✔ package-lock.json defines lockfileVersion (6.81329ms)
-✔ projects computed picks latest entries by date (2.264761ms)
-✔ keepalive emits heartbeat to stderr (6273.273396ms)
-✔ keepalive ignores first SIGINT (334.827143ms)
-✔ devDependencies omit @vscode/ripgrep (1.006569ms)
-✔ prepare-docs avoids ripgrep install (0.185171ms)
-✔ time to chill includes size with height in cm (1.309073ms)
-✔ time to chill height is positive (0.13322ms)
-✔ GitHub workflows use latest action versions (1.311653ms)
-ℹ tests 27
-ℹ suites 0
-ℹ pass 27
-ℹ fail 0
-ℹ cancelled 0
-ℹ skipped 0
-ℹ todo 0
-ℹ duration_ms 26127.701244
-Executed 22 tests
-
-=============================== Coverage summary ===============================
-Statements   : 83.43% ( 1128/1352 )
-Branches     : 79.22% ( 183/231 )
-Functions    : 75% ( 63/84 )
-Lines        : 83.43% ( 1128/1352 )
-================================================================================
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 112 files in 1.89 seconds (16.9ms each, v3.1.2)
+# Subtest: homepage work list mixes types
+ok 1 - homepage work list mixes types
+  ---
+  duration_ms: 1990.193626
+  type: 'test'
+  ...
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 112 files in 1.83 seconds (16.4ms each, v3.1.2)
+# Subtest: homepage hero and work filters
+ok 2 - homepage hero and work filters
+  ---
+  duration_ms: 1952.104758
+  type: 'test'
+  ...
+1..2
+# tests 2
+# suites 0
+# pass 2
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 3083.446145

--- a/docs/knowledge/homepage-hero-red.log
+++ b/docs/knowledge/homepage-hero-red.log
@@ -1,5 +1,12 @@
 npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
+> effusion_labs_final@1.0.0 test:guard
+> bash scripts/test-with-guardrails.sh
+
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:08:19Z
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:08:19Z
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
 > effusion_labs_final@1.0.0 test
 > c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
 
@@ -11,18 +18,8 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.35 seconds (29.9ms each, v3.1.2)
-✔ archive nav exposes child counts (3366.558054ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
 [11ty] Copied 76 Wrote 112 files in 3.33 seconds (29.8ms each, v3.1.2)
-✔ layout exposes build timestamp (3350.448322ms)
+✔ archive nav exposes child counts (3335.580982ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -31,8 +28,8 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 2.79 seconds (24.9ms each, v3.1.2)
-✔ code blocks expose copy control (2990.599329ms)
+[11ty] Copied 76 Wrote 112 files in 3.38 seconds (30.2ms each, v3.1.2)
+✔ layout exposes build timestamp (3385.48512ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -41,9 +38,8 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.31 seconds (29.6ms each, v3.1.2)
-✔ collection pages expose section metadata (3330.520374ms)
-✔ concept map JSON-LD export generates @context and @graph (3.786472ms)
+[11ty] Copied 76 Wrote 112 files in 2.76 seconds (24.6ms each, v3.1.2)
+✔ code blocks expose copy control (2902.358589ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -52,8 +48,9 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.34 seconds (29.8ms each, v3.1.2)
-✔ feed exposes build metadata (3355.260409ms)
+[11ty] Copied 76 Wrote 112 files in 3.06 seconds (27.3ms each, v3.1.2)
+✔ collection pages expose section metadata (3058.710815ms)
+✔ concept map JSON-LD export generates @context and @graph (3.393398ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -62,8 +59,8 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.40 seconds (30.3ms each, v3.1.2)
-✔ home page header includes primary nav landmark (3414.424877ms)
+[11ty] Copied 76 Wrote 112 files in 3.24 seconds (29.0ms each, v3.1.2)
+✔ feed exposes build metadata (3247.15615ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -72,8 +69,8 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 2.85 seconds (25.5ms each, v3.1.2)
-✔ homepage lists latest entries per section (3012.854965ms)
+[11ty] Copied 76 Wrote 112 files in 3.10 seconds (27.7ms each, v3.1.2)
+✔ home page header includes primary nav landmark (3105.809546ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -82,8 +79,8 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 2.91 seconds (26.0ms each, v3.1.2)
-✖ homepage hero and sections (3033.366576ms)
+[11ty] Copied 76 Wrote 112 files in 2.57 seconds (22.9ms each, v3.1.2)
+✔ homepage lists latest entries per section (2689.694843ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -92,39 +89,8 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.77 seconds (33.6ms each, v3.1.2)
-✔ transformed images have slugified filenames (3785.096558ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Benchmark    292ms   9%   112× (Configuration) "@11ty/eleventy/html-transformer" Transform
-[11ty] Copied 76 Wrote 112 files in 3.42 seconds (30.5ms each, v3.1.2)
-✔ logo image transforms to avif and webp (3568.439094ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.26 seconds (29.1ms each, v3.1.2)
-✔ markdown headings include anchor ids (3275.3683ms)
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
-	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.28 seconds (29.2ms each, v3.1.2)
-✔ monsters hub lists products and cross-links product and character pages (3289.704411ms)
+[11ty] Copied 76 Wrote 112 files in 2.59 seconds (23.1ms each, v3.1.2)
+✖ homepage hero and work filters (2734.129122ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -134,8 +100,7 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [11ty] Copied 76 Wrote 112 files in 3.22 seconds (28.8ms each, v3.1.2)
-✔ main nav marks current page and is labelled (3236.068298ms)
-✔ navigation items are sequentially ordered (1.128489ms)
+✔ markdown headings include anchor ids (3224.72603ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -144,8 +109,19 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
-[11ty] Copied 76 Wrote 112 files in 3.30 seconds (29.5ms each, v3.1.2)
-✔ buildLean sets env and output directory (3317.398782ms)
+[11ty] Copied 76 Wrote 112 files in 3.00 seconds (26.8ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (3000.446826ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.92 seconds (26.1ms each, v3.1.2)
+✔ main nav marks current page and is labelled (2926.167981ms)
+✔ navigation items are sequentially ordered (1.028252ms)
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
@@ -155,47 +131,60 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
 	- ./src/content/sparks/vapor-linked-governance.md
 [11ty] Copied 76 Wrote 112 files in 3.17 seconds (28.3ms each, v3.1.2)
-✔ spark listings reveal status text (3188.750594ms)
-✔ deploy workflow does not trigger on pull_request (1.419177ms)
-✔ build job runs only on push events (0.188696ms)
-✔ docs:links reports no broken links (1074.614732ms)
-✔ package-lock.json defines lockfileVersion (5.083217ms)
-✔ projects computed picks latest entries by date (2.448863ms)
-✔ keepalive emits heartbeat to stderr (6255.73434ms)
-✔ keepalive ignores first SIGINT (326.870145ms)
-✔ devDependencies omit @vscode/ripgrep (1.085647ms)
-✔ prepare-docs avoids ripgrep install (0.143476ms)
-✔ time to chill includes size with height in cm (1.291068ms)
-✔ time to chill height is positive (0.144115ms)
-✔ GitHub workflows use latest action versions (1.263902ms)
-ℹ tests 29
+✔ buildLean sets env and output directory (3169.683979ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.81 seconds (25.1ms each, v3.1.2)
+✔ spark listings reveal status text (2815.311308ms)
+✔ deploy workflow does not trigger on pull_request (1.156512ms)
+✔ build job runs only on push events (0.19497ms)
+✔ docs:links reports no broken links (1252.719364ms)
+✔ package-lock.json defines lockfileVersion (4.954902ms)
+✔ projects computed picks latest entries by date (1.959768ms)
+✔ keepalive emits heartbeat to stderr (6248.837056ms)
+✔ keepalive ignores first SIGINT (320.672964ms)
+✔ devDependencies omit @vscode/ripgrep (1.074028ms)
+✔ prepare-docs avoids ripgrep install (0.156151ms)
+✔ time to chill includes size with height in cm (1.146687ms)
+✔ time to chill height is positive (0.163696ms)
+✔ GitHub workflows use latest action versions (1.210564ms)
+ℹ tests 27
 ℹ suites 0
-ℹ pass 28
+ℹ pass 26
 ℹ fail 1
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 30469.984767
+ℹ duration_ms 25039.263462
 
 ✖ failing tests:
 
 test at test/integration/homepage.spec.mjs:18:1
-✖ homepage hero and sections (3033.366576ms)
-  AssertionError [ERR_ASSERTION]: 'EFFUSION LABS' == 'Experimental R&D you can actually use.'
-      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage.spec.mjs:27:10)
+✖ homepage hero and work filters (2734.129122ms)
+  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
+  
+    assert(workHeader)
+  
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage.spec.mjs:48:3)
       at async Test.run (node:internal/test_runner/test:1054:7)
       at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
     generatedMessage: true,
     code: 'ERR_ASSERTION',
-    actual: 'EFFUSION LABS',
-    expected: 'Experimental R&D you can actually use.',
+    actual: undefined,
+    expected: true,
     operator: '=='
   }
-Executed 24 tests
+Executed 22 tests
 
 =============================== Coverage summary ===============================
-Statements   : 84.83% ( 1147/1352 )
-Branches     : 79.74% ( 185/232 )
-Functions    : 76.19% ( 64/84 )
-Lines        : 84.83% ( 1147/1352 )
+Statements   : 83.43% ( 1128/1352 )
+Branches     : 78.87% ( 183/232 )
+Functions    : 75% ( 63/84 )
+Lines        : 83.43% ( 1128/1352 )
 ================================================================================

--- a/docs/reports/homepage-hero-continue.md
+++ b/docs/reports/homepage-hero-continue.md
@@ -1,14 +1,13 @@
 # Continuation – Homepage Hero
 
 ## Context Recap
-Homepage hero rebuilt with value proposition, dual CTAs, and a three-tile bento. Legacy logo and provenance line removed.
+Homepage hero extended with unified Work feed filters and animated lab seal flourish.
 
 ## Outstanding Items
-1. Integrate work feed filters into homepage.
-2. Add animated lab seal flourish.
+(none)
 
 ## Execution Strategy
-Implement filter toolbar and badge animation with prefers-reduced-motion safeguard.
+No further actions.
 
 ## Trigger Command
-NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs
+NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs test/integration/homepage-latest.spec.mjs

--- a/docs/reports/homepage-hero-ledger.md
+++ b/docs/reports/homepage-hero-ledger.md
@@ -1,13 +1,12 @@
-# homepage-hero Ledger (1/1)
+# homepage-hero Ledger (2/2)
 
 ## Criteria & Proofs
-- Failing check before fix (`docs/knowledge/homepage-hero-red.log`, sha256: 2f330543551302674f221894a70c014ff799684e6b86ad29cedd4536750bfccc).
-- Passing check after implementing hero (`docs/knowledge/homepage-hero-green.log`, sha256: e5124c282fc34026d68150d01efd7d6cce60ee5fa0519895fa5b8cbcad815451).
+- Failing check before fix (`docs/knowledge/homepage-hero-red.log`, sha256: 355ca2527fa59f5b8a95afac05afb1814781657b11917fbd428ba1d8f7f2363a).
+- Passing check after implementing filters and lab seal (`docs/knowledge/homepage-hero-green.log`, sha256: 6c742c45ef15ab45e41246804e258340105a70cfb47951cfc2e7f06f8416dc76).
 
 ## Delta Queue
-1. Integrate work feed filters into homepage.
-2. Add animated lab seal flourish.
+(none)
 
 ## Rollback
-- Last safe SHA: 6706e83
-- `git reset --hard 6706e83`
+- Last safe SHA: 0b8c188
+- `git reset --hard 0b8c188`

--- a/src/_includes/components/feed-entry.njk
+++ b/src/_includes/components/feed-entry.njk
@@ -1,9 +1,10 @@
 {% macro feedEntry(item) %}
-<li>
-  <a href="{{ item.url }}" class="block rounded-md border border-white/20 bg-white/5 p-4 hover:bg-white/10">
-    <h3 class="font-heading text-lg text-gray-100">{{ item.data.title }}</h3>
+<li data-type="{{ item.type }}">
+  <a href="{{ item.url }}" class="card">
+    <span class="chip">{{ item.type | capitalize }}</span>
+    <h3>{{ item.data.title }}</h3>
     {% if item.data.description %}
-    <p class="mt-1 text-sm text-gray-300">{{ item.data.description | truncate(140, true, '…') }}</p>
+    <p>{{ item.data.description | truncate(140, true, '…') }}</p>
     {% endif %}
   </a>
 </li>

--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -13,5 +13,8 @@
       {{ heroTile('Concept', 'Block Ledger', 'Auditable knowledge blocks across artifacts.', '/work/block-ledger') }}
       {{ heroTile('Spark', 'Raw Socket Report', 'Unfiltered notes from a midnight server check.', '/work/raw-socket-report') }}
     </div>
+    <div class="mt-8 flex justify-center">
+      <span class="lab-seal"></span>
+    </div>
   </div>
 </header>

--- a/src/_includes/components/work-feed.njk
+++ b/src/_includes/components/work-feed.njk
@@ -1,0 +1,19 @@
+{% from "components/feed-entry.njk" import feedEntry %}
+<section aria-labelledby="work-heading" class="space-y-4">
+  <h2 id="work-heading" class="text-2xl font-heading">Work</h2>
+  <div class="filters flex flex-wrap gap-2" role="toolbar" aria-label="Filter work">
+    <button class="btn btn-sm" data-filter="all" aria-pressed="true">All</button>
+    <button class="btn btn-sm" data-filter="project">Projects</button>
+    <button class="btn btn-sm" data-filter="concept">Concepts</button>
+    <button class="btn btn-sm" data-filter="spark">Sparks</button>
+    <button class="btn btn-sm" data-filter="meta">Meta</button>
+  </div>
+  <ul id="work-list" class="space-y-4">
+    {% for item in work %}
+      {{ feedEntry(item) }}
+    {% endfor %}
+  </ul>
+  <div class="more">
+    <a class="btn btn-secondary" href="/work">Browse all work</a>
+  </div>
+</section>

--- a/src/index.11tydata.js
+++ b/src/index.11tydata.js
@@ -6,9 +6,17 @@ function takeLatest(collection, n = 3) {
 
 module.exports = {
   eleventyComputed: {
-    projects: data => takeLatest(data.collections.projects),
-    concepts: data => takeLatest(data.collections.concepts),
-    sparks: data => takeLatest(data.collections.sparks),
-    meta: data => takeLatest(data.collections.meta)
+    work: data => {
+      const normalize = (items = [], type) =>
+        items.map(i => ({ url: i.url, data: i.data, date: i.date, type }));
+      return [
+        ...normalize(data.collections.projects, 'project'),
+        ...normalize(data.collections.concepts, 'concept'),
+        ...normalize(data.collections.sparks, 'spark'),
+        ...normalize(data.collections.meta, 'meta')
+      ]
+        .sort((a, b) => b.date - a.date)
+        .slice(0, 9);
+    }
   }
 };

--- a/src/index.njk
+++ b/src/index.njk
@@ -4,13 +4,10 @@ metaDisable: true
 showTitle: false
 ---
 
-{% from "components/feed-section.njk" import feedSection %}
-
 {% include "components/hero.njk" %}
 
 <main class="mx-auto max-w-screen-md px-6 sm:px-8 space-y-16">
-  {{ feedSection('Projects', '/projects/', projects) }}
-  {{ feedSection('Concepts', '/concepts/', concepts) }}
-  {{ feedSection('Sparks', '/sparks/', sparks) }}
-  {{ feedSection('Meta', '/meta/', meta) }}
+  {% include "components/work-feed.njk" %}
 </main>
+
+<script src="/assets/js/work-filters.js" defer></script>

--- a/src/scripts/work-filters.js
+++ b/src/scripts/work-filters.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const buttons = document.querySelectorAll('[data-filter]');
+  const items = document.querySelectorAll('#work-list > li');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      buttons.forEach(b => b.setAttribute('aria-pressed', b === btn ? 'true' : 'false'));
+      const filter = btn.dataset.filter;
+      items.forEach(li => {
+        const type = li.dataset.type;
+        li.classList.toggle('hidden', filter !== 'all' && type !== filter);
+      });
+    });
+  });
+});

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -2,8 +2,22 @@
   .tile { @apply bg-black/20 hover:bg-black/30; }
   .chip { @apply inline-block mb-2 rounded-full border border-white/20 px-2 py-0.5 text-xs; }
   .tile-primary { @apply bg-electric/10 hover:bg-electric/20; }
+  .card { @apply block rounded-md border border-white/20 bg-white/5 p-4 hover:bg-white/10 transition-shadow; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .tile { @apply transition-none hover:translate-y-0 hover:shadow-none; }
+  .lab-seal { animation: none; }
 }
+
+@keyframes lab-seal-oscillate {
+  from { transform: rotate(-0.25deg); }
+  to { transform: rotate(0.25deg); }
+}
+
+.lab-seal {
+  @apply inline-block w-12 h-12 rounded-full border border-electric/50 bg-electric/10;
+  animation: lab-seal-oscillate 4s ease-in-out infinite alternate;
+}
+
+.lab-seal:hover { transform: rotate(3deg); }

--- a/test/integration/homepage-latest.spec.mjs
+++ b/test/integration/homepage-latest.spec.mjs
@@ -5,15 +5,12 @@ import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { buildLean } from '../helpers/eleventy-env.mjs';
 
-test('homepage lists latest entries per section', async () => {
+test('homepage work list mixes types', async () => {
   const outDir = await buildLean('homepage-latest');
   const html = readFileSync(path.join(outDir, 'index.html'), 'utf8');
   const doc = new JSDOM(html).window.document;
-  const sections = ['Projects', 'Concepts', 'Sparks', 'Meta'];
-  sections.forEach(name => {
-    const h2 = Array.from(doc.querySelectorAll('main h2')).find(h => h.textContent.trim() === name);
-    const list = h2.closest('section').querySelector('ul');
-    const items = list.querySelectorAll('li');
-    assert(items.length >= 1 && items.length <= 3);
-  });
+  const items = Array.from(doc.querySelectorAll('#work-list > li'));
+  assert(items.length >= 6 && items.length <= 9);
+  const types = new Set(items.map(li => li.dataset.type));
+  ['project','concept','spark','meta'].forEach(t => assert(types.has(t)));
 });


### PR DESCRIPTION
## Summary
- unify Projects/Concepts/Sparks/Meta into one Work feed with filter chips
- add animated lab seal flourish to the hero
- document new homepage features

## Testing
- `npm run docs:links`
- `NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs test/integration/homepage-latest.spec.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a01f9d44b48330ad99bdbc61b88004