### PR TITLE
Filter templated wikilinks from dead link report

### DIFF
--- a/docs/knowledge/wikilink-filter-build-green.log
+++ b/docs/knowledge/wikilink-filter-build-green.log
@@ -1,0 +1,123 @@
+
+> effusion_labs_final@1.0.0 build
+> npx @11ty/eleventy
+
+🚀 Eleventy build starting with enhanced footnote system...
+/*! 🌼 daisyUI 5.0.50 */
+[11ty] Writing ./_site/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing ./_site/feed.xml from ./src/feed.njk
+[11ty] Writing ./_site/content/sparks/carbon-handshake/index.html from ./src/content/sparks/carbon-handshake.md (njk)
+[11ty/eleventy-img] Processing ./src/assets/static/logo.png (transform)
+[11ty] Writing ./_site/map/index.html from ./src/map.njk
+[11ty] Writing ./_site/404.html from ./src/404.njk
+[11ty] Writing ./_site/archives/index.html from ./src/archives/index.njk
+[11ty] Writing ./_site/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing ./_site/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/labubu/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--best-of-luck--plush--std--20231230--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/angel-in-clouds-v2/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/work/index.html from ./src/work.njk
+[11ty] Writing ./_site/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing ./_site/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing ./_site/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing ./_site/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing ./_site/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing ./_site/content/concepts/core-concept/index.html from ./src/content/concepts/core-concept.md (njk)
+[11ty] Writing ./_site/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing ./_site/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing ./_site/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing ./_site/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing ./_site/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing ./_site/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing ./_site/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing ./_site/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing ./_site/content/meta/anchor-demo/index.html from ./src/content/meta/anchor-demo.md (njk)
+[11ty] Writing ./_site/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing ./_site/content/meta/how-to-manufacture-a-legacy/index.html from ./src/content/meta/how-to-manufacture-a-legacy.md (njk)
+[11ty] Writing ./_site/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing ./_site/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing ./_site/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing ./_site/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing ./_site/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing ./_site/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing ./_site/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing ./_site/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing ./_site/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing ./_site/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing ./_site/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing ./_site/work/raw-socket-report/index.html from ./src/content/sparks/raw-socket-report.md (njk)
+[11ty] Writing ./_site/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing ./_site/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing ./_site/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing ./_site/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing ./_site/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing ./_site/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/mokoko/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box--single--20250425/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/best-of-luck/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/characters/zimomo/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box-set--sealed--20250425/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/big-into-energy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box--single--20250124/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/blue-diamond/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box-set--sealed--20250124/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/close-to-sweet-v1/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--dress-be-latte--plush--std--20231026/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/coca-cola/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box--single--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/dress-be-latte/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box-set--sealed--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/exciting-macaron/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--pendant--std--17cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-in-wild/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--plush-doll--std--40cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-into-spring/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--flip-with-me--plush--std--40cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/flip-with-me/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--forest-fairy-tale-china--figure--std--20250526--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/forest-fairy-tale-china/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--good-lucky-to-you-thailand--figure--std--20241220--reg-th/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/good-lucky-to-you-thailand/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--happy-halloween-party-sitting-pumpkin--pendant--sitting-pumpkin--20241025/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/happy-halloween-party-sitting-pumpkin/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box--single--15cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/have-a-seat/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box-set--sealed--15cm--20240712/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/hide-and-seek-in-singapore/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--hide-and-seek-in-singapore--figure--std--17.5cm--reg-sg/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/i-found-you-v1/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--jump-for-joy--plush--std--20230525/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/jump-for-joy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--pendant--std--17cm--20250207/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/lets-checkmate/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--plush-doll--std--37cm--20250207/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/magic-of-pumpkin/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-be-fancy-now--plush--std--20240315/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-be-fancy-now/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fantasy--plush--std--20241004/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fantasy/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fortune--pendant--std--20241004/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fortune/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--time-to-chill--plush--std--20221031/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/time-to-chill/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--wacky-mart-china--figure--std--20250612--reg-cn/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/twinkly-fairy-tale/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--walk-by-fortune--plush--std--20231229/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/wacky-mart-china/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--blue-diamond--pendant--std--17cm--20240618/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/series/walk-by-fortune/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--pendant--std--17cm/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--plush--std/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--pendant--std--17cm--20240308/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--plush--std--20240308/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--magic-of-pumpkin--pendant--std--17cm--20241027/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--twinkly-fairy-tale--pendant--std--17cm--20241128/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--angel-in-clouds-v2--plush--std--58cm--20241025/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--i-found-you-v1--plush--std--58cm--20231215/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+[11ty] Writing ./_site/index.html from ./src/index.njk
+✅ Eleventy build completed. Generated 113 files.
+[11ty/eleventy-img] 1 image optimized
+[11ty] Copied 77 Wrote 113 files in 2.95 seconds (26.1ms each, v3.1.2)

