### PR TITLE
silence interlinker dead link warnings

### DIFF
--- a/docs/reports/plugins-deadlink-continue.md
+++ b/docs/reports/plugins-deadlink-continue.md
@@ -1,0 +1,15 @@
+# Continuation: plugins-deadlink
+
+## Context Recap
+Interlinker plugin configured to disable dead link report, tests cover configuration.
+
+## Outstanding Items
+1. Add Eleventy build integration test to ensure no dead link warnings during build.
+2. Document interlinker configuration in README.
+
+## Execution Strategy
+- Extend test harness with an Eleventy build slice that asserts no dead link warnings.
+- Update README to describe interlinker configuration and dead link suppression.
+
+## Trigger Command
+npm test

--- a/docs/reports/plugins-deadlink-ledger.md
+++ b/docs/reports/plugins-deadlink-ledger.md
@@ -1,0 +1,26 @@
+# Ledger: plugins-deadlink
+
+## Criteria & Proofs
+1. Interlinker plugin disables dead link report.
+   - Proof: test `interlinker disables dead link report` passes and plugin options include `deadLinkReport: 'none'`.
+2. Plugin list structure returns arrays with functions.
+   - Proof: unit test `plugin list structure` passes.
+3. Interlinker options contract ensures default layout and dead link report.
+   - Proof: unit test `interlinker options contract` passes.
+
+## Evidence
+- `lib/plugins.js` SHA256: 09191d1a48052dbf77607ce64afd58f61795f738f3d9aaee835cbd1f708ed78d
+- `test/unit/plugins-deadlink.test.mjs` SHA256: 903b91cdac92e6ad59ce5e9e3e27c80ebecd6da4265f2b5f4153624f3e6f0359
+- `logs/plugins-deadlink-red.log` SHA256: ba4acbc9a07aa2e87d9b6e9c96f9e14be9c8c90d5033ee32a934ebc33679d6f4
+
+## Acceptance Map
+- Criteria satisfied: 3/3
+
+## Rollback
+- Last safe SHA: edf20b00f0d3fe9d633f029e88de76a2b147ab30
+- Rollback command: `git revert edf20b00f0d3fe9d633f029e88de76a2b147ab30`
+
+## Delta Queue
+1. Add Eleventy build integration test to ensure no dead link warnings during build.
+2. Document interlinker configuration in README.
+

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -10,20 +10,21 @@ const sitemap = require('@quasibit/eleventy-plugin-sitemap');
  * @returns {Array<[Function, Object]>}
  */
 function getPlugins() {
+  const interlinkerOptions = {
+    defaultLayout: 'layouts/embed.njk',
+    // Disable dead link console noise for templated references
+    deadLinkReport: 'none',
+    resolvingFns: new Map([
+      ['default', link => {
+        const href = link.href || link.link;
+        const label = link.title || link.name;
+        return `<a class="interlink" href="${href}">${label}</a>`;
+      }]
+    ])
+  };
+
   return [
-    [
-      interlinker,
-      {
-        defaultLayout: 'layouts/embed.njk',
-        resolvingFns: new Map([
-          ['default', link => {
-            const href = link.href || link.link;
-            const label = link.title || link.name;
-            return `<a class="interlink" href="${href}">${label}</a>`;
-          }]
-        ])
-      }
-    ],
+    [interlinker, interlinkerOptions],
     [navigation],
     [syntaxHighlight, { preAttributes: { tabindex: 0 } }],
     [rss],

--- a/logs/plugins-deadlink-red.log
+++ b/logs/plugins-deadlink-red.log
@@ -1,0 +1,231 @@
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.18 seconds (28.4ms each, v3.1.2)
+[32m✔ archive nav exposes child counts [90m(3196.44249ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.21 seconds (28.7ms each, v3.1.2)
+[32m✔ layout exposes build timestamp [90m(3226.82051ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.78 seconds (24.8ms each, v3.1.2)
+[32m✔ code blocks expose copy control [90m(2969.934665ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.37 seconds (30.1ms each, v3.1.2)
+[32m✔ collection pages expose section metadata [90m(3407.147417ms)[39m[39m
+[32m✔ concept map JSON-LD export generates @context and @graph [90m(3.744053ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.31 seconds (29.6ms each, v3.1.2)
+[32m✔ feed exposes build metadata [90m(3325.492556ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.27 seconds (29.2ms each, v3.1.2)
+[32m✔ home page header includes primary nav landmark [90m(3283.426347ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.74 seconds (24.4ms each, v3.1.2)
+[32m✔ homepage lists latest entries per section [90m(2863.812366ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 2.82 seconds (25.2ms each, v3.1.2)
+[32m✔ homepage hero and sections [90m(3029.012686ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 6.90 seconds (61.6ms each, v3.1.2)
+[32m✔ transformed images have slugified filenames [90m(6917.976396ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 6.84 seconds (61.1ms each, v3.1.2)
+[32m✔ logo image transforms to avif and webp [90m(6981.331205ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.99 seconds (35.6ms each, v3.1.2)
+[32m✔ markdown headings include anchor ids [90m(4023.614866ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 4.56 seconds (40.7ms each, v3.1.2)
+[32m✔ monsters hub lists products and cross-links product and character pages [90m(4572.044338ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.37 seconds (30.1ms each, v3.1.2)
+[32m✔ main nav marks current page and is labelled [90m(3419.728893ms)[39m[39m
+[32m✔ navigation items are sequentially ordered [90m(1.22498ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.19 seconds (28.5ms each, v3.1.2)
+[32m✔ buildLean sets env and output directory [90m(3205.398887ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 76 Wrote 112 files in 3.20 seconds (28.6ms each, v3.1.2)
+[32m✔ spark listings reveal status text [90m(3218.206706ms)[39m[39m
+[32m✔ docs:links reports no broken links [90m(1131.444171ms)[39m[39m
+[32m✔ package-lock.json defines lockfileVersion [90m(5.733567ms)[39m[39m
+[31m✖ interlinker disables dead link report [90m(2.181333ms)[39m[39m
+[32m✔ plugin list structure [90m(0.308342ms)[39m[39m
+[31m✖ interlinker options contract [90m(1.773041ms)[39m[39m
+[32m✔ devDependencies omit @vscode/ripgrep [90m(1.138631ms)[39m[39m
+[32m✔ prepare-docs avoids ripgrep install [90m(0.163356ms)[39m[39m
+[32m✔ time to chill includes size with height in cm [90m(1.220022ms)[39m[39m
+[32m✔ time to chill height is positive [90m(0.146575ms)[39m[39m
+[32m✔ GitHub workflows use latest action versions [90m(1.638622ms)[39m[39m
+[34mℹ tests 27[39m
+[34mℹ suites 0[39m
+[34mℹ pass 25[39m
+[34mℹ fail 2[39m
+[34mℹ cancelled 0[39m
+[34mℹ skipped 0[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms 28593.033913[39m
+
+[31m✖ failing tests:[39m
+
+test at test/unit/plugins-deadlink.test.mjs:6:7
+[31m✖ interlinker disables dead link report [90m(2.181333ms)[39m[39m
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  + actual - expected
+  
+  + undefined
+  - 'none'
+  
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/plugins-deadlink.test.mjs:9:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.start (node:internal/test_runner/test:944:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+      at async file:///workspace/effusion-labs/test/unit/plugins-deadlink.test.mjs:6:1 {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: undefined,
+    expected: 'none',
+    operator: 'strictEqual'
+  }
+
+test at test/unit/plugins-deadlink.test.mjs:23:7
+[31m✖ interlinker options contract [90m(1.773041ms)[39m[39m
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+  + actual - expected
+  
+    {
+  +   deadLinkReport: 'none',
+  -   deadLinkReport: undefined,
+      defaultLayout: 'layouts/embed.njk'
+    }
+  
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/plugins-deadlink.test.mjs:25:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.start (node:internal/test_runner/test:944:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+      at run (node:internal/test_runner/harness:307:12)
+      at test (node:internal/test_runner/harness:316:12)
+      at file:///workspace/effusion-labs/test/unit/plugins-deadlink.test.mjs:23:7 {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: { defaultLayout: 'layouts/embed.njk', deadLinkReport: 'none' },
+    expected: { defaultLayout: 'layouts/embed.njk', deadLinkReport: undefined },
+    operator: 'deepStrictEqual'
+  }
+Executed 22 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.69% ( 1134/1339 )
+Branches     : 79.65% ( 184/231 )
+Functions    : 76.19% ( 64/84 )
+Lines        : 84.69% ( 1134/1339 )
+================================================================================

--- a/test/unit/plugins-deadlink.test.mjs
+++ b/test/unit/plugins-deadlink.test.mjs
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import getPlugins from '../../lib/plugins.js';
+
+// Acceptance example: interlinker plugin disables dead link report
+await test('interlinker disables dead link report', () => {
+  const [plugin, opts] = getPlugins()[0];
+  assert.equal(typeof plugin, 'function');
+  assert.equal(opts.deadLinkReport, 'none');
+});
+
+// Property: plugin list entries are arrays with function at index 0
+await test('plugin list structure', () => {
+  const plugins = getPlugins();
+  assert.ok(Array.isArray(plugins), 'plugins should be an array');
+  plugins.forEach(entry => {
+    assert.ok(Array.isArray(entry), 'each plugin entry should be an array');
+    assert.equal(typeof entry[0], 'function', 'plugin should be a function');
+  });
+});
+
+// Contract: interlinker options include expected defaults
+await test('interlinker options contract', () => {
+  const [, opts] = getPlugins()[0];
+  assert.deepEqual(
+    { defaultLayout: 'layouts/embed.njk', deadLinkReport: 'none' },
+    { defaultLayout: opts.defaultLayout, deadLinkReport: opts.deadLinkReport }
+  );
+});


### PR DESCRIPTION
## Summary
- disable interlinker dead link report to stop build warnings
- cover plugin configuration with tests
- document provenance for plugin configuration

## Testing
- `npm test`
- `npm run docs:links`


------
https://chatgpt.com/codex/tasks/task_e_68a0334711dc83309c4ba68ad11f4848