### PR TITLE
feat: redesign homepage work feed into aesthetic grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates and Tailwind CSS. Markdown content in `src/content` feeds Eleventy's collections to generate a fully static site. Node.js 20 powers the build pipeline, and the resulting `_site/` directory can be served directly or packaged into a lightweight Nginx container. GitHub Actions drive tests and deployments to GitHub Container Registry.
 
 ## ✨ Key Features
-- Home page presents a unified Work feed with filter toolbar, interactive concept map CTA, and animated lab seal flourish.
+- Home page presents a multi-column Work feed with filter toolbar, interactive concept map CTA, and animated lab seal flourish.
 ### npm Scripts
 - `npm run dev` – start Eleventy with live reload.
 - `npm run build` – compile the production site to `_site/`.

--- a/docs/knowledge/homepage-feed-green.log
+++ b/docs/knowledge/homepage-feed-green.log
@@ -1,0 +1,40 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 113 files in 2.48 seconds (22.0ms each, v3.1.2)
+# Subtest: homepage work list mixes types
+ok 1 - homepage work list mixes types
+  ---
+  duration_ms: 2668.376215
+  type: 'test'
+  ...
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 113 files in 2.45 seconds (21.7ms each, v3.1.2)
+# Subtest: homepage hero and work filters
+ok 2 - homepage hero and work filters
+  ---
+  duration_ms: 2629.106013
+  type: 'test'
+  ...
+1..2
+# tests 2
+# suites 0
+# pass 2
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 4245.022393

--- a/docs/knowledge/homepage-feed-red.log
+++ b/docs/knowledge/homepage-feed-red.log
@@ -1,0 +1,56 @@
+TAP version 13
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 113 files in 2.62 seconds (23.2ms each, v3.1.2)
+# Subtest: homepage work list mixes types
+ok 1 - homepage work list mixes types
+  ---
+  duration_ms: 2738.425417
+  type: 'test'
+  ...
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+# \\t- ./src/content/sparks/vapor-linked-governance.md
+# [11ty] Copied 77 Wrote 113 files in 2.64 seconds (23.4ms each, v3.1.2)
+# Subtest: homepage hero and work filters
+not ok 2 - homepage hero and work filters
+  ---
+  duration_ms: 2815.275516
+  type: 'test'
+  location: '/workspace/effusion-labs/test/integration/homepage.spec.mjs:18:1'
+  failureType: 'testCodeFailure'
+  error: |-
+    The expression evaluated to a falsy value:
+    
+      assert(list.className.includes('grid'))
+    
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: true
+  actual: false
+  operator: '=='
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage.spec.mjs:77:3)
+    async Test.run (node:internal/test_runner/test:1054:7)
+    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)
+  ...
+1..2
+# tests 2
+# suites 0
+# pass 1
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 4463.055737

--- a/docs/reports/homepage-hero-continue.md
+++ b/docs/reports/homepage-hero-continue.md
@@ -1,13 +1,14 @@
 # Continuation – Homepage Hero
 
 ## Context Recap
-Homepage hero now includes branded logo, restored concept map call-to-action and refactored lab seal.
+Homepage hero now includes branded logo, restored concept map call-to-action, refactored lab seal, and a multi-column work feed with hover/focus affordance.
 
 ## Outstanding Items
-(none)
+1. Integrate rich metadata into Work collection and add showcase article.
+2. Enforce fluid type scale and 8px spacing with full accessibility pass.
 
 ## Execution Strategy
-No further actions.
+Implement metadata extraction and showcase article, then apply typography and accessibility refinements.
 
 ## Trigger Command
 NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs test/integration/homepage-latest.spec.mjs

--- a/docs/reports/homepage-hero-ledger.md
+++ b/docs/reports/homepage-hero-ledger.md
@@ -1,13 +1,16 @@
-# homepage-hero Ledger (4/4)
+# homepage-hero Ledger (5/5)
 
 ## Criteria & Proofs
 - Failing check before fix (`docs/knowledge/homepage-hero-red.log`, sha256: 355ca2527fa59f5b8a95afac05afb1814781657b11917fbd428ba1d8f7f2363a).
 - Passing check after implementing filters and lab seal (`docs/knowledge/homepage-hero-green.log`, sha256: 6c742c45ef15ab45e41246804e258340105a70cfb47951cfc2e7f06f8416dc76).
 - Failing check before restoring map CTA (`docs/knowledge/homepage-hero-map-red.log`, sha256: 8f566692af82968703cffcbe7588ce88edd24c8c6ddaf2177e0aa29f0b6f48d8).
 - Passing check after restoring map CTA and layout (`docs/knowledge/homepage-hero-map-green.log`, sha256: f576f7e398bf400f5a56baae65d70232c29a410accf7a1cd3e517511f2de8ead).