--- a/docs/knowledge/wikilink-filter-green.log
+++ b/docs/knowledge/wikilink-filter-green.log
@@ -1,0 +1,28 @@
+TAP version 13
+# Subtest: filterDeadLinks removes templated links
+ok 1 - filterDeadLinks removes templated links
+  ---
+  duration_ms: 2.042812
+  type: 'test'
+  ...
+# Subtest: result has no templated links
+ok 2 - result has no templated links
+  ---
+  duration_ms: 0.533775
+  type: 'test'
+  ...
+# Subtest: filterDeadLinks does not mutate input
+ok 3 - filterDeadLinks does not mutate input
+  ---
+  duration_ms: 0.425019
+  type: 'test'
+  ...
+1..3
+# tests 3
+# suites 0
+# pass 3
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 135.337024

--- a/docs/knowledge/wikilink-filter-red-run.log
+++ b/docs/knowledge/wikilink-filter-red-run.log
@@ -1,0 +1,38 @@
+TAP version 13
+# node:internal/modules/esm/resolve:274
+#     throw new ERR_MODULE_NOT_FOUND(
+#           ^
+# Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/effusion-labs/lib/wikilinks/filter-dead-links.js' imported from /workspace/effusion-labs/test/unit/wikilink-filter.test.mjs
+#     at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+#     at moduleResolve (node:internal/modules/esm/resolve:859:10)
+#     at defaultResolve (node:internal/modules/esm/resolve:983:11)
+#     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+#     at \#cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+#     at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+#     at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+#     at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+#   code: 'ERR_MODULE_NOT_FOUND',
+#   url: 'file:///workspace/effusion-labs/lib/wikilinks/filter-dead-links.js'
+# }
+# Node.js v22.18.0
+# Subtest: test/unit/wikilink-filter.test.mjs
+not ok 1 - test/unit/wikilink-filter.test.mjs
+  ---
+  duration_ms: 89.464344
+  type: 'test'
+  location: '/workspace/effusion-labs/test/unit/wikilink-filter.test.mjs:1:1'
+  failureType: 'testCodeFailure'
+  exitCode: 1
+  signal: ~
+  error: 'test failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 99.57811

--- a/docs/knowledge/wikilink-filter-red.log
+++ b/docs/knowledge/wikilink-filter-red.log
@@ -1,0 +1,38 @@
+TAP version 13
+# node:internal/modules/esm/resolve:274
+#     throw new ERR_MODULE_NOT_FOUND(
+#           ^
+# Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/effusion-labs/lib/wikilinks/filter-dead-links.js' imported from /workspace/effusion-labs/test/unit/wikilink-filter.test.mjs
+#     at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+#     at moduleResolve (node:internal/modules/esm/resolve:859:10)
+#     at defaultResolve (node:internal/modules/esm/resolve:983:11)
+#     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+#     at \#cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+#     at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+#     at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+#     at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+#   code: 'ERR_MODULE_NOT_FOUND',
+#   url: 'file:///workspace/effusion-labs/lib/wikilinks/filter-dead-links.js'
+# }
+# Node.js v22.18.0
+# Subtest: test/unit/wikilink-filter.test.mjs
+not ok 1 - test/unit/wikilink-filter.test.mjs
+  ---
+  duration_ms: 89.464344
+  type: 'test'
+  location: '/workspace/effusion-labs/test/unit/wikilink-filter.test.mjs:1:1'
+  failureType: 'testCodeFailure'
+  exitCode: 1
+  signal: ~
+  error: 'test failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 99.57811

--- a/docs/reports/link-hygiene-r3-continue.md
+++ b/docs/reports/link-hygiene-r3-continue.md
@@ -1,5 +1,5 @@
 # Context Recap
-Templated link warnings filtered and placeholder wikilinks removed, producing clean builds.
+Templated link warnings filtered with dedicated utility and test content excluded, producing clean builds.
 
 # Outstanding Items
 1. Add broader pattern ignore support.

--- a/docs/reports/link-hygiene-r3-ledger.md
+++ b/docs/reports/link-hygiene-r3-ledger.md
@@ -1,13 +1,15 @@
-# link-hygiene-r3 Ledger (1/1)
+# link-hygiene-r3 Ledger (2/2)
 
 ## Criteria & Proofs
 - Test suite passes with templated links ignored (`docs/knowledge/link-hygiene/test-green.log`, sha256: 3392048e756b8e14a7ffa54856854207a8ab6929e57adcc41a32b482e959c9e8).
 - Production build emits no wikilink warnings (`docs/knowledge/link-hygiene/build-green.log`, sha256: 1181da95c73473b40916f8c9306d0f071981618830ffb46e4747467b0744c3f6).
