### PR TITLE
feat: add unified work collection

### DIFF
--- a/lib/eleventy/register.js
+++ b/lib/eleventy/register.js
@@ -46,6 +46,7 @@ module.exports = function register(eleventyConfig) {
   });
 
   const singular = { sparks: 'spark', concepts: 'concept', projects: 'project', meta: 'meta' };
+  const workAreas = ['sparks', 'concepts', 'projects', 'meta'];
 
   CONTENT_AREAS.forEach(name => {
     eleventyConfig.addCollection(name, api =>
@@ -58,6 +59,19 @@ module.exports = function register(eleventyConfig) {
         })
     );
   });
+
+  eleventyConfig.addCollection('work', api =>
+    workAreas
+      .flatMap(name =>
+        api.getFilteredByGlob(glob(name)).map(page => ({
+          url: page.url,
+          data: page.data,
+          date: page.date,
+          type: singular[name]
+        }))
+      )
+      .sort((a, b) => b.date - a.date)
+  );
 
   eleventyConfig.addCollection('nodes', api =>
     api

--- a/src/index.11tydata.js
+++ b/src/index.11tydata.js
@@ -1,23 +1,5 @@
-function takeLatest(collection, n = 3) {
-  return [...(collection || [])]
-    .sort((a, b) => b.date - a.date)
-    .slice(0, n);
-}
-
 module.exports = {
   eleventyComputed: {
-    projects: data => takeLatest(data.collections.projects),
-    work: data => {
-      const normalize = (items = [], type) =>
-        items.map(i => ({ url: i.url, data: i.data, date: i.date, type }));
-      return [
-        ...normalize(data.collections.projects, 'project'),
-        ...normalize(data.collections.concepts, 'concept'),
-        ...normalize(data.collections.sparks, 'spark'),
-        ...normalize(data.collections.meta, 'meta')
-      ]
-        .sort((a, b) => b.date - a.date)
-        .slice(0, 9);
-    }
+    work: data => (data.collections.work || []).slice(0, 9)
   }
 };


### PR DESCRIPTION
## Summary
- add Eleventy `work` collection aggregating sparks, concepts, projects, and meta
- simplify homepage data to use unified work collection

## Testing
- `NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs test/integration/homepage-latest.spec.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a024ee8d488330a6417543139ac9af