### PR TITLE
Restore concept map CTA and hero branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates and Tailwind CSS. Markdown content in `src/content` feeds Eleventy's collections to generate a fully static site. Node.js 20 powers the build pipeline, and the resulting `_site/` directory can be served directly or packaged into a lightweight Nginx container. GitHub Actions drive tests and deployments to GitHub Container Registry.
 
 ## ✨ Key Features
-- Home page presents a unified Work feed with filter toolbar and animated lab seal flourish.
+- Home page presents a unified Work feed with filter toolbar, interactive concept map CTA, and animated lab seal flourish.
 ### npm Scripts
 - `npm run dev` – start Eleventy with live reload.
 - `npm run build` – compile the production site to `_site/`.

--- a/docs/knowledge/homepage-hero-map-green.log
+++ b/docs/knowledge/homepage-hero-map-green.log
@@ -1,0 +1,40 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 113 files in 1.73 seconds (15.4ms each, v3.1.2)
+# Subtest: homepage work list mixes types
+ok 1 - homepage work list mixes types
+  ---
+  duration_ms: 1831.796446
+  type: 'test'
+  ...
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 113 files in 1.76 seconds (15.6ms each, v3.1.2)
+# Subtest: homepage hero and work filters
+ok 2 - homepage hero and work filters
+  ---
+  duration_ms: 1908.982773
+  type: 'test'
+  ...
+1..2
+# tests 2
+# suites 0
+# pass 2
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 2984.364948

--- a/docs/knowledge/homepage-hero-map-red.log
+++ b/docs/knowledge/homepage-hero-map-red.log
@@ -1,0 +1,55 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 112 files in 1.89 seconds (16.9ms each, v3.1.2)
+# Subtest: homepage work list mixes types
+ok 1 - homepage work list mixes types
+  ---
+  duration_ms: 1976.921581
+  type: 'test'
+  ...
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 112 files in 1.95 seconds (17.4ms each, v3.1.2)
+# Subtest: homepage hero and work filters
+not ok 2 - homepage hero and work filters
+  ---
+  duration_ms: 2058.407901
+  type: 'test'
+  location: '/workspace/effusion-labs/test/integration/homepage.spec.mjs:18:1'
+  failureType: 'testCodeFailure'
+  error: |-
+    The expression evaluated to a falsy value:
+    
+      assert(mapHeading)
+    
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: true
+  operator: '=='
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage.spec.mjs:42:3)
+    async Test.run (node:internal/test_runner/test:1054:7)
+    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)
+  ...
+1..2
+# tests 2
+# suites 0
+# pass 1
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 3223.072906

--- a/docs/reports/homepage-hero-continue.md
+++ b/docs/reports/homepage-hero-continue.md
@@ -1,7 +1,7 @@
 # Continuation – Homepage Hero
 
 ## Context Recap
-Homepage hero extended with unified Work feed filters and animated lab seal flourish.
+Homepage hero now includes branded logo, restored concept map call-to-action and refactored lab seal.
 
 ## Outstanding Items
 (none)

--- a/docs/reports/homepage-hero-ledger.md
+++ b/docs/reports/homepage-hero-ledger.md
@@ -1,8 +1,10 @@
-# homepage-hero Ledger (2/2)
+# homepage-hero Ledger (4/4)
 
 ## Criteria & Proofs
 - Failing check before fix (`docs/knowledge/homepage-hero-red.log`, sha256: 355ca2527fa59f5b8a95afac05afb1814781657b11917fbd428ba1d8f7f2363a).
 - Passing check after implementing filters and lab seal (`docs/knowledge/homepage-hero-green.log`, sha256: 6c742c45ef15ab45e41246804e258340105a70cfb47951cfc2e7f06f8416dc76).
+- Failing check before restoring map CTA (`docs/knowledge/homepage-hero-map-red.log`, sha256: 8f566692af82968703cffcbe7588ce88edd24c8c6ddaf2177e0aa29f0b6f48d8).
+- Passing check after restoring map CTA and layout (`docs/knowledge/homepage-hero-map-green.log`, sha256: f576f7e398bf400f5a56baae65d70232c29a410accf7a1cd3e517511f2de8ead).
 
 ## Delta Queue
 (none)

--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -1,6 +1,7 @@
 {% from "components/hero-tile.njk" import heroTile %}
 <header class="hero bg-gradient-to-b from-ink to-electric text-paper">
-  <div class="container mx-auto max-w-screen-xl px-6 py-24 text-center space-y-6">
+  <div class="container mx-auto max-w-screen-2xl px-6 py-32 text-center space-y-6">
+    <img src="{{ branding.logoSrc }}" alt="{{ branding.logoAlt }}" width="{{ branding.logoWidth }}" height="{{ branding.logoHeight }}" class="mx-auto h-16 w-16" />
     <p class="eyebrow font-mono text-sm">Effusion Labs</p>
     <h1 class="font-heading font-semibold text-4xl md:text-5xl">Experimental R&D you can actually use.</h1>
     <p class="lede font-body text-lg">Prototypes, systems, and notes from the lab.</p>
