### PR TITLE
Improve theme readability with accessible fonts and colors

### DIFF
--- a/docs/knowledge/typography-colors-docs.log
+++ b/docs/knowledge/typography-colors-docs.log
@@ -1,0 +1,23 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 docs:links
+> markdown-link-check -c link-check.config.json README.md
+
+
+FILE: README.md
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml
+  [✓] ./LICENSE
+  [✓] #-project-overview
+  [✓] #-key-features
+  [✓] #-quickstart
+  [✓] #-project-layout
+  [✓] #-deployment
+  [✓] #-quality-assurance
+  [✓] #-contributing
+  [✓] #-license
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml/badge.svg
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml/badge.svg
+  [✓] https://img.shields.io/badge/license-ISC-blue.svg
+
+  14 links checked.

--- a/docs/knowledge/typography-colors-green.log
+++ b/docs/knowledge/typography-colors-green.log
@@ -1,0 +1,176 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test:guard
+> bash scripts/test-with-guardrails.sh
+
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:47:13Z
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:47:13Z
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.24 seconds (28.7ms each, v3.1.2)
+✔ archive nav exposes child counts (3253.426528ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.19 seconds (28.2ms each, v3.1.2)
+✔ layout exposes build timestamp (3201.699355ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.75 seconds (24.3ms each, v3.1.2)
+✔ code blocks expose copy control (2915.986253ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.34 seconds (29.6ms each, v3.1.2)
+✔ collection pages expose section metadata (3356.889867ms)
+✔ concept map JSON-LD export generates @context and @graph (3.939319ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.40 seconds (30.1ms each, v3.1.2)
+✔ feed exposes build metadata (3418.340819ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.43 seconds (30.4ms each, v3.1.2)
+✔ home page header includes primary nav landmark (3450.553749ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.78 seconds (24.6ms each, v3.1.2)
+✔ homepage work list mixes types (2923.28698ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.90 seconds (25.6ms each, v3.1.2)
+✔ homepage hero and work filters (3101.474975ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.37 seconds (29.8ms each, v3.1.2)
+✔ markdown headings include anchor ids (3382.400964ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.20 seconds (28.3ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (3217.836697ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.33 seconds (29.5ms each, v3.1.2)
+✔ main nav marks current page and is labelled (3351.94629ms)
+✔ navigation items are sequentially ordered (1.050547ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.47 seconds (30.7ms each, v3.1.2)
+✔ buildLean sets env and output directory (3485.917294ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.08 seconds (27.2ms each, v3.1.2)
+✔ spark listings reveal status text (3091.434332ms)
+✔ deploy workflow does not trigger on pull_request (1.256952ms)
+✔ build job runs only on push events (0.199413ms)
+✔ defines improved background colors (1.394885ms)
+✔ text contrast meets WCAG AA (0.522503ms)
+✔ tailwind exposes readable fonts (0.107963ms)
+✔ docs:links reports no broken links (1134.97014ms)
+✔ package-lock.json defines lockfileVersion (4.705721ms)
+✔ projects computed picks latest entries by date (2.638525ms)
+✔ keepalive emits heartbeat to stderr (6335.781779ms)
+✔ keepalive ignores first SIGINT (321.908529ms)
+✔ devDependencies omit @vscode/ripgrep (1.083738ms)
+✔ prepare-docs avoids ripgrep install (0.146763ms)
+✔ time to chill includes size with height in cm (1.397654ms)
+✔ time to chill height is positive (0.146038ms)
+✔ GitHub workflows use latest action versions (1.32659ms)
+ℹ tests 30
+ℹ suites 0
+ℹ pass 30
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 26292.184185
+Executed 23 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.13% ( 1188/1412 )
+Branches     : 78.72% ( 185/235 )
+Functions    : 74.07% ( 60/81 )
+Lines        : 84.13% ( 1188/1412 )
+================================================================================
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:47:44Z

--- a/docs/knowledge/typography-colors-red.log
+++ b/docs/knowledge/typography-colors-red.log
@@ -1,0 +1,228 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test:guard
+> bash scripts/test-with-guardrails.sh
+
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:45:09Z
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:45:09Z
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.25 seconds (28.8ms each, v3.1.2)
+✔ archive nav exposes child counts (3258.874995ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.16 seconds (28.0ms each, v3.1.2)
+✔ layout exposes build timestamp (3167.551185ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[11ty] Copied 77 Wrote 113 files in 2.86 seconds (25.3ms each, v3.1.2)
+✔ code blocks expose copy control (3040.600396ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.33 seconds (29.5ms each, v3.1.2)
+✔ collection pages expose section metadata (3331.446549ms)
+✔ concept map JSON-LD export generates @context and @graph (3.611183ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.30 seconds (29.2ms each, v3.1.2)
+✔ feed exposes build metadata (3306.114294ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.49 seconds (30.9ms each, v3.1.2)
+✔ home page header includes primary nav landmark (3494.212915ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.70 seconds (23.9ms each, v3.1.2)
+✔ homepage work list mixes types (2834.66956ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.80 seconds (24.8ms each, v3.1.2)
+✔ homepage hero and work filters (2980.636873ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.24 seconds (28.6ms each, v3.1.2)
+✔ markdown headings include anchor ids (3239.399091ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.38 seconds (29.9ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (3381.552721ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.19 seconds (28.2ms each, v3.1.2)
+✔ main nav marks current page and is labelled (3193.639552ms)
+✔ navigation items are sequentially ordered (1.022702ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.47 seconds (30.7ms each, v3.1.2)
+✔ buildLean sets env and output directory (3467.789229ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.00 seconds (26.6ms each, v3.1.2)
+✔ spark listings reveal status text (3002.916741ms)
+✔ deploy workflow does not trigger on pull_request (1.372613ms)
+✔ build job runs only on push events (0.275719ms)
+✖ defines improved background colors (3.116508ms)
+✔ text contrast meets WCAG AA (0.616689ms)
+✖ tailwind exposes readable fonts (0.470278ms)
+✔ docs:links reports no broken links (1157.865237ms)
+✔ package-lock.json defines lockfileVersion (4.763688ms)
+✖ projects computed picks latest entries by date (1.238888ms)
+✔ keepalive emits heartbeat to stderr (6269.463646ms)
+✔ keepalive ignores first SIGINT (335.724095ms)
+✔ devDependencies omit @vscode/ripgrep (1.107156ms)
+✔ prepare-docs avoids ripgrep install (0.164168ms)
+✔ time to chill includes size with height in cm (1.215299ms)
+✔ time to chill height is positive (0.143262ms)
+✔ GitHub workflows use latest action versions (1.454993ms)
+ℹ tests 30
+ℹ suites 0
+ℹ pass 27
+ℹ fail 3
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 25977.654448
+
+✖ failing tests:
+
+test at test/unit/design-tokens.test.mjs:36:1
+✖ defines improved background colors (3.116508ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  + actual - expected
+  
+  + '0 0 0'
+  - '18 18 18'
+  
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/design-tokens.test.mjs:39:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.start (node:internal/test_runner/test:944:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: '0 0 0',
+    expected: '18 18 18',
+    operator: 'strictEqual'
+  }
+
+test at test/unit/design-tokens.test.mjs:50:1
+✖ tailwind exposes readable fonts (0.470278ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  + actual - expected
+  
+  + "'Space Grotesk Variable'"
+  - "'Inter'"
+  
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/design-tokens.test.mjs:51:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)
+      at Test.postRun (node:internal/test_runner/test:1173:19)
+      at Test.run (node:internal/test_runner/test:1101:12)
+      at async Test.processPendingSubtests (node:internal/test_runner/test:744:7) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: "'Space Grotesk Variable'",
+    expected: "'Inter'",
+    operator: 'strictEqual'
+  }
+
+test at test/unit/index-data.test.mjs:5:1
+✖ projects computed picks latest entries by date (1.238888ms)
+  TypeError [Error]: indexData.eleventyComputed.projects is not a function
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/index-data.test.mjs:12:45)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.start (node:internal/test_runner/test:944:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+Executed 23 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.1% ( 1185/1409 )
+Branches     : 78.87% ( 183/232 )
+Functions    : 73.75% ( 59/80 )
+Lines        : 84.1% ( 1185/1409 )
+================================================================================

--- a/docs/knowledge/typography-colors-refactor.log
+++ b/docs/knowledge/typography-colors-refactor.log
@@ -1,0 +1,32 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test:guard
+> bash scripts/test-with-guardrails.sh
+
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:48:06Z
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:48:06Z
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+✔ defines improved background colors (1.404533ms)
+✔ text contrast meets WCAG AA (0.604368ms)
+✔ tailwind exposes readable fonts (0.113658ms)
+ℹ tests 3
+ℹ suites 0
+ℹ pass 3
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 276.440732
+Executed 1 tests
+
+=============================== Coverage summary ===============================
+Statements   : 90.56% ( 144/159 )
+Branches     : 57.14% ( 12/21 )
+Functions    : 100% ( 5/5 )
+Lines        : 90.56% ( 144/159 )
+================================================================================
+::notice:: LLM-safe: shell alive @ 2025-08-16T06:48:08Z

--- a/docs/reports/typography-colors-continue.md
+++ b/docs/reports/typography-colors-continue.md
@@ -1,0 +1,13 @@
+# typography-colors Continuation
+
+## Context Recap
+Implemented accessible color tokens, updated typography, and synchronized documentation.
+
+## Outstanding Items
+- None
+
+## Execution Strategy
+Maintain contrast and readability across future components.
+
+## Trigger Command
+npm run dev

--- a/docs/reports/typography-colors-ledger.md
+++ b/docs/reports/typography-colors-ledger.md
@@ -1,0 +1,21 @@
+# typography-colors Ledger
+
+## Criteria & Proof
+1. Light and dark backgrounds set to accessible values.
+   - Evidence: `src/styles/tokens.css`
+   - Test: `docs/knowledge/typography-colors-green.log`
+2. Text contrast meets WCAG AA.
+   - Test: `docs/knowledge/typography-colors-green.log`
+3. Tailwind exposes Merriweather and Inter fonts.
+   - Evidence: `tailwind.config.cjs`
+   - Test: `docs/knowledge/typography-colors-green.log`
+4. Theming guide updated.
+   - Evidence: `docs/theming.md`
+   - Check: `docs/knowledge/typography-colors-docs.log`
+
+## Index
+4/4 criteria satisfied
+
+## Rollback
+`git reset --hard 8a93dd4989c4a234db8e8025e92ae18fd3ae0e95`
+

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -6,16 +6,18 @@ Effusion Labs ships with a default dark theme and an optional light mode. Theme 
 
 ```css
 html[data-theme="dark"] {
-  --color-bg: 0 0 0;
-  --color-surface: 26 26 26;
-  --color-text: 240 240 240;
+  --color-bg: 18 18 18;
+  --color-surface: 35 35 35;
+  --color-text: 235 235 235;
 }
 html[data-theme="light"] {
-  --color-bg: 255 255 255;
-  --color-surface: 240 240 240;
-  --color-text: 26 26 26;
+  --color-bg: 245 245 245;
+  --color-surface: 230 230 230;
+  --color-text: 30 30 30;
 }
 ```
+
+Headings use the Merriweather typeface while body copy defaults to Inter for improved readability.
 
 Utilities like `bg-background`, `bg-surface` and `text-text` resolve to these variables so the same classes work across themes.
 

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -12,11 +12,11 @@
   <link rel="stylesheet" href="/assets/css/app.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@10..48,300..900&family=Space+Grotesk:wght@300..700&family=JetBrains+Mono:wght@400;700&family=Spectral:wght@400..700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Merriweather:wght@400;700&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
   <script src="/assets/js/lucide.min.js"></script>
 </head>
 
-<body class="bg-ink text-paper font-body leading-relaxed text-[17px]">
+<body class="bg-background text-text font-body leading-relaxed text-[17px]">
   <a href="#main" class="skip-link">Skip to main content</a>
   {% include 'header.njk' %}
 

--- a/src/index.11tydata.js
+++ b/src/index.11tydata.js
@@ -1,5 +1,9 @@
 module.exports = {
   eleventyComputed: {
-    work: data => (data.collections.work || []).slice(0, 9)
+    work: data => (data.collections.work || []).slice(0, 9),
+    projects: data =>
+      (data.collections.projects || [])
+        .sort((a, b) => b.date - a.date)
+        .slice(0, 3)
   }
 };

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,20 +1,20 @@
 :root,
 html[data-theme="dark"] {
-  --color-bg: 0 0 0;
-  --color-surface: 26 26 26;
-  --color-text: 240 240 240;
+  --color-bg: 18 18 18;
+  --color-surface: 35 35 35;
+  --color-text: 235 235 235;
   --color-primary: 10 132 255;
-  --color-border: 51 51 51;
-  --color-code-bg: 30 30 30;
-  --color-code-text: 240 240 240;
+  --color-border: 60 60 60;
+  --color-code-bg: 40 40 40;
+  --color-code-text: 235 235 235;
 }
 
 html[data-theme="light"] {
-  --color-bg: 255 255 255;
-  --color-surface: 240 240 240;
-  --color-text: 26 26 26;
+  --color-bg: 245 245 245;
+  --color-surface: 230 230 230;
+  --color-text: 30 30 30;
   --color-primary: 10 132 255;
-  --color-border: 204 204 204;
-  --color-code-bg: 245 245 245;
-  --color-code-text: 26 26 26;
+  --color-border: 200 200 200;
+  --color-code-bg: 235 235 235;
+  --color-code-text: 30 30 30;
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -19,10 +19,9 @@ module.exports = {
         alarm: "#FF2E2E"
       },
       fontFamily: {
-        heading: ["'Bricolage Grotesque Variable'", "sans-serif"],
-        body:    ["'Space Grotesk Variable'", "sans-serif"],
-        mono:    ["'JetBrains Mono'", "monospace"],
-        spectral:["'Spectral'", "serif"]
+        heading: ["'Merriweather'", "serif"],
+        body: ["'Inter'", "sans-serif"],
+        mono: ["'Roboto Mono'", "monospace"]
       }
     }
   },

--- a/test/helpers/color.mjs
+++ b/test/helpers/color.mjs
@@ -1,0 +1,11 @@
+export function luminance(rgb) {
+  const [r, g, b] = rgb.split(/\s+/).map((n) => parseInt(n, 10) / 255);
+  const transform = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const [R, G, B] = [r, g, b].map(transform);
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+export function contrast(bg, text) {
+  const [light, dark] = [luminance(bg), luminance(text)].sort((a, b) => b - a);
+  return (light + 0.05) / (dark + 0.05);
+}

--- a/test/unit/design-tokens.test.mjs
+++ b/test/unit/design-tokens.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import tailwindConfig from '../../tailwind.config.cjs';
+import { contrast } from '../helpers/color.mjs';
+
+function parseTheme(tokens, theme) {
+  const regex = new RegExp(`html\\[data-theme="${theme}"\\]\\s*{([^}]*)}`, 'm');
+  const match = tokens.match(regex);
+  if (!match) return {};
+  return Object.fromEntries(
+    match[1]
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .map((l) => l.replace(';', '').split(':').map((s) => s.trim()))
+  );
+}
+
+
+const tokens = fs.readFileSync(path.join(process.cwd(), 'src/styles/tokens.css'), 'utf8');
+
+test('defines improved background colors', () => {
+  const dark = parseTheme(tokens, 'dark');
+  const light = parseTheme(tokens, 'light');
+  assert.equal(dark['--color-bg'], '18 18 18');
+  assert.equal(light['--color-bg'], '245 245 245');
+});
+
+test('text contrast meets WCAG AA', () => {
+  const dark = parseTheme(tokens, 'dark');
+  const light = parseTheme(tokens, 'light');
+  assert.ok(contrast(dark['--color-bg'], dark['--color-text']) >= 4.5);
+  assert.ok(contrast(light['--color-bg'], light['--color-text']) >= 4.5);
+});
+
+test('tailwind exposes readable fonts', () => {
+  assert.equal(tailwindConfig.theme.extend.fontFamily.body[0], "'Inter'");
+  assert.equal(tailwindConfig.theme.extend.fontFamily.heading[0], "'Merriweather'");
+});


### PR DESCRIPTION
## Summary
- refine light and dark theme color tokens for better contrast
- switch typography to Merriweather headings and Inter body text; load via Google Fonts
- ensure layout uses theme tokens and add helper for contrast tests

## Testing
- `npm run test:guard`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_68a0282e93a08330ab5244dab5896449