### PR TITLE
feat(markdown_gateway): allow solver URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates
 
 ### Services
 - `effusion-labs` container exposed on port `18400:80` via `docker-compose.yml`.
+- `markdown_gateway` proxies HTML to Markdown via FlareSolverr; override the default solver address with `SOLVER_URL`.
 
 ## ⚡ Quickstart
 ```bash

--- a/docs/knowledge/solver-url-env-docs.log
+++ b/docs/knowledge/solver-url-env-docs.log
@@ -1,0 +1,23 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 docs:links
+> markdown-link-check -c link-check.config.json README.md
+
+
+FILE: README.md
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml
+  [✓] ./LICENSE
+  [✓] #-project-overview
+  [✓] #-key-features
+  [✓] #-quickstart
+  [✓] #-project-layout
+  [✓] #-deployment
+  [✓] #-quality-assurance
+  [✓] #-contributing
+  [✓] #-license
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml/badge.svg
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml/badge.svg
+  [✓] https://img.shields.io/badge/license-ISC-blue.svg
+
+  14 links checked.

--- a/docs/knowledge/solver-url-env-green.log
+++ b/docs/knowledge/solver-url-env-green.log
@@ -1,0 +1,173 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.34 seconds (47.3ms each, v3.1.2)
+✔ archive nav exposes child counts (5363.646769ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.30 seconds (46.9ms each, v3.1.2)
+✔ layout exposes build timestamp (5327.794128ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.48 seconds (39.7ms each, v3.1.2)
+✔ code blocks expose copy control (4776.751889ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.25 seconds (46.4ms each, v3.1.2)
+✔ collection pages expose section metadata (5273.682689ms)
+✔ concept map JSON-LD export generates @context and @graph (4.322976ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.15 seconds (45.6ms each, v3.1.2)
+✔ feed exposes build metadata (5173.321534ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.53 seconds (48.9ms each, v3.1.2)
+✔ home page header includes primary nav landmark (5551.697837ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.76 seconds (42.1ms each, v3.1.2)
+✔ homepage work list mixes types (4994.518961ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.53 seconds (40.0ms each, v3.1.2)
+✔ homepage hero and work filters (4837.40586ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.70 seconds (50.4ms each, v3.1.2)
+✔ markdown headings include anchor ids (5717.963225ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.27 seconds (46.6ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (5302.988474ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.14 seconds (45.5ms each, v3.1.2)
+✔ main nav marks current page and is labelled (5167.582415ms)
+✔ navigation items are sequentially ordered (2.472253ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.46 seconds (48.3ms each, v3.1.2)
+✔ buildLean sets env and output directory (5483.121159ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.96 seconds (43.9ms each, v3.1.2)
+✔ spark listings reveal status text (4978.659776ms)
+✔ deploy workflow does not trigger on pull_request (2.062102ms)
+✔ build job runs only on push events (0.342506ms)
+✔ defines improved background colors (2.393286ms)
+✔ text contrast meets WCAG AA (0.983675ms)
+✔ tailwind exposes readable fonts (0.179256ms)
+✔ includes fluid type scale tokens (0.19852ms)
+✔ docs:links reports no broken links (1740.663824ms)
+✔ package-lock.json defines lockfileVersion (7.688701ms)
+✔ projects computed picks latest entries by date (3.199054ms)
+✔ keepalive emits heartbeat to stderr (6454.350092ms)
+✔ keepalive ignores first SIGINT (447.607521ms)
+✔ gateway reads SOLVER_URL from environment (1.91738ms)
+✔ gateway retains default solver URL (0.224799ms)
+✔ source link renders with arrow and class (21.128843ms)
+✔ non-source link keeps text (3.844966ms)
+✔ devDependencies omit @vscode/ripgrep (2.120118ms)
+✔ prepare-docs avoids ripgrep install (0.316352ms)
+✔ time to chill includes size with height in cm (2.021385ms)
+✔ time to chill height is positive (0.200944ms)
+✔ GitHub workflows use latest action versions (1.929479ms)
+ℹ tests 35
+ℹ suites 0
+ℹ pass 35
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 38290.229469
+Executed 25 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.2% ( 1194/1418 )
+Branches     : 78.9% ( 187/237 )
+Functions    : 74.07% ( 60/81 )
+Lines        : 84.2% ( 1194/1418 )
+================================================================================

--- a/docs/knowledge/solver-url-env-red.log
+++ b/docs/knowledge/solver-url-env-red.log
@@ -1,0 +1,258 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.25 seconds (46.4ms each, v3.1.2)
+✔ archive nav exposes child counts (5270.916345ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.32 seconds (47.1ms each, v3.1.2)
+✔ layout exposes build timestamp (5339.426728ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.63 seconds (41.0ms each, v3.1.2)
+✔ code blocks expose copy control (4931.872066ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.35 seconds (47.3ms each, v3.1.2)
+✔ collection pages expose section metadata (5366.545852ms)
+✔ concept map JSON-LD export generates @context and @graph (5.430183ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.32 seconds (47.1ms each, v3.1.2)
+✔ feed exposes build metadata (5343.221085ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.17 seconds (45.7ms each, v3.1.2)
+✔ home page header includes primary nav landmark (5187.909657ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.49 seconds (39.8ms each, v3.1.2)
+✔ homepage work list mixes types (4732.034683ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.69 seconds (41.5ms each, v3.1.2)
+✔ homepage hero and work filters (4968.627396ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.37 seconds (47.5ms each, v3.1.2)
+✔ markdown headings include anchor ids (5391.495785ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.44 seconds (48.1ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (5458.904981ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.35 seconds (47.4ms each, v3.1.2)
+✔ main nav marks current page and is labelled (5372.984336ms)
+✔ navigation items are sequentially ordered (1.600766ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.33 seconds (47.2ms each, v3.1.2)
+✔ buildLean sets env and output directory (5363.218671ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.84 seconds (42.8ms each, v3.1.2)
+✔ spark listings reveal status text (4867.89313ms)
+✔ deploy workflow does not trigger on pull_request (1.960858ms)
+✔ build job runs only on push events (0.324703ms)
+✔ defines improved background colors (4.837711ms)
+✔ text contrast meets WCAG AA (1.346436ms)
+✔ tailwind exposes readable fonts (0.246639ms)
+✔ includes fluid type scale tokens (0.255585ms)
+✔ docs:links reports no broken links (1673.44883ms)
+✔ package-lock.json defines lockfileVersion (8.48995ms)
+✔ projects computed picks latest entries by date (2.920392ms)
+✔ keepalive emits heartbeat to stderr (6397.717958ms)
+✔ keepalive ignores first SIGINT (446.691162ms)
+✖ gateway reads SOLVER_URL from environment (3.086828ms)
+✔ gateway retains default solver URL (0.235793ms)
+✔ source link renders with arrow and class (21.230191ms)
+✔ non-source link keeps text (2.57663ms)
+✔ devDependencies omit @vscode/ripgrep (1.955189ms)
+✔ prepare-docs avoids ripgrep install (0.229526ms)
+✔ time to chill includes size with height in cm (2.01886ms)
+✔ time to chill height is positive (0.197651ms)
+✔ GitHub workflows use latest action versions (2.063424ms)
+ℹ tests 35
+ℹ suites 0
+ℹ pass 34
+ℹ fail 1
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 37845.439291
+
+✖ failing tests:
+
+test at test/unit/markdown-gateway-config.test.mjs:10:7
+✖ gateway reads SOLVER_URL from environment (3.086828ms)
+  AssertionError [ERR_ASSERTION]: The input did not match the regular expression /os\.environ\.get\(\"SOLVER_URL\"/. Input:
+  
+  'import os\n' +
+    'from functools import wraps\n' +
+    'from urllib.parse import urljoin\n' +
+    '\n' +
+    'import requests\n' +
+    'from bs4 import BeautifulSoup\n' +
+    'from flask import Flask, jsonify, request\n' +
+    'from markdownify import markdownify\n' +
+    'from readability import Document\n' +
+    '\n' +
+    'app = Flask(__name__)\n' +
+    'API_KEY = os.environ.get("GATEWAY_API_KEY")\n' +
+    'SOLVER_URL = "http://solver:8191/v1"\n' +
+    '\n' +
+    '\n' +
+    'def require_api_key(func):\n' +
+    '    @wraps(func)\n' +
+    '    def wrapper(*args, **kwargs):\n' +
+    '        if not API_KEY or request.headers.get("X-Api-Key") != API_KEY:\n' +
+    '            return jsonify({"error": "unauthorized"}), 401\n' +
+    '        return func(*args, **kwargs)\n' +
+    '\n' +
+    '    return wrapper\n' +
+    '\n' +
+    '\n' +
+    '@app.route("/health", methods=["GET"])\n' +
+    'def health():\n' +
+    '    return jsonify({"status": "healthy"}), 200\n' +
+    '\n' +
+    '\n' +
+    '@app.route("/convert", methods=["POST"])\n' +
+    '@require_api_key\n' +
+    'def convert():\n' +
+    '    data = request.get_json(silent=True) or {}\n' +
+    '    url = data.get("url")\n' +
+    '    if not url:\n' +
+    '        return jsonify({"error": "url is required"}), 400\n' +
+    '\n' +
+    '    payload = {"cmd": "request.get", "url": url}\n' +
+    '    try:\n' +
+    '        solver_resp = requests.post(SOLVER_URL, json=payload, timeout=120)\n' +
+    '\n' +
+    '        solver_resp.raise_for_status()\n' +
+    '        body = solver_resp.json()\n' +
+    '        if body.get("status") != "ok":\n' +
+    '            return jsonify({"error": "solver error"}), 502\n' +
+    '        html = body.get("solution", {}).get("response")\n' +
+    '        if not html:\n' +
+    '            return jsonify({"error": "empty response"}), 502\n' +
+    '    except requests.RequestException as exc:\n' +
+    '        return jsonify({"error": str(exc)}), 502\n' +
+    '\n' +
+    '    doc = Document(html)\n' +
+    '    cleaned_html = doc.summary()\n' +
+    '    soup = BeautifulSoup(cleaned_html, "lxml")\n' +
+    '    for tag in soup.find_all(href=True):\n' +
+    '        tag["href"] = urljoin(url, tag["href"])\n' +
+    '    for tag in soup.find_all(src=True):\n' +
+    '        tag["src"] = urljoin(url, tag["src"])\n' +
+    '    markdown = markdownify(str(soup))\n' +
+    '    return jsonify({"flareresolver": body, "markdown": markdown})\n' +
+    '\n' +
+    '\n' +
+    'if __name__ == "__main__":\n' +
+    '    app.run(host="0.0.0.0", port=5000)\n'
+  
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/markdown-gateway-config.test.mjs:11:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.start (node:internal/test_runner/test:944:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+      at async file:///workspace/effusion-labs/test/unit/markdown-gateway-config.test.mjs:10:1 {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 'import os\nfrom functools import wraps\nfrom urllib.parse import urljoin\n\nimport requests\nfrom bs4 import BeautifulSoup\nfrom flask import Flask, jsonify, request\nfrom markdownify import markdownify\nfrom readability import Document\n\napp = Flask(__name__)\nAPI_KEY = os.environ.get("GATEWAY_API_KEY")\nSOLVER_URL = "http://solver:8191/v1"\n\n\ndef require_api_key(func):\n    @wraps(func)\n    def wrapper(*args, **kwargs):\n        if not API_KEY or request.headers.get("X-Api-Key") != API_KEY:\n            return jsonify({"error": "unauthorized"}), 401\n        return func(*args, **kwargs)\n\n    return wrapper\n\n\n@app.route("/health", methods=["GET"])\ndef health():\n    return jsonify({"status": "healthy"}), 200\n\n\n@app.route("/convert", methods=["POST"])\n@require_api_key\ndef convert():\n    data = request.get_json(silent=True) or {}\n    url = data.get("url")\n    if not url:\n        return jsonify({"error": "url is required"}), 400\n\n    payload = {"cmd": "request.get", "url": url}\n    try:\n        solver_resp = requests.post(SOLVER_URL, json=payload, timeout=120)\n\n        solver_resp.raise_for_status()\n        body = solver_resp.json()\n        if body.get("status") != "ok":\n            return jsonify({"error": "solver error"}), 502\n        html = body.get("solution", {}).get("response")\n        if not html:\n            return jsonify({"error": "empty response"}), 502\n    except requests.RequestException as exc:\n        return jsonify({"error": str(exc)}), 502\n\n    doc = Document(html)\n    cleaned_html = doc.summary()\n    soup = BeautifulSoup(cleaned_html, "lxml")\n    for tag in soup.find_all(href=True):\n        tag["href"] = urljoin(url, tag["href"])\n    for tag in soup.find_all(src=True):\n        tag["src"] = urljoin(url, tag["src"])\n    markdown = markdownify(str(soup))\n    return jsonify({"flareresolver": body, "markdown": markdown})\n\n\nif __name__ == "__main__":\n    app.run(host="0.0.0.0", port=5000)\n',
+    expected: /os\.environ\.get\(\"SOLVER_URL\"/,
+    operator: 'match'
+  }
+Executed 25 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.2% ( 1194/1418 )
+Branches     : 78.9% ( 187/237 )
+Functions    : 74.07% ( 60/81 )
+Lines        : 84.2% ( 1194/1418 )
+================================================================================

--- a/docs/knowledge/solver-url-env-refactor.log
+++ b/docs/knowledge/solver-url-env-refactor.log
@@ -1,0 +1,173 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.69 seconds (50.3ms each, v3.1.2)
+✔ archive nav exposes child counts (5707.591364ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.67 seconds (50.1ms each, v3.1.2)
+✔ layout exposes build timestamp (5690.892451ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.04 seconds (44.6ms each, v3.1.2)
+✔ code blocks expose copy control (5317.826072ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.46 seconds (48.3ms each, v3.1.2)
+✔ collection pages expose section metadata (5490.334245ms)
+✔ concept map JSON-LD export generates @context and @graph (3.861842ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.31 seconds (47.0ms each, v3.1.2)
+✔ feed exposes build metadata (5331.34505ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.18 seconds (45.9ms each, v3.1.2)
+✔ home page header includes primary nav landmark (5206.933977ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.63 seconds (41.0ms each, v3.1.2)
+✔ homepage work list mixes types (4841.095336ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.83 seconds (42.7ms each, v3.1.2)
+✔ homepage hero and work filters (5098.617845ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.49 seconds (48.6ms each, v3.1.2)
+✔ markdown headings include anchor ids (5514.760446ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.18 seconds (45.9ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (5203.284566ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.39 seconds (47.7ms each, v3.1.2)
+✔ main nav marks current page and is labelled (5414.859264ms)
+✔ navigation items are sequentially ordered (1.596498ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 5.46 seconds (48.3ms each, v3.1.2)
+✔ buildLean sets env and output directory (5482.369194ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.83 seconds (42.7ms each, v3.1.2)
+✔ spark listings reveal status text (4868.306345ms)
+✔ deploy workflow does not trigger on pull_request (1.864333ms)
+✔ build job runs only on push events (0.339902ms)
+✔ defines improved background colors (2.261224ms)
+✔ text contrast meets WCAG AA (0.882978ms)
+✔ tailwind exposes readable fonts (0.201717ms)
+✔ includes fluid type scale tokens (0.186738ms)
+✔ docs:links reports no broken links (1621.979854ms)
+✔ package-lock.json defines lockfileVersion (7.279264ms)
+✔ projects computed picks latest entries by date (3.59233ms)
+✔ keepalive emits heartbeat to stderr (6417.174135ms)
+✔ keepalive ignores first SIGINT (439.330405ms)
+✔ gateway reads SOLVER_URL from environment (1.961315ms)
+✔ gateway retains default solver URL (0.242045ms)
+✔ source link renders with arrow and class (17.915659ms)
+✔ non-source link keeps text (3.038081ms)
+✔ devDependencies omit @vscode/ripgrep (1.77709ms)
+✔ prepare-docs avoids ripgrep install (0.290801ms)
+✔ time to chill includes size with height in cm (1.972639ms)
+✔ time to chill height is positive (0.26829ms)
+✔ GitHub workflows use latest action versions (2.300067ms)
+ℹ tests 35
+ℹ suites 0
+ℹ pass 35
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 38775.982183
+Executed 25 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.2% ( 1194/1418 )
+Branches     : 78.9% ( 187/237 )
+Functions    : 74.07% ( 60/81 )
+Lines        : 84.2% ( 1194/1418 )
+================================================================================

--- a/docs/reports/solver-url-env-continue.md
+++ b/docs/reports/solver-url-env-continue.md
@@ -1,0 +1,13 @@
+# Continuation — solver-url-env
+
+## Context Recap
+Gateway now reads `SOLVER_URL` from environment with default fallback and tests.
+
+## Outstanding Items
+- None
+
+## Execution Strategy
+- N/A
+
+## Trigger Command
+- `npm test`

--- a/docs/reports/solver-url-env-ledger.md
+++ b/docs/reports/solver-url-env-ledger.md
@@ -1,0 +1,25 @@
+# Ledger — solver-url-env
+
+## Criteria & Proofs
+1. Gateway reads `SOLVER_URL` from environment.
+   - Proof: `test/unit/markdown-gateway-config.test.mjs`
+   - Log: `docs/knowledge/solver-url-env-green.log`
+2. Gateway retains default solver address when env absent.
+   - Proof: `test/unit/markdown-gateway-config.test.mjs`
+   - Log: `docs/knowledge/solver-url-env-green.log`
+
+## Index
+- satisfied criteria: 2/2
+
+## Hashes
+- `markdown_gateway/app.py` – ff7e62c0d736fd853b2c87d74d55b48b995d452e41548bc40f320a9286c5e2c7
+- `test/unit/markdown-gateway-config.test.mjs` – eb274d2378195c462115a37eb7db29ef3656e388b5df40a9d106f36cf625a90e
+- `README.md` – 78d61a92450e7504859518edd14486403e7e8ce7e0abf7109a846c6dc75cf18d
+- `docs/knowledge/solver-url-env-red.log` – 91759e46712f5a23d9c2d357f7ba3c0b2736e5c9fd53cc898ad295f7437349de
+- `docs/knowledge/solver-url-env-green.log` – 626e77808bc8dbda5ecacb14e5ab177e0c84b42b00678ad17dbb73f89d3997ba
+- `docs/knowledge/solver-url-env-refactor.log` – c40f51d03f3e892e396e7ae637aa54ffc8cd99680d21aaae9340efd9b7695b9c
+- `docs/knowledge/solver-url-env-docs.log` – f13671568040182d054b7dce248859d6174f9645b7896219305a2a1c76b4e3e3
+
+## Rollback
+- Last safe SHA: b155a3ab0060f0ab9f9f0e6228df764e6cd4daca
+- Rollback command: `git reset --hard b155a3ab0060f0ab9f9f0e6228df764e6cd4daca`

--- a/markdown_gateway/app.py
+++ b/markdown_gateway/app.py
@@ -10,7 +10,14 @@ from readability import Document
 
 app = Flask(__name__)
 API_KEY = os.environ.get("GATEWAY_API_KEY")
-SOLVER_URL = "http://solver:8191/v1"
+DEFAULT_SOLVER_URL = "http://solver:8191/v1"
+
+
+def get_solver_url() -> str:
+    return os.environ.get("SOLVER_URL", DEFAULT_SOLVER_URL)
+
+
+SOLVER_URL = get_solver_url()
 
 
 def require_api_key(func):

--- a/test/unit/markdown-gateway-config.test.mjs
+++ b/test/unit/markdown-gateway-config.test.mjs
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const appPath = path.join(process.cwd(), 'markdown_gateway', 'app.py');
+const appSource = fs.readFileSync(appPath, 'utf8');
+
+// Acceptance example: app.py reads solver URL from environment variable
+await test('gateway reads SOLVER_URL from environment', () => {
+  assert.match(appSource, /os\.environ\.get\(\"SOLVER_URL\"/);
+});
+
+// Property: default solver URL remains the internal service address
+await test('gateway retains default solver URL', () => {
+  assert.match(appSource, /"http:\/\/solver:8191\/v1"/);
+});


### PR DESCRIPTION
## Summary
- allow configuring markdown gateway solver via `SOLVER_URL`
- test that gateway reads env variable and retains default
- document solver configuration in README

## Testing
- `npm test`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_68a02e37c0bc833080fd20fad91b45a7