### PR TITLE
Unify tag metadata and add schema plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates
 - `@11ty/eleventy-plugin-syntaxhighlight` – adds Prism-based code highlighting.
 - `@11ty/eleventy-plugin-rss` – generates RSS feeds for collections.
 - `@quasibit/eleventy-plugin-sitemap` – emits `sitemap.xml` with a predefined hostname.
+- `@quasibit/eleventy-plugin-schema` – generates JSON-LD structured data for pages.
 - `@11ty/eleventy-img` – transforms images to AVIF, WebP and original formats.
 
 ### Tailwind Theme

--- a/docs/knowledge/tags-metadata/docs-links.log
+++ b/docs/knowledge/tags-metadata/docs-links.log
@@ -1,0 +1,23 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 docs:links
+> markdown-link-check -c link-check.config.json README.md
+
+
+FILE: README.md
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml
+  [✓] ./LICENSE
+  [✓] #-project-overview
+  [✓] #-key-features
+  [✓] #-quickstart
+  [✓] #-project-layout
+  [✓] #-deployment
+  [✓] #-quality-assurance
+  [✓] #-contributing
+  [✓] #-license
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml/badge.svg
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml/badge.svg
+  [✓] https://img.shields.io/badge/license-ISC-blue.svg
+
+  14 links checked.

