### PR TITLE
Improve footnote popover formatting and source separation

### DIFF
--- a/lib/markdown/footnotes.js
+++ b/lib/markdown/footnotes.js
@@ -103,16 +103,13 @@ function footnotePopover(md) {
         defHtml = footnoteData.content;
       }
       
-      // Clean up HTML for popover display - flatten block elements for inline display
+      // Clean up HTML for popover display and separate source attribution
       defHtml = defHtml
-        // Convert blockquotes to italic spans (preserving content but making inline-safe)
-        .replace(/<blockquote[^>]*>/g, '<em>')
-        .replace(/<\/blockquote>/g, '</em>')
-        // Remove all paragraph tags
+        .replace(/<\/?blockquote[^>]*>/g, '')
         .replace(/<\/?p[^>]*>/g, '')
-        // Convert line breaks
         .replace(/\n+/g, ' ')
         .replace(/\s+/g, ' ')
+        .replace(/\s*Source:(.*?)(<a href="#fnref)/i, '<br><span class="footnote-source">Source:$1</span>$2')
         .trim();
         
     } catch (error) {

--- a/logs/test-fail-footnote-popover.log
+++ b/logs/test-fail-footnote-popover.log
@@ -1,0 +1,190 @@
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.65 seconds (32.6ms each, v3.1.2)
+[32m✔ archive nav exposes child counts [90m(3655.3812ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.62 seconds (32.3ms each, v3.1.2)
+[32m✔ layout exposes build timestamp [90m(3623.807393ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.08 seconds (27.5ms each, v3.1.2)
+[32m✔ code blocks expose copy control [90m(3248.815054ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.25 seconds (29.0ms each, v3.1.2)
+[32m✔ collection pages expose section metadata [90m(3253.852166ms)[39m[39m
+[32m✔ concept map JSON-LD export generates @context and @graph [90m(2.467889ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.37 seconds (30.1ms each, v3.1.2)
+[32m✔ feed exposes build metadata [90m(3375.401009ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.53 seconds (31.6ms each, v3.1.2)
+[32m✔ home page header includes primary nav landmark [90m(3536.688132ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 2.91 seconds (26.0ms each, v3.1.2)
+[31m✖ homepage lists latest entries per section [90m(3022.38814ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 2.95 seconds (26.3ms each, v3.1.2)
+[32m✔ homepage hero and work filters [90m(3154.330929ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 7.36 seconds (65.7ms each, v3.1.2)
+[32m✔ transformed images have slugified filenames [90m(7361.720787ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 7.51 seconds (67.0ms each, v3.1.2)
+[32m✔ logo image transforms to avif and webp [90m(7635.683142ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 5.00 seconds (44.7ms each, v3.1.2)
+[32m✔ markdown headings include anchor ids [90m(5013.419957ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 4.77 seconds (42.6ms each, v3.1.2)
+[32m✔ monsters hub lists products and cross-links product and character pages [90m(4776.663052ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.45 seconds (30.8ms each, v3.1.2)
+[32m✔ main nav marks current page and is labelled [90m(3447.958513ms)[39m[39m
+[32m✔ navigation items are sequentially ordered [90m(1.162646ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.36 seconds (30.0ms each, v3.1.2)
+[32m✔ buildLean sets env and output directory [90m(3364.521194ms)[39m[39m
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink (/archives/collectables/designer-toys/pop-mart/the-monsters/characters/{{ c.data.slug }}/) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[node-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[@photogabble/wikilinks] WARNING Wikilink ([[bracketed-handle]]) found pointing to to non-existent page in:
+	- ./src/content/sparks/vapor-linked-governance.md
+[11ty] Copied 77 Wrote 112 files in 3.45 seconds (30.8ms each, v3.1.2)
+[32m✔ spark listings reveal status text [90m(3450.385947ms)[39m[39m
+[32m✔ docs:links reports no broken links [90m(1310.323194ms)[39m[39m
+[32m✔ package-lock.json defines lockfileVersion [90m(6.698055ms)[39m[39m
+[32m✔ devDependencies omit @vscode/ripgrep [90m(1.222701ms)[39m[39m
+[32m✔ prepare-docs avoids ripgrep install [90m(0.166041ms)[39m[39m
+[32m✔ time to chill includes size with height in cm [90m(1.146263ms)[39m[39m
+[32m✔ time to chill height is positive [90m(0.146693ms)[39m[39m
+[32m✔ GitHub workflows use latest action versions [90m(2.131423ms)[39m[39m
+[34mℹ tests 24[39m
+[34mℹ suites 0[39m
+[34mℹ pass 23[39m
+[34mℹ fail 1[39m
+[34mℹ cancelled 0[39m
+[34mℹ skipped 0[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms 29453.494866[39m
+
+[31m✖ failing tests:[39m
+
+test at test/integration/homepage-latest.spec.mjs:8:1
+[31m✖ homepage lists latest entries per section [90m(3022.38814ms)[39m[39m
+  TypeError [Error]: Cannot read properties of undefined (reading 'closest')
+      at file:///workspace/effusion-labs/test/integration/homepage-latest.spec.mjs:15:21
+      at Array.forEach (<anonymous>)
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage-latest.spec.mjs:13:12)
+      at async Test.run (node:internal/test_runner/test:1054:7)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)
+Executed 21 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.65% ( 1131/1336 )
+Branches     : 79.91% ( 183/229 )
+Functions    : 75.3% ( 61/81 )
+Lines        : 84.65% ( 1131/1336 )
+================================================================================

--- a/src/styles/app.tailwind.css
+++ b/src/styles/app.tailwind.css
@@ -55,7 +55,8 @@
 
   .annotation-popup {
     @apply absolute -translate-x-1/2 left-1/2 top-7 z-50 max-w-sm rounded-xl p-4 text-sm leading-relaxed
-           border shadow-xl opacity-0 pointer-events-none transition-all duration-200 ease-in-out translate-y-1;
+           border shadow-xl opacity-0 pointer-events-none transition-all duration-200 ease-in-out translate-y-1
+           text-left overflow-y-auto max-h-72 block;
     background-color: hsl(var(--b1)/.95);
     backdrop-filter: blur(6px);
     border-color: hsl(var(--bc)/.12);
@@ -85,7 +86,7 @@
   }
 
   @media (max-width:640px){
-    .annotation-popup { @apply fixed inset-x-4 bottom-4 mx-auto translate-x-0 transform-none max-w-[90vw]; }
+    .annotation-popup { @apply fixed inset-x-4 bottom-4 mx-auto translate-x-0 transform-none max-w-[90vw] max-h-[70vh]; }
   }
 }
 

--- a/test/unit/footnote-popover.test.mjs
+++ b/test/unit/footnote-popover.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import MarkdownIt from 'markdown-it';
+import markdownItFootnote from 'markdown-it-footnote';
+import { applyMarkdownExtensions } from '../../lib/markdown/index.js';
+import { JSDOM } from 'jsdom';
+
+test('footnote popover separates source line', () => {
+  const md = applyMarkdownExtensions(new MarkdownIt().use(markdownItFootnote));
+  const input = 'Reference[^1]\n\n[^1]: Footnote text\n> Source: [Example](https://example.com)';
+  const html = md.render(input);
+  const dom = new JSDOM(html);
+  const popup = dom.window.document.querySelector('.annotation-popup');
+  assert.ok(popup, 'popover exists');
+  const source = popup.querySelector('.footnote-source');
+  assert.ok(source, 'source element exists');
+  assert.ok(source.textContent.trim().startsWith('Source:'), 'source text starts with label');
+  const link = source.querySelector('a');
+  assert.ok(link, 'source contains a link');
+  assert.notStrictEqual(source.previousElementSibling, null, 'source is separated from previous content');
+});


### PR DESCRIPTION
## Summary
- ensure `Source:` lines in footnotes render on their own line inside popovers
- expand popover container styling for better desktop/mobile readability
- add regression test for footnote popover source separation

## Testing
- `npm run test:all` *(fails: homepage lists latest entries per section - Cannot read properties of undefined (reading 'closest'))*

------
https://chatgpt.com/codex/tasks/task_e_68a03a6319ac83308c397b2db00c4852