+- Failing check before feed grid and card redesign (`docs/knowledge/homepage-feed-red.log`, sha256: 418580a7655b4d98ae542e441bec95b3701d5df6eca8518a54ab267df9f82928).
+- Passing check after feed grid and card redesign (`docs/knowledge/homepage-feed-green.log`, sha256: 6ac328aeb5a04dcf696092d99601e554c6c6b579096c63dbe1a5295a2d68c4ac).
 
 ## Delta Queue
-(none)
+- integrate rich metadata into Work collection and add showcase article
+- enforce fluid type scale and 8px spacing with full accessibility pass
 
 ## Rollback
 - Last safe SHA: 0b8c188

--- a/src/_includes/components/feed-entry.njk
+++ b/src/_includes/components/feed-entry.njk
@@ -1,10 +1,15 @@
 {% macro feedEntry(item) %}
 <li data-type="{{ item.type }}">
-  <a href="{{ item.url }}" class="card">
-    <span class="chip">{{ item.type | capitalize }}</span>
-    <h3>{{ item.data.title }}</h3>
+  <a href="{{ item.url }}" class="aesthetic-row hover:-translate-y-1 hover:shadow-lg hover:border-electric/50 focus:-translate-y-1 focus:shadow-lg focus:border-electric/50 focus:outline-none">
+    <div class="flex items-start justify-between">
+      <span class="chip">{{ item.type | capitalize }}</span>
+      {% if item.date %}
+      <time datetime="{{ item.date.toISOString() }}" class="text-xs opacity-80">{{ item.date.toISOString().slice(0, 10) }}</time>
+      {% endif %}
+    </div>
+    <h3 class="mt-2">{{ item.data.title }}</h3>
     {% if item.data.description %}
-    <p>{{ item.data.description | truncate(140, true, '…') }}</p>
+    <p class="mt-1">{{ item.data.description | truncate(140, true, '…') }}</p>
     {% endif %}
   </a>
 </li>

--- a/src/_includes/components/work-feed.njk
+++ b/src/_includes/components/work-feed.njk
@@ -8,7 +8,7 @@
     <button class="btn btn-sm" data-filter="spark">Sparks</button>
     <button class="btn btn-sm" data-filter="meta">Meta</button>
   </div>
-  <ul id="work-list" class="space-y-4">
+  <ul id="work-list" class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
     {% for item in work %}
       {{ feedEntry(item) }}
     {% endfor %}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -2,7 +2,9 @@
   .tile { @apply bg-black/20 hover:bg-black/30; }
   .chip { @apply inline-block mb-2 rounded-full border border-white/20 px-2 py-0.5 text-xs; }
   .tile-primary { @apply bg-electric/10 hover:bg-electric/20; }
-  .card { @apply block rounded-md border border-white/20 bg-white/5 p-4 hover:bg-white/10 transition-shadow; }
+  .aesthetic-row {
+    @apply block rounded-md border border-white/20 bg-white/5 p-4 transition-all duration-200 hover:bg-white/10 focus:bg-white/10;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/test/integration/homepage.spec.mjs
+++ b/test/integration/homepage.spec.mjs
@@ -73,6 +73,25 @@ test('homepage hero and work filters', async () => {
     assert.equal(chip.textContent.trim().toLowerCase(), li.dataset.type);
   });
 
+  // Acceptance: work list uses grid layout
+  assert(list.className.includes('grid'));
+
+  // Property: each item exposes published date
+  items.forEach(li => {
+    const time = li.querySelector('time');
+    assert(time);
+    assert(time.getAttribute('datetime'));
+  });
+
+  // Contract: card affords hover/focus lift
+  items.forEach(li => {
+    const card = li.querySelector('a.aesthetic-row');
+    assert(card);
+    const cls = card.getAttribute('class');
+    assert(cls.includes('hover:-translate-y-1'));
+    assert(cls.includes('focus:-translate-y-1'));
+  });
+
   // Contract: frontend script present
   const scriptPath = path.join(outDir, 'assets/js/work-filters.js');
   assert(existsSync(scriptPath));


### PR DESCRIPTION
## Summary
- render homepage work feed as a responsive grid of aesthetic-row cards
- add hover/focus lift affordance and published date metadata on each card
- document multi-column feed in README

## Testing
- `NODE_OPTIONS=--import=./test/setup/http.mjs node --test test/integration/homepage.spec.mjs test/integration/homepage-latest.spec.mjs`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_68a026a05bfc8330bc0c29499a936a57