--- a/docs/knowledge/tags-metadata/test-green.log
+++ b/docs/knowledge/tags-metadata/test-green.log
@@ -1,0 +1,174 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.42 seconds (30.3ms each, v3.1.2)
+✔ archive nav exposes child counts (3424.796062ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.38 seconds (29.9ms each, v3.1.2)
+✔ layout exposes build timestamp (3381.581109ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.05 seconds (27.0ms each, v3.1.2)
+✔ code blocks expose copy control (3204.662422ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.59 seconds (31.7ms each, v3.1.2)
+✔ collection pages expose section metadata (3591.259689ms)
+✔ concept map JSON-LD export generates @context and @graph (2.629216ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.49 seconds (30.9ms each, v3.1.2)
+✔ feed exposes build metadata (3503.794004ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.46 seconds (30.7ms each, v3.1.2)
+✔ home page header includes primary nav landmark (3471.137292ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.98 seconds (26.4ms each, v3.1.2)
+✔ homepage work list mixes types (3107.18357ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.97 seconds (26.3ms each, v3.1.2)
+✔ homepage hero and work filters (3134.327104ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.44 seconds (30.5ms each, v3.1.2)
+✔ markdown headings include anchor ids (3447.438108ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.33 seconds (29.5ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (3336.46049ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.20 seconds (28.3ms each, v3.1.2)
+✔ main nav marks current page and is labelled (3204.038764ms)
+✔ navigation items are sequentially ordered (1.066081ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.32 seconds (29.4ms each, v3.1.2)
+✔ buildLean sets env and output directory (3322.500392ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.99 seconds (26.5ms each, v3.1.2)
+✔ spark listings reveal status text (2996.497027ms)
+✔ deploy workflow does not trigger on pull_request (1.307912ms)
+✔ build job runs only on push events (0.254291ms)
+✔ defines improved background colors (2.682379ms)
+✔ text contrast meets WCAG AA (0.566127ms)
+✔ tailwind exposes readable fonts (0.110407ms)
+✔ includes fluid type scale tokens (0.115727ms)
+✔ docs:links reports no broken links (1114.514852ms)
+✔ package-lock.json defines lockfileVersion (4.780866ms)
+✔ projects computed picks latest entries by date (2.248899ms)
+✔ keepalive emits heartbeat to stderr (6286.841424ms)
+✔ keepalive ignores first SIGINT (322.792267ms)
+✔ source link renders with arrow and class (12.014662ms)
+✔ non-source link keeps text (1.731512ms)
+✔ devDependencies omit @vscode/ripgrep (1.105963ms)
+✔ prepare-docs avoids ripgrep install (0.159479ms)
+✔ merges tag-like metadata into unified tags and categories (2.111174ms)
+✔ deduplicates tag values (0.1828ms)
+✔ categories returns empty array when spark_type absent (0.108058ms)
+✔ time to chill includes size with height in cm (1.231468ms)
+✔ time to chill height is positive (0.139296ms)
+✔ GitHub workflows use latest action versions (1.281161ms)
+ℹ tests 36
+ℹ suites 0
+ℹ pass 36
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 26787.98657
+Executed 25 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.37% ( 1210/1434 )
+Branches     : 79.35% ( 196/247 )
+Functions    : 75% ( 63/84 )
+Lines        : 84.37% ( 1210/1434 )
+================================================================================

--- a/docs/knowledge/tags-metadata/test-red.log
+++ b/docs/knowledge/tags-metadata/test-red.log
@@ -1,0 +1,196 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.51 seconds (31.0ms each, v3.1.2)
+✔ archive nav exposes child counts (3509.078367ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.38 seconds (29.9ms each, v3.1.2)
+✔ layout exposes build timestamp (3380.511096ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.00 seconds (26.5ms each, v3.1.2)
+✔ code blocks expose copy control (3189.636093ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.41 seconds (30.2ms each, v3.1.2)
+✔ collection pages expose section metadata (3411.219176ms)
+✔ concept map JSON-LD export generates @context and @graph (2.816543ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.31 seconds (29.3ms each, v3.1.2)
+✔ feed exposes build metadata (3309.7677ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.21 seconds (28.4ms each, v3.1.2)
+✔ home page header includes primary nav landmark (3214.765322ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.05 seconds (27.0ms each, v3.1.2)
+✔ homepage work list mixes types (3184.552433ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.86 seconds (25.3ms each, v3.1.2)
+✔ homepage hero and work filters (3032.275283ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.50 seconds (30.9ms each, v3.1.2)
+✔ markdown headings include anchor ids (3498.260865ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.50 seconds (31.0ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (3501.263175ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.35 seconds (29.6ms each, v3.1.2)
+✔ main nav marks current page and is labelled (3349.83644ms)
+✔ navigation items are sequentially ordered (1.340062ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 3.34 seconds (29.6ms each, v3.1.2)
+✔ buildLean sets env and output directory (3344.679036ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 2.97 seconds (26.3ms each, v3.1.2)
+✔ spark listings reveal status text (2974.05443ms)
+✔ deploy workflow does not trigger on pull_request (1.974841ms)
+✔ build job runs only on push events (0.38857ms)
+✔ defines improved background colors (1.396377ms)
+✔ text contrast meets WCAG AA (0.629222ms)
+✔ tailwind exposes readable fonts (0.143804ms)
+✔ includes fluid type scale tokens (0.149434ms)
+✔ docs:links reports no broken links (1140.487105ms)
+✔ package-lock.json defines lockfileVersion (5.912906ms)
+✔ projects computed picks latest entries by date (3.667651ms)
+✔ keepalive emits heartbeat to stderr (6245.071335ms)
+✔ keepalive ignores first SIGINT (319.781414ms)
+✔ source link renders with arrow and class (11.201502ms)
+✔ non-source link keeps text (1.622291ms)
+✔ devDependencies omit @vscode/ripgrep (1.059594ms)
+✔ prepare-docs avoids ripgrep install (0.179564ms)
+node:internal/modules/esm/resolve:274
+    throw new ERR_MODULE_NOT_FOUND(
+          ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/effusion-labs/src/_data/eleventyComputed.js' imported from /workspace/effusion-labs/test/unit/taxonomy.test.mjs
+    at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+    at moduleResolve (node:internal/modules/esm/resolve:859:10)
+    at defaultResolve (node:internal/modules/esm/resolve:983:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+  code: 'ERR_MODULE_NOT_FOUND',
+  url: 'file:///workspace/effusion-labs/src/_data/eleventyComputed.js'
+}
+
+Node.js v22.18.0
+✖ test/unit/taxonomy.test.mjs (256.150631ms)
+✔ time to chill includes size with height in cm (1.231577ms)
+✔ time to chill height is positive (0.134347ms)
+✔ GitHub workflows use latest action versions (1.658552ms)
+ℹ tests 34
+ℹ suites 0
+ℹ pass 33
+ℹ fail 1
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 26761.496572
+
+✖ failing tests:
+
+test at test/unit/taxonomy.test.mjs:1:1
+✖ test/unit/taxonomy.test.mjs (256.150631ms)
+  'test failed'
+Executed 25 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.2% ( 1194/1418 )
+Branches     : 78.9% ( 187/237 )
+Functions    : 74.07% ( 60/81 )
+Lines        : 84.2% ( 1194/1418 )
+================================================================================

--- a/docs/reports/tags-metadata-continue.md
+++ b/docs/reports/tags-metadata-continue.md
@@ -1,0 +1,14 @@
+# Continuation: tags-metadata
+
+## Context Recap
+Merged tag-like metadata into unified tags and categories and added schema support.
+
+## Outstanding Items
+1. Expand taxonomy to generate dedicated tag pages.
+2. Explore visual tag browsing.
+
+## Execution Strategy
+Build Eleventy collections for tags and categories, then expose navigation to browse them.
+
+## Trigger Command
+npm test

--- a/docs/reports/tags-metadata-ledger.md
+++ b/docs/reports/tags-metadata-ledger.md
@@ -1,0 +1,22 @@
+# tags-metadata Ledger
+
+## Criteria
+1. Metadata fields `tags`, `analytic_lens`, `memory_ref` and `spark_type` merge into a unified `tags` array.
+2. `spark_type` surfaces as `categories` via global computed data.
+3. `@quasibit/eleventy-plugin-schema@1.11.1` installed and registered.
+
+## Proofs
+- `test/unit/taxonomy.test.mjs` exercises tag and category computation.
+- `docs/knowledge/tags-metadata/test-green.log` shows passing tests.
+- `docs/knowledge/tags-metadata/docs-links.log` validates README links.
+- `package-lock.json` lists `@quasibit/eleventy-plugin-schema@1.11.1` with integrity `sha512-Ln5VGI40txKJCbDX/ndXJp9lJOUHH75IpHn2E15uUN4LBRVW4BS/rimOL1iBVpnqJwFoVr3c+OubtC7sEQK9+w==` (MIT, https://github.com/quasibit/eleventy-plugin-schema).
+
+## Index
+3/3 criteria satisfied.
+
+## Delta Queue
+- none
+
+## Rollback
+Last safe commit: `836a84f20c2ded905792fd2806545c28e2c3ee4a`
+Rollback command: `git reset --hard 836a84f20c2ded905792fd2806545c28e2c3ee4a`

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -3,6 +3,7 @@ const navigation = require('@11ty/eleventy-navigation');
 const rss = require('@11ty/eleventy-plugin-rss');
 const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const sitemap = require('@quasibit/eleventy-plugin-sitemap');
+const schema = require('@quasibit/eleventy-plugin-schema');
 
 /**
  * Return the plugin configuration list for Eleventy.
@@ -28,7 +29,8 @@ function getPlugins() {
     [syntaxHighlight, { preAttributes: { tabindex: 0 } }],
     [rss],
     // Tailwind compilation handled via PostCSS pipeline
-    [sitemap, { sitemap: { hostname: 'https://effusionlabs.com' } }]
+    [sitemap, { sitemap: { hostname: 'https://effusionlabs.com' } }],
+    [schema]
   ];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@11ty/eleventy-img": "^6.0.4",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
         "@playwright/test": "^1.54.2",
+        "@quasibit/eleventy-plugin-schema": "1.11.1",
         "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@tailwindcss/typography": "^0.5.16",
@@ -1176,6 +1177,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@quasibit/eleventy-plugin-schema": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@quasibit/eleventy-plugin-schema/-/eleventy-plugin-schema-1.11.1.tgz",
+      "integrity": "sha512-Ln5VGI40txKJCbDX/ndXJp9lJOUHH75IpHn2E15uUN4LBRVW4BS/rimOL1iBVpnqJwFoVr3c+OubtC7sEQK9+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@11ty/eleventy": "^0.11.0 || ^0.12.0 || ^1.0.0 || ^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/@quasibit/eleventy-plugin-sitemap": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
     "@playwright/test": "^1.54.2",
+    "@quasibit/eleventy-plugin-schema": "1.11.1",
     "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/typography": "^0.5.16",

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -1,0 +1,14 @@
+const toArray = v => (Array.isArray(v) ? v : v ? [v] : []);
+
+module.exports = {
+  tags: data => {
+    const merged = [
+      ...toArray(data.tags),
+      ...toArray(data.analytic_lens),
+      ...toArray(data.memory_ref),
+      ...toArray(data.spark_type)
+    ].filter(v => typeof v === 'string');
+    return Array.from(new Set(merged)).sort();
+  },
+  categories: data => toArray(data.spark_type).filter(v => typeof v === 'string').sort()
+};

--- a/test/unit/taxonomy.test.mjs
+++ b/test/unit/taxonomy.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import computed from '../../src/_data/eleventyComputed.js';
+
+// Acceptance example: metadata fields merge into tags and categories
+const sampleData = {
+  tags: ['pierre-paulin', 'design-legacy'],
+  analytic_lens: ['narrative-engineering', 'institutional-gatekeeping'],
+  memory_ref: ['estate-law', 'brand-management'],
+  spark_type: 'analytic-report'
+};
+
+test('merges tag-like metadata into unified tags and categories', () => {
+  const tags = computed.tags(sampleData);
+  const categories = computed.categories(sampleData);
+  assert.deepStrictEqual(
+    tags.sort(),
+    [
+      'pierre-paulin',
+      'design-legacy',
+      'narrative-engineering',
+      'institutional-gatekeeping',
+      'estate-law',
+      'brand-management',
+      'analytic-report'
+    ].sort()
+  );
+  assert.deepStrictEqual(categories, ['analytic-report']);
+});
+
+// Property: tags are unique
+const duplicateData = {
+  tags: ['a'],
+  analytic_lens: ['a', 'b'],
+  memory_ref: ['b'],
+  spark_type: 'a'
+};
+
+test('deduplicates tag values', () => {
+  const tags = computed.tags(duplicateData);
+  assert.deepStrictEqual(tags.sort(), ['a', 'b']);
+});
+
+// Contract: categories fall back to empty array
+
+test('categories returns empty array when spark_type absent', () => {
+  const categories = computed.categories({});
+  assert.deepStrictEqual(categories, []);
+});


### PR DESCRIPTION
## Summary
- merge tag-like front matter (`analytic_lens`, `memory_ref`, `spark_type`) into global tags and categories
- register `@quasibit/eleventy-plugin-schema` for JSON-LD structured data
- document schema plugin in README

## Testing
- `npm test`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_68a02d7df2a88330a127e0bfc52aac1c