### PR TITLE
feat: establish fluid type scale foundation

### DIFF
--- a/docs/knowledge/fluid-type-scale-green.log
+++ b/docs/knowledge/fluid-type-scale-green.log
@@ -1,0 +1,169 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.58 seconds (40.6ms each, v3.1.2)
+✔ archive nav exposes child counts (4605.519866ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[11ty] Copied 77 Wrote 113 files in 4.53 seconds (40.1ms each, v3.1.2)
+✔ layout exposes build timestamp (4554.566755ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.82 seconds (33.8ms each, v3.1.2)
+✔ code blocks expose copy control (4065.836376ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.52 seconds (40.0ms each, v3.1.2)
+✔ collection pages expose section metadata (4539.41444ms)
+✔ concept map JSON-LD export generates @context and @graph (3.783697ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.52 seconds (40.0ms each, v3.1.2)
+✔ feed exposes build metadata (4540.511027ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.61 seconds (40.8ms each, v3.1.2)
+✔ home page header includes primary nav landmark (4638.704685ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.07 seconds (36.0ms each, v3.1.2)
+✔ homepage work list mixes types (4307.704234ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.01 seconds (35.5ms each, v3.1.2)
+✔ homepage hero and work filters (4244.508181ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.63 seconds (41.0ms each, v3.1.2)
+✔ markdown headings include anchor ids (4648.095503ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.50 seconds (39.8ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (4518.279041ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.50 seconds (39.9ms each, v3.1.2)
+✔ main nav marks current page and is labelled (4527.780072ms)
+✔ navigation items are sequentially ordered (1.949503ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.58 seconds (40.5ms each, v3.1.2)
+✔ buildLean sets env and output directory (4593.375891ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.11 seconds (36.3ms each, v3.1.2)
+✔ spark listings reveal status text (4129.216809ms)
+✔ deploy workflow does not trigger on pull_request (1.717036ms)
+✔ build job runs only on push events (0.341803ms)
+✔ defines improved background colors (2.009581ms)
+✔ text contrast meets WCAG AA (0.846329ms)
+✔ tailwind exposes readable fonts (0.204183ms)
+✔ includes fluid type scale tokens (0.176238ms)
+✔ docs:links reports no broken links (1553.691997ms)
+✔ package-lock.json defines lockfileVersion (12.321176ms)
+✔ projects computed picks latest entries by date (3.478864ms)
+✔ keepalive emits heartbeat to stderr (6365.55074ms)
+✔ keepalive ignores first SIGINT (402.195846ms)
+✔ devDependencies omit @vscode/ripgrep (1.496109ms)
+✔ prepare-docs avoids ripgrep install (0.193889ms)
+✔ time to chill includes size with height in cm (1.639521ms)
+✔ time to chill height is positive (0.20463ms)
+✔ GitHub workflows use latest action versions (1.851666ms)
+ℹ tests 31
+ℹ suites 0
+ℹ pass 31
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 33749.345709
+Executed 23 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.13% ( 1188/1412 )
+Branches     : 78.72% ( 185/235 )
+Functions    : 74.07% ( 60/81 )
+Lines        : 84.13% ( 1188/1412 )
+================================================================================

--- a/docs/knowledge/fluid-type-scale-red.log
+++ b/docs/knowledge/fluid-type-scale-red.log
@@ -1,0 +1,188 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.66 seconds (41.2ms each, v3.1.2)
+✔ archive nav exposes child counts (4681.764248ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.62 seconds (40.9ms each, v3.1.2)
+✔ layout exposes build timestamp (4639.336256ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.96 seconds (35.1ms each, v3.1.2)
+✔ code blocks expose copy control (4203.970892ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.83 seconds (42.7ms each, v3.1.2)
+✔ collection pages expose section metadata (4846.715383ms)
+✔ concept map JSON-LD export generates @context and @graph (3.594779ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/meta/unified-referencing-syntax.md
+[11ty] Copied 77 Wrote 113 files in 4.72 seconds (41.7ms each, v3.1.2)
+✔ feed exposes build metadata (4744.332959ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.58 seconds (40.5ms each, v3.1.2)
+✔ home page header includes primary nav landmark (4586.879091ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.69 seconds (41.5ms each, v3.1.2)
+✔ homepage work list mixes types (4899.743219ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.01 seconds (35.5ms each, v3.1.2)
+✔ homepage hero and work filters (4214.144261ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.35 seconds (47.3ms each, v3.1.2)
+✔ markdown headings include anchor ids (5353.248095ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.56 seconds (40.4ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (4564.878573ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.56 seconds (40.3ms each, v3.1.2)
+✔ main nav marks current page and is labelled (4563.376602ms)
+✔ navigation items are sequentially ordered (1.715486ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.72 seconds (41.8ms each, v3.1.2)
+✔ buildLean sets env and output directory (4725.391333ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[11ty] Copied 77 Wrote 113 files in 4.25 seconds (37.6ms each, v3.1.2)
+✔ spark listings reveal status text (4249.719136ms)
+✔ deploy workflow does not trigger on pull_request (1.674075ms)
+✔ build job runs only on push events (0.271196ms)
+✔ defines improved background colors (3.164585ms)
+✔ text contrast meets WCAG AA (1.481082ms)
+✔ tailwind exposes readable fonts (0.469948ms)
+✖ includes fluid type scale tokens (1.31397ms)
+✔ docs:links reports no broken links (1722.708384ms)
+✔ package-lock.json defines lockfileVersion (14.52572ms)
+✔ projects computed picks latest entries by date (3.325522ms)
+✔ keepalive emits heartbeat to stderr (6362.750295ms)
+✔ keepalive ignores first SIGINT (410.499719ms)
+✔ devDependencies omit @vscode/ripgrep (1.539078ms)
+✔ prepare-docs avoids ripgrep install (0.268538ms)
+✔ time to chill includes size with height in cm (1.749565ms)
+✔ time to chill height is positive (0.182794ms)
+✔ GitHub workflows use latest action versions (1.937524ms)
+ℹ tests 31
+ℹ suites 0
+ℹ pass 30
+ℹ fail 1
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 34633.69045
+
+✖ failing tests:
+
+test at test/unit/design-tokens.test.mjs:43:1
+✖ includes fluid type scale tokens (1.31397ms)
+  AssertionError [ERR_ASSERTION]: missing --step--2
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/design-tokens.test.mjs:46:12)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)
+      at Test.postRun (node:internal/test_runner/test:1173:19)
+      at Test.run (node:internal/test_runner/test:1101:12)
+      at async Test.processPendingSubtests (node:internal/test_runner/test:744:7) {
+    generatedMessage: false,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '=='
+  }
+Executed 23 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.13% ( 1188/1412 )
+Branches     : 78.72% ( 185/235 )
+Functions    : 74.07% ( 60/81 )
+Lines        : 84.13% ( 1188/1412 )
+================================================================================

--- a/docs/reports/site-redesign-r3-continue.md
+++ b/docs/reports/site-redesign-r3-continue.md
@@ -1,0 +1,14 @@
+# Continuation – Site Redesign R3
+
+## Context Recap
+Established fluid type scale with --step CSS variables and applied an 8px vertical rhythm across base elements.
+
+## Outstanding Items
+1. Implement 12-column grid foundation across page layouts.
+2. Define site-wide interaction language for motion and component states respecting `prefers-reduced-motion`.
+
+## Execution Strategy
+Introduce grid utilities and adjust templates, then unify transition and motion behaviors.
+
+## Trigger Command
+NODE_OPTIONS=--import=./test/setup/http.mjs npm run test:guard

--- a/docs/reports/site-redesign-r3-ledger.md
+++ b/docs/reports/site-redesign-r3-ledger.md
@@ -1,0 +1,16 @@
+# site-redesign-r3 Ledger
+
+## Criteria & Proof
+- Failing check before type scale tokens (`docs/knowledge/fluid-type-scale-red.log`, sha256: 90cf2a169b1a53e93228e9f853769736deabe631a50fb885577530dd4e2a83cc).
+- Passing check after type scale tokens (`docs/knowledge/fluid-type-scale-green.log`, sha256: 8bf18298a74e4469030fa562fd41bce31f0367003416ba2e46440c7b0d82e64b).
+
+## Index
+1/1 criteria satisfied
+
+## Delta Queue
+- Implement 12-column grid foundation across layouts
+- Define site-wide interaction language respecting prefers-reduced-motion
+
+## Rollback
+- Last safe SHA: 0b8c188
+- `git reset --hard 0b8c188`

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,10 +1,15 @@
 # Theming
 
-Effusion Labs ships with a default dark theme and an optional light mode. Theme colors are driven by CSS custom properties declared in `src/styles/tokens.css` and exposed to Tailwind as design tokens.
+Effusion Labs ships with a default dark theme and an optional light mode. Theme colors and typography are driven by CSS custom properties declared in `src/styles/tokens.css` and exposed to Tailwind as design tokens.
 
 ## Tokens
 
 ```css
+:root {
+  --step-0: clamp(1rem, calc(0.94rem + 0.17vw), 1.2rem);
+  --step-1: clamp(1.13rem, calc(1.06rem + 0.27vw), 1.44rem);
+  /* ... */
+}
 html[data-theme="dark"] {
   --color-bg: 18 18 18;
   --color-surface: 35 35 35;
@@ -27,4 +32,4 @@ The header exposes a keyboard-accessible button that switches between dark and l
 
 ## Extending
 
-Add new variables in `tokens.css` and reference them from `tailwind.config.cjs` to create additional color roles.
+Add new variables in `tokens.css` and reference them from `tailwind.config.cjs` to create additional color roles or extend the type scale.

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -16,7 +16,7 @@
   <script src="/assets/js/lucide.min.js"></script>
 </head>
 
-<body class="bg-background text-text font-body leading-relaxed text-[17px]">
+<body class="bg-background text-text font-body">
   <a href="#main" class="skip-link">Skip to main content</a>
   {% include 'header.njk' %}
 

--- a/src/styles/app.tailwind.css
+++ b/src/styles/app.tailwind.css
@@ -7,8 +7,11 @@
 @import "./home.css";
 
 @layer base {
-  h1 { @apply font-heading text-[clamp(2rem,4vw+1rem,3rem)]; }
-  h2 { @apply font-heading text-[clamp(1.5rem,3vw+0.75rem,2.25rem)]; }
+  body { @apply font-body text-[var(--step-0)] leading-[1.5]; }
+  h1 { @apply font-heading text-[var(--step-4)] mb-8; }
+  h2 { @apply font-heading text-[var(--step-3)] mb-6; }
+  h3 { @apply font-heading text-[var(--step-2)] mb-4; }
+  p, ul, ol, blockquote { @apply mb-4; }
 
   .heading-anchor { @apply mr-2 no-underline text-gray-400; }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,3 +1,13 @@
+:root {
+  --step--2: clamp(0.79rem, calc(0.75rem + 0.17vw), 0.94rem);
+  --step--1: clamp(0.89rem, calc(0.84rem + 0.17vw), 1.06rem);
+  --step-0: clamp(1rem, calc(0.94rem + 0.17vw), 1.2rem);
+  --step-1: clamp(1.13rem, calc(1.06rem + 0.27vw), 1.44rem);
+  --step-2: clamp(1.27rem, calc(1.19rem + 0.35vw), 1.73rem);
+  --step-3: clamp(1.42rem, calc(1.33rem + 0.43vw), 2.07rem);
+  --step-4: clamp(1.6rem, calc(1.48rem + 0.52vw), 2.49rem);
+}
+
 :root,
 html[data-theme="dark"] {
   --color-bg: 18 18 18;

--- a/test/unit/design-tokens.test.mjs
+++ b/test/unit/design-tokens.test.mjs
@@ -39,3 +39,10 @@ test('tailwind exposes readable fonts', () => {
   assert.equal(tailwindConfig.theme.extend.fontFamily.body[0], "'Inter'");
   assert.equal(tailwindConfig.theme.extend.fontFamily.heading[0], "'Merriweather'");
 });
+
+test('includes fluid type scale tokens', () => {
+  const required = ['--step--2', '--step--1', '--step-0', '--step-1', '--step-2', '--step-3', '--step-4'];
+  for (const token of required) {
+    assert.ok(tokens.includes(token), `missing ${token}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add --step fluid type scale tokens and apply 8px rhythm across base typography
- document new tokens in theming guide
- record R3 ledger and continuation for site redesign

## Testing
- `npm run test:guard`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02a5dce80833099662ff0dde5b8f6