### PR TITLE
feat: scaffold MSCHF overlay with seeded grid and crosshair

### DIFF
--- a/docs/knowledge/mschf-overlay-test-green.log
+++ b/docs/knowledge/mschf-overlay-test-green.log
@@ -1,0 +1,147 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.68 seconds (41.4ms each, v3.1.2)
+✔ archive nav exposes child counts (4704.818064ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.69 seconds (41.5ms each, v3.1.2)
+✔ layout exposes build timestamp (4709.500763ms)
+[11ty] Copied 78 Wrote 113 files in 3.91 seconds (34.6ms each, v3.1.2)
+✔ code blocks expose copy control (4153.982901ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.47 seconds (39.6ms each, v3.1.2)
+✔ collection pages expose section metadata (4492.430107ms)
+✔ concept map JSON-LD export generates @context and @graph (3.94531ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.82 seconds (42.7ms each, v3.1.2)
+✔ feed exposes build metadata (4842.668296ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.57 seconds (40.4ms each, v3.1.2)
+✔ home page header includes primary nav landmark (4589.557868ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 3.87 seconds (34.3ms each, v3.1.2)
+✖ homepage work list mixes types (4121.897938ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 3.93 seconds (34.7ms each, v3.1.2)
+✔ homepage hero and work filters (4237.67818ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.53 seconds (40.1ms each, v3.1.2)
+✔ markdown headings include anchor ids (4550.974868ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.51 seconds (39.9ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (4532.726329ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 3.89 seconds (34.4ms each, v3.1.2)
+✔ overlay root exists and carries defaults (4126.139271ms)
+✔ seed generation modes (2.648546ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.54 seconds (40.2ms each, v3.1.2)
+✔ main nav marks current page and is labelled (4560.488418ms)
+✔ navigation items are sequentially ordered (1.580542ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.54 seconds (40.2ms each, v3.1.2)
+✔ buildLean sets env and output directory (4564.854869ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.63 seconds (41.0ms each, v3.1.2)
+✔ spark listings reveal status text (4653.149612ms)
+[11ty] Copied 78 Wrote 113 files in 4.46 seconds (39.4ms each, v3.1.2)
+✔ wikilinks ignore templated paths (4477.020411ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 78 Wrote 113 files in 4.32 seconds (38.2ms each, v3.1.2)
+✖ work pages build and latest redirects (4347.070386ms)
+✔ deploy workflow does not trigger on pull_request (1.946324ms)
+✔ build job runs only on push events (0.302639ms)
+✔ defines improved background colors (1.983977ms)
+✔ text contrast meets WCAG AA (0.809668ms)
+✔ tailwind exposes readable fonts (1.401473ms)
+✔ includes fluid type scale tokens (0.256234ms)
+✔ docs:links reports no broken links (1517.697103ms)
+✔ package-lock.json defines lockfileVersion (7.695362ms)
+✔ projects computed picks latest entries by date (3.306231ms)
+✔ keepalive emits heartbeat to stderr (6414.369793ms)
+✔ keepalive ignores first SIGINT (417.67056ms)
+✔ gateway reads SOLVER_URL from environment (1.984445ms)
+✔ gateway retains default solver URL (0.300732ms)
+✔ external link renders with arrow and class (16.529028ms)
+✔ internal link keeps text without external markers (2.390913ms)
+✔ external link starting with arrow does not duplicate (7.588942ms)
+✔ devDependencies omit @vscode/ripgrep (1.536617ms)
+✔ prepare-docs avoids ripgrep install (0.25058ms)
+✔ merges tag-like metadata into unified tags and categories (2.96806ms)
+✔ deduplicates tag values (0.294027ms)
+✔ categories returns empty array when spark_type absent (0.210763ms)
+✔ time to chill includes size with height in cm (1.846371ms)
+✔ time to chill height is positive (0.240441ms)
+✔ filterDeadLinks removes templated links (3.129175ms)
+✔ result has no templated links (0.440467ms)
+✔ filterDeadLinks does not mutate input (0.373392ms)
+✔ GitHub workflows use latest action versions (2.754027ms)
+ℹ tests 46
+ℹ suites 0
+ℹ pass 44
+ℹ fail 2
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 40055.643228
+
+✖ failing tests:
+
+test at test/integration/homepage-latest.spec.mjs:8:1
+✖ homepage work list mixes types (4121.897938ms)
+  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
+  
+    assert(types.has(t))
+  
+      at file:///workspace/effusion-labs/test/integration/homepage-latest.spec.mjs:15:53
+      at Array.forEach (<anonymous>)
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage-latest.spec.mjs:15:40)
+      at async Test.run (node:internal/test_runner/test:1054:7)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '=='
+  }
+
+test at test/integration/work-pages.spec.mjs:7:1
+✖ work pages build and latest redirects (4347.070386ms)
+  AssertionError [ERR_ASSERTION]: work/drop/index.html missing
+      at file:///workspace/effusion-labs/test/integration/work-pages.spec.mjs:17:5
+      at Array.forEach (<anonymous>)
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/work-pages.spec.mjs:16:9)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async Test.run (node:internal/test_runner/test:1054:7)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
+    generatedMessage: false,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '=='
+  }
+Executed 30 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.5% ( 1282/1517 )
+Branches     : 79.92% ( 215/269 )
+Functions    : 75.82% ( 69/91 )
+Lines        : 84.5% ( 1282/1517 )
+================================================================================

--- a/docs/knowledge/mschf-overlay-test-red.log
+++ b/docs/knowledge/mschf-overlay-test-red.log
@@ -1,0 +1,164 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs --all
+
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.76 seconds (42.1ms each, v3.1.2)
+✔ archive nav exposes child counts (4779.225364ms)
+[11ty] Copied 77 Wrote 113 files in 4.71 seconds (41.7ms each, v3.1.2)
+✔ layout exposes build timestamp (4736.196316ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.06 seconds (36.0ms each, v3.1.2)
+✔ code blocks expose copy control (4364.290471ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 5.12 seconds (45.3ms each, v3.1.2)
+✔ collection pages expose section metadata (5144.016438ms)
+✔ concept map JSON-LD export generates @context and @graph (4.741159ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.82 seconds (42.7ms each, v3.1.2)
+✔ feed exposes build metadata (4840.545619ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.99 seconds (44.2ms each, v3.1.2)
+✔ home page header includes primary nav landmark (5014.1153ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.00 seconds (35.4ms each, v3.1.2)
+✖ homepage work list mixes types (4218.545835ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 3.97 seconds (35.1ms each, v3.1.2)
+✔ homepage hero and work filters (4218.413491ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.79 seconds (42.4ms each, v3.1.2)
+✔ markdown headings include anchor ids (4806.214265ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.64 seconds (41.1ms each, v3.1.2)
+✔ monsters hub lists products and cross-links product and character pages (4662.317398ms)
+node:internal/modules/esm/resolve:274
+    throw new ERR_MODULE_NOT_FOUND(
+          ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/effusion-labs/lib/mschf-seed.mjs' imported from /workspace/effusion-labs/test/integration/mschf-overlay.spec.mjs
+    at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+    at moduleResolve (node:internal/modules/esm/resolve:859:10)
+    at defaultResolve (node:internal/modules/esm/resolve:983:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
+    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
+  code: 'ERR_MODULE_NOT_FOUND',
+  url: 'file:///workspace/effusion-labs/lib/mschf-seed.mjs'
+}
+
+Node.js v22.18.0
+✖ test/integration/mschf-overlay.spec.mjs (604.304889ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.81 seconds (42.6ms each, v3.1.2)
+✔ main nav marks current page and is labelled (4835.7619ms)
+✔ navigation items are sequentially ordered (2.026509ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.75 seconds (42.0ms each, v3.1.2)
+✔ buildLean sets env and output directory (4767.6928ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.53 seconds (40.1ms each, v3.1.2)
+✔ spark listings reveal status text (4534.784378ms)
+[11ty] Copied 77 Wrote 113 files in 4.51 seconds (39.9ms each, v3.1.2)
+✔ wikilinks ignore templated paths (4519.605093ms)
+[@photogabble/wikilinks] WARNING Wikilink ([[missing-node]]) found pointing to to non-existent page in:
+	- ./src/test/wikilinks-ignore.md
+[11ty] Copied 77 Wrote 113 files in 4.65 seconds (41.2ms each, v3.1.2)
+✖ work pages build and latest redirects (4662.067659ms)
+✔ deploy workflow does not trigger on pull_request (1.703612ms)
+✔ build job runs only on push events (0.286843ms)
+✔ defines improved background colors (2.043121ms)
+✔ text contrast meets WCAG AA (0.821162ms)
+✔ tailwind exposes readable fonts (0.152454ms)
+✔ includes fluid type scale tokens (0.180081ms)
+✔ docs:links reports no broken links (1632.522656ms)
+✔ package-lock.json defines lockfileVersion (10.372721ms)
+✔ projects computed picks latest entries by date (2.999265ms)
+✔ keepalive emits heartbeat to stderr (6411.995741ms)
+✔ keepalive ignores first SIGINT (442.843271ms)
+✔ gateway reads SOLVER_URL from environment (3.000152ms)
+✔ gateway retains default solver URL (0.204195ms)
+✔ external link renders with arrow and class (18.219002ms)
+✔ internal link keeps text without external markers (2.439532ms)
+✔ external link starting with arrow does not duplicate (4.750007ms)
+✔ devDependencies omit @vscode/ripgrep (1.490911ms)
+✔ prepare-docs avoids ripgrep install (0.245973ms)
+✔ merges tag-like metadata into unified tags and categories (2.896847ms)
+✔ deduplicates tag values (0.254826ms)
+✔ categories returns empty array when spark_type absent (0.14873ms)
+✔ time to chill includes size with height in cm (1.705382ms)
+✔ time to chill height is positive (0.249595ms)
+✔ filterDeadLinks removes templated links (3.159267ms)
+✔ result has no templated links (0.342061ms)
+✔ filterDeadLinks does not mutate input (9.074268ms)
+✔ GitHub workflows use latest action versions (2.485475ms)
+ℹ tests 45
+ℹ suites 0
+ℹ pass 42
+ℹ fail 3
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 40794.907967
+
+✖ failing tests:
+
+test at test/integration/homepage-latest.spec.mjs:8:1
+✖ homepage work list mixes types (4218.545835ms)
+  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
+  
+    assert(types.has(t))
+  
+      at file:///workspace/effusion-labs/test/integration/homepage-latest.spec.mjs:15:53
+      at Array.forEach (<anonymous>)
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/homepage-latest.spec.mjs:15:40)
+      at async Test.run (node:internal/test_runner/test:1054:7)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '=='
+  }
+
+test at test/integration/mschf-overlay.spec.mjs:1:1
+✖ test/integration/mschf-overlay.spec.mjs (604.304889ms)
+  'test failed'
+
+test at test/integration/work-pages.spec.mjs:7:1
+✖ work pages build and latest redirects (4662.067659ms)
+  AssertionError [ERR_ASSERTION]: work/drop/index.html missing
+      at file:///workspace/effusion-labs/test/integration/work-pages.spec.mjs:17:5
+      at Array.forEach (<anonymous>)
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/integration/work-pages.spec.mjs:16:9)
+      at async Test.run (node:internal/test_runner/test:1054:7)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
+    generatedMessage: false,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '=='
+  }
+Executed 30 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.38% ( 1259/1492 )
+Branches     : 79.61% ( 207/260 )
+Functions    : 76.13% ( 67/88 )
+Lines        : 84.38% ( 1259/1492 )
+================================================================================

--- a/docs/reports/mschf-overlay-continue.md
+++ b/docs/reports/mschf-overlay-continue.md
@@ -1,0 +1,15 @@
+# mschf-overlay Continuation
+
+## Context Recap
+- Overlay root and seed engine implemented with grid and crosshair modules.
+
+## Outstanding Items
+1. Expand modules (stickers, stamp, halftone).
+2. Integrate scroll-driven animations and Motion fallback.
+
+## Execution Strategy
+- Extend the overlay engine with additional modular layers driven by seeded RNG.
+- Add CSS scroll-driven effects with Motion-based fallbacks respecting prefers-reduced-motion.
+
+## Trigger Command
+`npm test -- --all`

--- a/docs/reports/mschf-overlay-ledger.md
+++ b/docs/reports/mschf-overlay-ledger.md
@@ -1,0 +1,13 @@
+# mschf-overlay Ledger (1/1)
+
+## Criteria & Proofs
+- Failing test before implementation (`docs/knowledge/mschf-overlay-test-red.log`, sha256: 7cd1f3e433511ada4bfce5d87e24018bbe26923bc7846aba81d95749077a566b).
+- Passing test after adding overlay engine (`docs/knowledge/mschf-overlay-test-green.log`, sha256: ec46ae20c749930bb8aff0cc95ad79224dde24b658a7e3ad3acf9f9789647af6).
+
+## Delta Queue
+1. Expand modules (stickers, stamp, halftone).
+2. Integrate scroll-driven animations and Motion fallback.
+
+## Rollback
+- Last safe SHA: 63b2ae7
+- `git reset --hard 63b2ae7`

--- a/docs/ux/mschf-overlay.md
+++ b/docs/ux/mschf-overlay.md
@@ -1,0 +1,34 @@
+# MSCHF Overlay
+
+The MSCHF overlay decorates pages with seeded decals and grid textures while keeping content accessible.
+
+## Controls
+
+Attach attributes to the `#page-shell` wrapper:
+
+| Attribute | Values | Default | Description |
+| --- | --- | --- | --- |
+| `data-mschf` | `on` \| `off` \| `auto` | `auto` | Enable overlay or force disable. |
+| `data-mschf-intensity` | `lite` \| `loud` | `lite` | Governs element counts and probabilities. |
+| `data-mschf-seed-mode` | `page` \| `session` | `page` | Ephemeral seed per load or stable for a tab session. |
+
+Use `localStorage.setItem('mschf:off','1')` to opt out persistently.
+
+## Modules
+
+- **Faint Grid** – low-opacity radial grid, 35% chance when `loud`.
+- **Crosshair** – centered ring and axes; 50% chance (`lite`) or 60% (`loud`).
+
+## Seeds
+
+`?mschf-seed=<n>` freezes the composition. Without a forced seed, `page` mode generates a new value for each load; `session` mode stores the seed in `sessionStorage`.
+
+## Contracts
+
+- Overlay elements are `aria-hidden="true"` and `pointer-events:none`.
+- Respects `prefers-reduced-motion`; no animation yet.
+- Overlay markup sits below interactive UI.
+
+## Adding Zones
+
+Decorate sections by marking them with `data-mschf-zone`. Future modules can read these markers to inject decals near the zone.

--- a/lib/mschf-seed.mjs
+++ b/lib/mschf-seed.mjs
@@ -1,0 +1,25 @@
+export function computeSeed(mode = 'page', forced, storage) {
+  if (forced) return String(forced);
+  if (mode === 'session' && storage) {
+    const existing = storage.getItem ? storage.getItem('mschfSeed') : undefined;
+    if (existing) return existing;
+    const newSeed = randomInt();
+    if (storage.setItem) storage.setItem('mschfSeed', newSeed);
+    return newSeed;
+  }
+  return randomInt();
+}
+
+function randomInt() {
+  return crypto.getRandomValues(new Uint32Array(1))[0].toString();
+}
+
+export function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function() {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ t >>> 15, t | 1);
+    r ^= r + Math.imul(r ^ r >>> 7, r | 61);
+    return ((r ^ r >>> 14) >>> 0) / 4294967296;
+  };
+}

--- a/src/index.njk
+++ b/src/index.njk
@@ -4,12 +4,17 @@ metaDisable: true
 showTitle: false
 ---
 
-{% include "components/hero.njk" %}
+<div id="page-shell" data-mschf="auto" data-mschf-intensity="lite" data-mschf-seed-mode="page">
+  <div id="mschf-overlay-root" aria-hidden="true"></div>
 
-{% include "components/map-cta.njk" %}
+  {% include "components/hero.njk" %}
 
-<main class="mx-auto max-w-screen-xl px-6 sm:px-8 space-y-16">
-  {% include "components/work-feed.njk" %}
-</main>
+  {% include "components/map-cta.njk" %}
 
-<script src="/assets/js/work-filters.js" defer></script>
+  <main class="mx-auto max-w-screen-xl px-6 sm:px-8 space-y-16">
+    {% include "components/work-feed.njk" %}
+  </main>
+
+  <script src="/assets/js/work-filters.js" defer></script>
+  <script type="module" src="/assets/js/mschf-overlay.js" defer></script>
+</div>

--- a/src/scripts/mschf-overlay.js
+++ b/src/scripts/mschf-overlay.js
@@ -1,0 +1,65 @@
+function computeSeed(mode = 'page', forced, storage) {
+  if (forced) return String(forced);
+  if (mode === 'session' && storage) {
+    const existing = storage.getItem('mschfSeed');
+    if (existing) return existing;
+    const newSeed = randomInt();
+    storage.setItem('mschfSeed', newSeed);
+    return newSeed;
+  }
+  return randomInt();
+}
+
+function randomInt() {
+  return crypto.getRandomValues(new Uint32Array(1))[0].toString();
+}
+
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function() {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ t >>> 15, t | 1);
+    r ^= r + Math.imul(r ^ r >>> 7, r | 61);
+    return ((r ^ r >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+function init() {
+  const shell = document.getElementById('page-shell');
+  if (!shell) return;
+  if (shell.dataset.mschf === 'off') return;
+  if (localStorage.getItem('mschf:off')) return;
+
+  const intensity = shell.dataset.mschfIntensity || 'lite';
+  const mode = shell.dataset.mschfSeedMode || 'page';
+  const forced = new URL(window.location.href).searchParams.get('mschf-seed');
+  const seed = computeSeed(mode, forced, window.sessionStorage);
+  const rand = mulberry32(parseInt(seed, 10) || 0);
+
+  const root = document.getElementById('mschf-overlay-root');
+  if (!root) return;
+  root.innerHTML = '';
+  root.style.pointerEvents = 'none';
+  root.style.position = 'fixed';
+  root.style.inset = '0';
+  root.style.zIndex = '10';
+  root.setAttribute('aria-hidden', 'true');
+
+  if (intensity === 'loud' && rand() < 0.35) {
+    const grid = document.createElement('div');
+    grid.className = 'mschf-grid';
+    root.appendChild(grid);
+  }
+
+  const crossProb = intensity === 'loud' ? 0.6 : 0.5;
+  if (rand() < crossProb) {
+    const cross = document.createElement('div');
+    cross.className = 'mschf-crosshair';
+    cross.innerHTML = '<div class="mschf-crosshair-ring"></div>' +
+      '<div class="mschf-crosshair-v"></div>' +
+      '<div class="mschf-crosshair-h"></div>';
+    root.appendChild(cross);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/src/styles/app.tailwind.css
+++ b/src/styles/app.tailwind.css
@@ -5,6 +5,7 @@
 @plugin "@tailwindcss/typography";
 @import "prismjs/themes/prism-tomorrow.css";
 @import "./home.css";
+@import "./mschf-overlay.css";
 
 @layer base {
   body { @apply font-body text-[var(--step-0)] leading-[1.5]; }

--- a/src/styles/mschf-overlay.css
+++ b/src/styles/mschf-overlay.css
@@ -1,0 +1,50 @@
+#mschf-overlay-root {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+}
+
+.mschf-grid {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle at 1px 1px, currentColor 1px, transparent 1.5px);
+  background-size: 18px 18px;
+  opacity: 0.08;
+  mix-blend-mode: difference;
+}
+
+.mschf-crosshair {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 38px;
+  height: 38px;
+  transform: translate(-50%, -50%);
+  opacity: 0.25;
+}
+.mschf-crosshair-ring {
+  position: absolute;
+  inset: 0;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+.mschf-crosshair-v,
+.mschf-crosshair-h {
+  position: absolute;
+  background: currentColor;
+}
+.mschf-crosshair-v {
+  left: 50%;
+  top: 0;
+  width: 1px;
+  height: 100%;
+  transform: translateX(-50%);
+}
+.mschf-crosshair-h {
+  top: 50%;
+  left: 0;
+  height: 1px;
+  width: 100%;
+  transform: translateY(-50%);
+}

--- a/test/integration/mschf-overlay.spec.mjs
+++ b/test/integration/mschf-overlay.spec.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+import { buildLean } from '../helpers/eleventy-env.mjs';
+import { computeSeed } from '../../lib/mschf-seed.mjs';
+
+test('overlay root exists and carries defaults', async () => {
+  const outDir = await buildLean('homepage');
+  const html = readFileSync(path.join(outDir, 'index.html'), 'utf8');
+  const doc = new JSDOM(html).window.document;
+
+  const shell = doc.querySelector('#page-shell');
+  assert(shell);
+  assert.equal(shell.dataset.mschf, 'auto');
+  assert.equal(shell.dataset.mschfIntensity, 'lite');
+  assert.equal(shell.dataset.mschfSeedMode, 'page');
+
+  const first = shell.firstElementChild;
+  assert(first);
+  assert.equal(first.id, 'mschf-overlay-root');
+  assert.equal(first.getAttribute('aria-hidden'), 'true');
+});
+
+test('seed generation modes', () => {
+  const s1 = computeSeed('page');
+  const s2 = computeSeed('page');
+  assert.notEqual(s1, s2);
+
+  const forced = computeSeed('page', '123');
+  assert.equal(forced, '123');
+
+  const store = { value: null, getItem(){ return this.value; }, setItem(_, v){ this.value = v; } };
+  const session1 = computeSeed('session', undefined, store);
+  const session2 = computeSeed('session', undefined, store);
+  assert.equal(session1, session2);
+});


### PR DESCRIPTION
## Summary
- add page-level MSCHF overlay root with data controls and seed engine
- introduce seeded grid and crosshair modules with per-load randomness
- document MSCHF overlay controls and seed behaviors

## Testing
- `npm test -- --all` *(fails: homepage work list mixes types, work pages build and latest redirects)*
- `node --test test/integration/mschf-overlay.spec.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a042975ac4833080761936182c5257