### PR TITLE
Add work section and fix drop CTAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates
 
 ## ✨ Key Features
 - Home page presents a multi-column Work feed with filter toolbar, interactive concept map CTA, and animated lab seal flourish.
+- Dedicated `/work` section aggregates projects, concepts, and sparks with category filters and deep links.
 ### npm Scripts
 - `npm run dev` – start Eleventy with live reload.
 - `npm run build` – compile the production site to `_site/`.

--- a/docs/knowledge/work-pages-green.log
+++ b/docs/knowledge/work-pages-green.log
@@ -1,0 +1,189 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test:guard
+> bash scripts/test-with-guardrails.sh
+
+::notice:: LLM-safe: shell alive @ 2025-08-16T07:17:55Z
+::notice:: LLM-safe: shell alive @ 2025-08-16T07:17:55Z
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.57 seconds (39.7ms each, v3.1.2)
+✔ archive nav exposes child counts (4579.705456ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.53 seconds (39.4ms each, v3.1.2)
+✔ layout exposes build timestamp (4535.251625ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 3.79 seconds (33.0ms each, v3.1.2)
+✔ code blocks expose copy control (4069.237548ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.61 seconds (40.1ms each, v3.1.2)
+✔ collection pages expose section metadata (4622.75407ms)
+✔ concept map JSON-LD export generates @context and @graph (3.930938ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.43 seconds (38.5ms each, v3.1.2)
+✔ feed exposes build metadata (4440.205105ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.66 seconds (40.6ms each, v3.1.2)
+✔ home page header includes primary nav landmark (4672.057241ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 3.82 seconds (33.2ms each, v3.1.2)
+✔ homepage work list mixes types (4009.310074ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 3.85 seconds (33.5ms each, v3.1.2)
+✔ homepage hero and work filters (4081.894428ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.50 seconds (39.1ms each, v3.1.2)
+✔ markdown headings include anchor ids (4502.496501ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.50 seconds (39.1ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (4520.505234ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.56 seconds (39.7ms each, v3.1.2)
+✔ main nav marks current page and is labelled (4580.735601ms)
+✔ navigation items are sequentially ordered (1.639659ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.58 seconds (39.8ms each, v3.1.2)
+✔ buildLean sets env and output directory (4597.901666ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.61 seconds (40.1ms each, v3.1.2)
+✔ spark listings reveal status text (4637.028864ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.53 seconds (39.4ms each, v3.1.2)
+✔ work pages build and latest redirects (4552.461048ms)
+✔ deploy workflow does not trigger on pull_request (2.639693ms)
+✔ build job runs only on push events (0.397805ms)
+✔ defines improved background colors (1.963839ms)
+✔ text contrast meets WCAG AA (0.781892ms)
+✔ tailwind exposes readable fonts (5.020122ms)
+✔ includes fluid type scale tokens (0.220437ms)
+✔ docs:links reports no broken links (1756.267726ms)
+✔ package-lock.json defines lockfileVersion (6.724041ms)
+✔ projects computed picks latest entries by date (2.865088ms)
+✔ keepalive emits heartbeat to stderr (6376.57961ms)
+✔ keepalive ignores first SIGINT (437.274637ms)
+✔ source link renders with arrow and class (17.194184ms)
+✔ non-source link keeps text (2.483272ms)
+✔ devDependencies omit @vscode/ripgrep (1.59775ms)
+✔ prepare-docs avoids ripgrep install (0.207841ms)
+✔ time to chill includes size with height in cm (1.865054ms)
+✔ time to chill height is positive (0.224641ms)
+✔ GitHub workflows use latest action versions (1.902127ms)
+ℹ tests 34
+ℹ suites 0
+ℹ pass 34
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 36223.311335
+Executed 25 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.25% ( 1199/1423 )
+Branches     : 78.75% ( 189/240 )
+Functions    : 74.39% ( 61/82 )
+Lines        : 84.25% ( 1199/1423 )
+================================================================================
+::notice:: LLM-safe: shell alive @ 2025-08-16T07:18:38Z

--- a/docs/knowledge/work-pages-red.log
+++ b/docs/knowledge/work-pages-red.log
@@ -1,0 +1,205 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test:guard
+> bash scripts/test-with-guardrails.sh
+
+::notice:: LLM-safe: shell alive @ 2025-08-16T07:16:01Z
+::notice:: LLM-safe: shell alive @ 2025-08-16T07:16:01Z
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.31 seconds (38.2ms each, v3.1.2)
+✔ archive nav exposes child counts (4332.060148ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.47 seconds (39.6ms each, v3.1.2)
+✔ layout exposes build timestamp (4492.079229ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/projects/project-lichen.md
+[11ty] Copied 77 Wrote 113 files in 3.76 seconds (33.3ms each, v3.1.2)
+✔ code blocks expose copy control (3992.249112ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.45 seconds (39.4ms each, v3.1.2)
+✔ collection pages expose section metadata (4468.525194ms)
+✔ concept map JSON-LD export generates @context and @graph (3.663208ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.46 seconds (39.5ms each, v3.1.2)
+✔ feed exposes build metadata (4481.378023ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.56 seconds (40.4ms each, v3.1.2)
+✔ home page header includes primary nav landmark (4580.913549ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.18 seconds (37.0ms each, v3.1.2)
+✔ homepage work list mixes types (4380.347712ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.20 seconds (37.2ms each, v3.1.2)
+✔ homepage hero and work filters (4517.714308ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.70 seconds (41.6ms each, v3.1.2)
+✔ markdown headings include anchor ids (4722.418565ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.65 seconds (41.1ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (4669.819366ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.83 seconds (42.7ms each, v3.1.2)
+✔ main nav marks current page and is labelled (4846.480597ms)
+✔ navigation items are sequentially ordered (1.422536ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.68 seconds (41.4ms each, v3.1.2)
+✔ buildLean sets env and output directory (4699.461016ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.57 seconds (40.5ms each, v3.1.2)
+✔ spark listings reveal status text (4599.464395ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 113 files in 4.56 seconds (40.4ms each, v3.1.2)
+✖ work pages build and latest redirects (4583.601605ms)
+✔ deploy workflow does not trigger on pull_request (1.684074ms)
+✔ build job runs only on push events (0.333943ms)
+✔ defines improved background colors (2.116092ms)
+✔ text contrast meets WCAG AA (0.85751ms)
+✔ tailwind exposes readable fonts (6.796291ms)
+✔ includes fluid type scale tokens (0.253637ms)
+✔ docs:links reports no broken links (1664.636131ms)
+✔ package-lock.json defines lockfileVersion (7.128606ms)
+✔ projects computed picks latest entries by date (2.698593ms)
+✔ keepalive emits heartbeat to stderr (6365.453958ms)
+✔ keepalive ignores first SIGINT (408.624794ms)
+✔ source link renders with arrow and class (16.23933ms)
+✔ non-source link keeps text (2.36009ms)
+✔ devDependencies omit @vscode/ripgrep (1.50274ms)
+✔ prepare-docs avoids ripgrep install (0.257774ms)
+✔ time to chill includes size with height in cm (1.817751ms)
+✔ time to chill height is positive (0.238478ms)
+✔ GitHub workflows use latest action versions (1.712255ms)
+ℹ tests 34
+ℹ suites 0
+ℹ pass 33
+ℹ fail 1
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 36696.065966
+
+✖ failing tests:
+
+test at test/integration/work-pages.spec.mjs:7:1
+✖ work pages build and latest redirects (4583.601605ms)
+  AssertionError [ERR_ASSERTION]: work/index.html missing
+      at file:///workspace/effusion-labs/test/integration/work-pages.spec.mjs:17:5
+      at Array.forEach (<anonymous>)
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/work-pages.spec.mjs:16:9)
+      at async Test.run (node:internal/test_runner/test:1054:7)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
+    generatedMessage: false,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '=='
+  }
+Executed 25 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.2% ( 1194/1418 )
+Branches     : 78.57% ( 187/238 )
+Functions    : 74.07% ( 60/81 )
+Lines        : 84.2% ( 1194/1418 )
+================================================================================

--- a/docs/knowledge/work-pages-refactor.log
+++ b/docs/knowledge/work-pages-refactor.log
@@ -1,0 +1,189 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test:guard
+> bash scripts/test-with-guardrails.sh
+
+::notice:: LLM-safe: shell alive @ 2025-08-16T07:20:48Z
+::notice:: LLM-safe: shell alive @ 2025-08-16T07:20:48Z
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.68 seconds (40.7ms each, v3.1.2)
+✔ archive nav exposes child counts (4699.857412ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.46 seconds (38.8ms each, v3.1.2)
+✔ layout exposes build timestamp (4479.93638ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 3.78 seconds (32.9ms each, v3.1.2)
+✔ code blocks expose copy control (4010.156478ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.51 seconds (39.2ms each, v3.1.2)
+✔ collection pages expose section metadata (4536.252052ms)
+✔ concept map JSON-LD export generates @context and @graph (3.786081ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.45 seconds (38.7ms each, v3.1.2)
+✔ feed exposes build metadata (4472.823974ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.74 seconds (41.2ms each, v3.1.2)
+✔ home page header includes primary nav landmark (4761.96515ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 3.87 seconds (33.7ms each, v3.1.2)
+✔ homepage work list mixes types (4068.065946ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 3.75 seconds (32.6ms each, v3.1.2)
+✔ homepage hero and work filters (4004.738294ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.71 seconds (41.0ms each, v3.1.2)
+✔ markdown headings include anchor ids (4733.061803ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.55 seconds (39.6ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (4575.192975ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.61 seconds (40.1ms each, v3.1.2)
+✔ main nav marks current page and is labelled (4643.698662ms)
+✔ navigation items are sequentially ordered (2.358313ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.66 seconds (40.5ms each, v3.1.2)
+✔ buildLean sets env and output directory (4676.594892ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.53 seconds (39.3ms each, v3.1.2)
+✔ spark listings reveal status text (4544.157219ms)
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 115 files in 4.46 seconds (38.8ms each, v3.1.2)
+✔ work pages build and latest redirects (4478.573034ms)
+✔ deploy workflow does not trigger on pull_request (1.685697ms)
+✔ build job runs only on push events (0.271305ms)
+✔ defines improved background colors (1.937924ms)
+✔ text contrast meets WCAG AA (0.848646ms)
+✔ tailwind exposes readable fonts (0.215299ms)
+✔ includes fluid type scale tokens (0.269793ms)
+✔ docs:links reports no broken links (1696.842825ms)
+✔ package-lock.json defines lockfileVersion (6.622079ms)
+✔ projects computed picks latest entries by date (2.761779ms)
+✔ keepalive emits heartbeat to stderr (6430.425337ms)
+✔ keepalive ignores first SIGINT (427.809316ms)
+✔ source link renders with arrow and class (17.126996ms)
+✔ non-source link keeps text (2.565462ms)
+✔ devDependencies omit @vscode/ripgrep (1.737757ms)
+✔ prepare-docs avoids ripgrep install (0.240117ms)
+✔ time to chill includes size with height in cm (1.620939ms)
+✔ time to chill height is positive (0.177856ms)
+✔ GitHub workflows use latest action versions (1.76686ms)
+ℹ tests 34
+ℹ suites 0
+ℹ pass 34
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 36568.232876
+Executed 25 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.39% ( 1211/1435 )
+Branches     : 79.18% ( 194/245 )
+Functions    : 75% ( 63/84 )
+Lines        : 84.39% ( 1211/1435 )
+================================================================================
+::notice:: LLM-safe: shell alive @ 2025-08-16T07:21:31Z

--- a/docs/knowledge/work-readme-links.log
+++ b/docs/knowledge/work-readme-links.log
@@ -1,0 +1,23 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 docs:links
+> markdown-link-check -c link-check.config.json README.md
+
+
+FILE: README.md
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml
+  [✓] ./LICENSE
+  [✓] #-project-overview
+  [✓] #-key-features
+  [✓] #-quickstart
+  [✓] #-project-layout
+  [✓] #-deployment
+  [✓] #-quality-assurance
+  [✓] #-contributing
+  [✓] #-license
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml/badge.svg
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml/badge.svg
+  [✓] https://img.shields.io/badge/license-ISC-blue.svg
+
+  14 links checked.

--- a/docs/reports/work-pages-continue.md
+++ b/docs/reports/work-pages-continue.md
@@ -1,0 +1,11 @@
+# Continuation
+
+## Context Recap
+Work section implemented with redirects and validated links.
+
+## Outstanding Items
+1. Add more work entries for broader coverage.
+2. Enhance styling of /work page.
+
+## Execution Strategy
+Run `npm run test:guard`.

--- a/docs/reports/work-pages-ledger.md
+++ b/docs/reports/work-pages-ledger.md
@@ -1,0 +1,13 @@
+# work-pages-ledger
+
+## Criteria
+1. Work CTAs resolve to existing pages.
+2. Latest redirect contains meta refresh.
+
+## Proof
+- docs/knowledge/work-pages-green.log
+- docs/knowledge/work-pages-refactor.log
+- docs/knowledge/work-readme-links.log
+
+## Rollback
+`git revert 012f11cbf73430520bfee1515b73b81cc8636bbb`

--- a/src/_includes/layouts/redirect.njk
+++ b/src/_includes/layouts/redirect.njk
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0; url={{ redirect }}">
+  <link rel="canonical" href="{{ redirect }}">
+</head>
+<body>
+  <p>Redirecting to <a href="{{ redirect }}">{{ redirect }}</a>...</p>
+</body>
+</html>

--- a/src/content/concepts/block-ledger.md
+++ b/src/content/concepts/block-ledger.md
@@ -6,6 +6,7 @@ status: draft
 tags: [concept, block]
 certainty: exploratory
 importance: 1
+permalink: /work/block-ledger/
 ---
 
 # Blocks as Units

--- a/src/content/projects/project-lichen.md
+++ b/src/content/projects/project-lichen.md
@@ -5,6 +5,7 @@ date: 2025-08-02
 status: draft
 tags: [knowledge-graph, adaptive-systems, prototype]
 featured: true
+permalink: /work/drop/
 ---
 
 Project Lichen explores how slow-growing knowledge can be modeled like a living substrate. Inspired by lichen's symbiotic structure, the prototype binds disparate notes into an adaptive graph that thickens where attention accumulates.

--- a/src/content/sparks/raw-socket-report.md
+++ b/src/content/sparks/raw-socket-report.md
@@ -8,6 +8,7 @@ tags:
   - rough-notes
 spark_type: log
 description: "Unfiltered notes from a midnight server check."
+permalink: /work/raw-socket-report/
 ---
 
 This log fragment intentionally retains its rough edges.

--- a/src/work.11tydata.js
+++ b/src/work.11tydata.js
@@ -1,0 +1,5 @@
+module.exports = {
+  eleventyComputed: {
+    work: data => data.collections.work
+  }
+};

--- a/src/work.njk
+++ b/src/work.njk
@@ -1,0 +1,9 @@
+---
+layout: "layout.njk"
+metaDisable: true
+showTitle: false
+---
+<main class="mx-auto max-w-screen-xl px-6 sm:px-8 space-y-16">
+  {% include "components/work-feed.njk" %}
+</main>
+<script src="/assets/js/work-filters.js" defer></script>

--- a/src/work/latest.11ty.js
+++ b/src/work/latest.11ty.js
@@ -1,0 +1,12 @@
+exports.data = {
+  layout: "layouts/redirect.njk",
+  permalink: "/work/latest/index.html",
+  eleventyComputed: {
+    redirect: data => {
+      const w = data.collections.work && data.collections.work[0];
+      return w ? w.url : '/work/';
+    }
+  }
+};
+
+exports.render = () => '';

--- a/test/integration/work-pages.spec.mjs
+++ b/test/integration/work-pages.spec.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { buildLean } from '../helpers/eleventy-env.mjs';
+
+test('work pages build and latest redirects', async () => {
+  const outDir = await buildLean('work-pages');
+  const pages = [
+    'work/index.html',
+    'work/latest/index.html',
+    'work/drop/index.html',
+    'work/block-ledger/index.html',
+    'work/raw-socket-report/index.html'
+  ];
+  pages.forEach(p => {
+    assert(existsSync(path.join(outDir, p)), `${p} missing`);
+  });
+  const latest = readFileSync(path.join(outDir, 'work/latest/index.html'), 'utf8');
+  assert(latest.includes('<meta http-equiv="refresh"'));
+});


### PR DESCRIPTION
## Summary
- Route project, concept, and spark entries under `/work/*` and add latest redirect
- Introduce `/work` listing page with filter script
- Document new work section in README

## Testing
- `npm run test:guard`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_68a02ed673688330a4fc4543653ca5e7