@@ -13,8 +14,6 @@
       {{ heroTile('Concept', 'Block Ledger', 'Auditable knowledge blocks across artifacts.', '/work/block-ledger') }}
       {{ heroTile('Spark', 'Raw Socket Report', 'Unfiltered notes from a midnight server check.', '/work/raw-socket-report') }}
     </div>
-    <div class="mt-8 flex justify-center">
-      <span class="lab-seal"></span>
-    </div>
+    <span class="lab-seal mt-8 block mx-auto"></span>
   </div>
 </header>

--- a/src/_includes/components/map-cta.njk
+++ b/src/_includes/components/map-cta.njk
@@ -1,0 +1,5 @@
+<section aria-labelledby="map-heading" class="text-center space-y-4">
+  <h2 id="map-heading" class="text-2xl font-heading">Explore the Interactive Concept Map</h2>
+  <p class="mx-auto max-w-prose text-lg text-neutral-300">Navigate the living knowledge graph that links every spark, concept, and project in the lab.</p>
+  <a href="/map/" class="btn btn-secondary">Launch the Map</a>
+</section>

--- a/src/content/meta/how-to-manufacture-a-legacy.md
+++ b/src/content/meta/how-to-manufacture-a-legacy.md
@@ -1,0 +1,38 @@
+---
+title: "How to Manufacture a Legacy: The Pierre Paulin Estate Between Preservation and Product"
+layout: "layout.njk"
+date: 2025-08-02
+status: Stable
+certainty: adversarial-analytic
+importance: 4
+tags:
+  - pierre-paulin
+  - design-legacy
+  - estate-management
+  - brand-engineering
+  - intellectual-property
+  - luxury-market
+  - authenticity
+  - narrative-control
+spark_type: analytic-report
+target: Paulin, Paulin, Paulin as a Legacy-to-Luxury Conversion Engine
+analytic_lens:
+  - narrative-engineering
+  - institutional-gatekeeping
+  - material-authenticity
+  - market-as-verdict
+  - posthumous-authorship
+memory_ref:
+  - [estate-law]
+  - [brand-management]
+  - [cultural-capital]
+  - [luxury-goods-theory]
+  - [provenance]
+preamble:
+  classification: "[META] Brand audit and critique of posthumous legacy management"
+  version: "6.0-final-dense"
+---
+
+The Pierre Paulin estate has evolved from archival stewardship to a tightly controlled luxury engine. This report audits the strategies that turn preserved designs into market-ready artifacts, highlighting how narrative control shapes authenticity and demand.
+
+By tracing legal frameworks, material authenticity, and market reception, the piece exposes how legacy manufacturing operates as a deliberate brand maneuver rather than passive preservation.

--- a/src/index.njk
+++ b/src/index.njk
@@ -6,7 +6,9 @@ showTitle: false
 
 {% include "components/hero.njk" %}
 
-<main class="mx-auto max-w-screen-md px-6 sm:px-8 space-y-16">
+{% include "components/map-cta.njk" %}
+
+<main class="mx-auto max-w-screen-xl px-6 sm:px-8 space-y-16">
   {% include "components/work-feed.njk" %}
 </main>
 

--- a/test/integration/homepage.spec.mjs
+++ b/test/integration/homepage.spec.mjs
@@ -37,6 +37,17 @@ test('homepage hero and work filters', async () => {
   assert.equal(bento.querySelectorAll('a').length, 3);
   assert(!/· unknown ·/.test(html));
 
+  // Map CTA
+  const mapHeading = Array.from(doc.querySelectorAll('h2')).find(h => /Interactive Concept Map/i.test(h.textContent));
+  assert(mapHeading);
+  const mapSection = mapHeading.closest('section');
+  assert(mapSection);
+  const mapLink = Array.from(mapSection.querySelectorAll('a')).find(a => /Launch the Map/i.test(a.textContent));
+  assert(mapLink);
+  assert.equal(mapLink.getAttribute('href'), '/map/');
+  // Property: exactly one link within the map section
+  assert.equal(Array.from(mapSection.querySelectorAll('a[href="/map/"]')).length, 1);
+
   // Skip link
   const skip = doc.querySelector('a.skip-link');
   assert(skip);


### PR DESCRIPTION
## Summary
- add branded logo to hero and restore interactive concept map section
- widen homepage layout for work feed and streamline lab seal
- introduce Pierre Paulin estate meta article and document map CTA in README

## Testing
- `NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs test/integration/homepage-latest.spec.mjs`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_68a022142b5883308de1da6253e80cd0