### PR TITLE
Fix external link arrow for source references only

### DIFF
--- a/docs/knowledge/markdown-links.fail.log
+++ b/docs/knowledge/markdown-links.fail.log
@@ -1,0 +1,32 @@
+✖ non-source link keeps text (16.423694ms)
+✔ devDependencies omit @vscode/ripgrep (1.040444ms)
+✔ prepare-docs avoids ripgrep install (0.141537ms)
+✔ time to chill includes size with height in cm (1.183835ms)
+✔ time to chill height is positive (0.168152ms)
+✔ GitHub workflows use latest action versions (1.2982ms)
+ℹ tests 32
+ℹ suites 0
+ℹ pass 31
+ℹ fail 1
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 25726.636935
+
+✖ failing tests:
+
+test at test/unit/markdown-links.test.mjs:18:7
+✖ non-source link keeps text (16.423694ms)
+  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
+  
+    assert.ok(html.includes('Example'))
+  
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/markdown-links.test.mjs:22:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.start (node:internal/test_runner/test:944:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+      at run (node:internal/test_runner/harness:307:12)
+      at test (node:internal/test_runner/harness:316:12)
+      at file:///workspace/effusion-labs/test/unit/markdown-links.test.mjs:18:7 {
+    generatedMessage: true,

--- a/lib/markdown/links.js
+++ b/lib/markdown/links.js
@@ -5,9 +5,15 @@
 function externalLinks(md) {
   const base = md.renderer.rules.link_open || ((t, i, o, e, s) => s.renderToken(t, i, o));
   md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-    tokens[idx].attrJoin('class', 'external-link');
-    const nxt = tokens[idx + 1];
-    if (nxt?.type === 'text') nxt.content = '↗ source';
+    const href = tokens[idx].attrGet('href') || '';
+    const isExternal = /^https?:\/\//.test(href);
+    if (isExternal) {
+      tokens[idx].attrJoin('class', 'external-link');
+      const nxt = tokens[idx + 1];
+      if (nxt?.type === 'text' && nxt.content.toLowerCase() === 'source') {
+        nxt.content = '↗ source';
+      }
+    }
     return base(tokens, idx, options, env, self);
   };
 }

--- a/test/unit/markdown-links.test.mjs
+++ b/test/unit/markdown-links.test.mjs
@@ -1,0 +1,24 @@
+import MarkdownIt from 'markdown-it';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import links from '../../lib/markdown/links.js';
+const { externalLinks } = links;
+
+// Acceptance example: external source links get arrow text and class
+await test('source link renders with arrow and class', () => {
+  const md = new MarkdownIt();
+  md.use(externalLinks);
+  const html = md.render('[source](https://example.com)');
+  assert.match(html, /class="external-link"/);
+  assert.ok(html.includes('↗ source'));
+});
+
+// Property: other links preserve their original text
+await test('non-source link keeps text', () => {
+  const md = new MarkdownIt();
+  md.use(externalLinks);
+  const html = md.render('[Example](https://example.com)');
+  assert.ok(html.includes('Example'));
+  assert.ok(!html.includes('↗ source'));
+});


### PR DESCRIPTION
## Summary
- scope `↗ source` text to external links that explicitly use "source" as link text
- test markdown link plugin to ensure only source links get arrow and other links keep their text

## Testing
- `npm run test:guard`

------
https://chatgpt.com/codex/tasks/task_e_68a02b77359c8330a77625f903c51170