+- filterDeadLinks utility removes templated entries (`docs/knowledge/wikilink-filter-green.log`, sha256: 3a5c7985e086984d5a6a464fdb8abbba8ac1d1668f534dad4c9d00b784664212).
+- Eleventy build runs clean with filter in place (`docs/knowledge/wikilink-filter-build-green.log`, sha256: 34b360b53440a1ac230bbabe2473e0d777e12f25c8502489af565af395b245cf).
 
 ## Delta Queue
 1. Add broader pattern ignore support.
 2. Monitor dead-link report for orphan pages.
 
 ## Rollback
-- Last safe SHA: ee73c84
-- `git reset --hard ee73c84`
+- Last safe SHA: af6044f
+- `git reset --hard af6044f`

--- a/lib/eleventy/register.js
+++ b/lib/eleventy/register.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const fs = require('node:fs');
 const slugify = require('slugify');
 const { dirs } = require('../config');
+const { filterDeadLinks } = require('../wikilinks/filter-dead-links');
 
 const getPlugins = require('../plugins');
 const filters = require('../filters');
@@ -26,6 +27,7 @@ module.exports = function register(eleventyConfig) {
 
   if (process.env.ELEVENTY_ENV !== 'test') {
     eleventyConfig.ignores.add('test/**');
+    eleventyConfig.ignores.add('src/test/**');
   }
 
   eleventyConfig.on('eleventy.after', () => {
@@ -33,14 +35,15 @@ module.exports = function register(eleventyConfig) {
     const deadLinksPath = path.join(root, '.dead-links.json');
     if (!fs.existsSync(deadLinksPath)) return;
     const data = JSON.parse(fs.readFileSync(deadLinksPath, 'utf8'));
-    const TEMPLATE_SYNTAX = /\{\{.*\}\}/;
-    for (const [link, files] of Object.entries(data)) {
-      if (TEMPLATE_SYNTAX.test(link)) continue;
-      console.warn(
-        '[@photogabble/wikilinks] WARNING Wikilink (' + link + ') found pointing to to non-existent page in:'
-      );
-      for (const file of files) {
-        console.warn(`\t- ${file}`);
+    const filtered = filterDeadLinks(data);
+    if (Object.keys(filtered).length) {
+      for (const [link, files] of Object.entries(filtered)) {
+        console.warn(
+          '[@photogabble/wikilinks] WARNING Wikilink (' + link + ') found pointing to to non-existent page in:'
+        );
+        for (const file of files) {
+          console.warn(`\t- ${file}`);
+        }
       }
     }
     fs.rmSync(deadLinksPath);

--- a/lib/wikilinks/filter-dead-links.js
+++ b/lib/wikilinks/filter-dead-links.js
@@ -1,0 +1,14 @@
+const TEMPLATE_SYNTAX = /\{\{.*\}\}/;
+
+/**
+ * Remove templated wikilinks from a dead link report object.
+ * @param {Record<string,string[]>} deadLinks
+ * @returns {Record<string,string[]>}
+ */
+function filterDeadLinks(deadLinks) {
+  return Object.fromEntries(
+    Object.entries(deadLinks).filter(([link]) => !TEMPLATE_SYNTAX.test(link)),
+  );
+}
+
+module.exports = { filterDeadLinks, TEMPLATE_SYNTAX };

--- a/test/unit/wikilink-filter.test.mjs
+++ b/test/unit/wikilink-filter.test.mjs
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { filterDeadLinks, TEMPLATE_SYNTAX } from '../../lib/wikilinks/filter-dead-links.js';
+
+await test('filterDeadLinks removes templated links', () => {
+  const input = {
+    '/archives/{{ id }}/': ['foo.md'],
+    '/real/path/': ['bar.md']
+  };
+  const result = filterDeadLinks(input);
+  assert.deepEqual(result, { '/real/path/': ['bar.md'] });
+});
+
+await test('result has no templated links', () => {
+  const result = filterDeadLinks({
+    '/a/{{ b }}/': ['a.md'],
+    '/c/': ['c.md']
+  });
+  Object.keys(result).forEach(link => {
+    assert.ok(!TEMPLATE_SYNTAX.test(link));
+  });
+});
+
+await test('filterDeadLinks does not mutate input', () => {
+  const input = { '/a/{{ b }}/': ['a'], '/c/': ['c'] };
+  const copy = structuredClone(input);
+  filterDeadLinks(input);
+  assert.deepEqual(input, copy);
+});


### PR DESCRIPTION
## Summary
- add utility to strip templated wikilinks from dead link reports
- ignore src/test content in production builds and hook filtering into Eleventy
- cover dead link filter with unit tests

## Testing
- `node --test test/unit/wikilink-filter.test.mjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a03995d18083309c8607776b2ffa66