### PR TITLE
Ensure homepage feed covers all content types

### DIFF
--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -61,10 +61,10 @@
       </div>
     {% endif %}
 
-    {# build meta #}
-    <div class="mt-10 border-t border-current/20 pt-2 font-mono text-[11px] opacity-70">
-      {{ build.branch }} · {{ build.hash }} · {{ build.builtAtIso }}
-    </div>
+  {# build meta #}
+  <div class="mt-10 border-t border-current/20 pt-2 font-mono text-[11px] opacity-70">
+    {{ build.branch }} · {{ build.hash }} · {{ build.builtAtIso }}
+  </div>
   </div>
 
   {# MSCHF mode — optional decals & micro-chaos #}
@@ -80,4 +80,5 @@
       </span>
     </div>
   {% endif %}
+  <span class="lab-seal" aria-hidden="true"></span>
 </header>

--- a/src/index.11tydata.js
+++ b/src/index.11tydata.js
@@ -1,6 +1,39 @@
 module.exports = {
+  title: "Experimental R&D you can actually use.",
+  lede: "Prototypes, systems, and notes from the lab.",
+  ctas: [
+    { href: "/work/latest", label: "See the latest drop" },
+    { href: "/work", label: "Explore the lab", kind: "ghost" }
+  ],
+  tiles: [
+    { k: "project", h: "Latest Project", s: "Try the newest build", url: "/work/latest", featured: true },
+    { k: "concept", h: "Core Concepts", s: "Structural notes and models", url: "/work" },
+    { k: "spark", h: "Fresh Sparks", s: "Quick experiments and ideas", url: "/work" }
+  ],
   eleventyComputed: {
-    work: data => (data.collections.work || []).slice(0, 9),
+    work: data => {
+      const col = data.collections.work || [];
+      const required = ['project','concept','spark','meta'];
+      const result = [];
+      const usedUrls = new Set();
+      // ensure at least one of each required type
+      for (const type of required) {
+        const item = col.find(i => i.type === type);
+        if (item) {
+          result.push(item);
+          usedUrls.add(item.url);
+        }
+      }
+      // fill remaining slots with most recent items not already used
+      for (const item of col) {
+        if (result.length >= 9) break;
+        if (!usedUrls.has(item.url)) {
+          result.push(item);
+          usedUrls.add(item.url);
+        }
+      }
+      return result;
+    },
     projects: data =>
       (data.collections.projects || [])
         .sort((a, b) => b.date - a.date)

--- a/src/work/drop.11ty.js
+++ b/src/work/drop.11ty.js
@@ -1,0 +1,12 @@
+exports.data = {
+  layout: "layouts/redirect.njk",
+  permalink: "/work/drop/index.html",
+  eleventyComputed: {
+    redirect: data => {
+      const w = data.collections.work && data.collections.work[0];
+      return w ? w.url : '/work/';
+    }
+  }
+};
+
+exports.render = () => '';

--- a/test/integration/homepage-latest.spec.mjs
+++ b/test/integration/homepage-latest.spec.mjs
@@ -12,5 +12,8 @@ test('homepage work list mixes types', async () => {
   const items = Array.from(doc.querySelectorAll('#work-list > li'));
   assert(items.length >= 6 && items.length <= 9);
   const types = new Set(items.map(li => li.dataset.type));
-  ['project','concept','spark','meta'].forEach(t => assert(types.has(t)));
+  const valid = ['project','concept','spark','meta'];
+  valid.forEach(t => assert(types.has(t)));
+  // Property: each item tagged with a valid type
+  items.forEach(li => assert(valid.includes(li.dataset.type)));
 });

--- a/test/integration/homepage.spec.mjs
+++ b/test/integration/homepage.spec.mjs
@@ -4,6 +4,7 @@ import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { buildLean } from '../helpers/eleventy-env.mjs';
+import branding from '../../src/_data/branding.js';
 
 function walk(dir, files = []) {
   for (const entry of readdirSync(dir)) {
@@ -46,18 +47,6 @@ test('homepage hero and work filters', async () => {
   assert.equal(logo.getAttribute('sizes'), branding.logoSizes);
   assert.equal(logo.getAttribute('loading'), 'eager');
   assert.equal(logo.getAttribute('fetchpriority'), 'high');
-
-  // Map CTA
-  const mapHeading = Array.from(doc.querySelectorAll('h2')).find(h => /Interactive Concept Map/i.test(h.textContent));
-  assert(mapHeading);
-  const mapSection = mapHeading.closest('section');
-  assert(mapSection);
-  const mapLink = Array.from(mapSection.querySelectorAll('a')).find(a => /Launch the Map/i.test(a.textContent));
-  assert(mapLink);
-  assert.equal(mapLink.getAttribute('href'), '/map/');
-  // Property: exactly one link within the map section
-  assert.equal(Array.from(mapSection.querySelectorAll('a[href="/map/"]')).length, 1);
-
 
   // Map CTA
   const mapHeading = Array.from(doc.querySelectorAll('h2')).find(h => /Interactive Concept Map/i.test(h.textContent));

--- a/test/integration/logo-image.spec.mjs
+++ b/test/integration/logo-image.spec.mjs
@@ -8,8 +8,7 @@ import branding from '../../src/_data/branding.js';
 
 test('logo image transforms to avif and webp', withImages(async () => {
   const outDir = await buildLean('logo-image');
-  const imageDir = path.join('_site', 'assets', 'images');
-  rmSync(imageDir, { recursive: true, force: true });
+  const imageDir = path.join(outDir, 'assets', 'images');
   const html = readFileSync(path.join(outDir, 'index.html'), 'utf8');
   const dom = new JSDOM(html);
   const picture = dom.window.document.querySelector('picture');


### PR DESCRIPTION
## Summary
- guarantee homepage work feed includes project, concept, spark, and meta entries
- add lab seal flourish and hero metadata
- fix integration tests and logo image build path

## Testing
- `npm run test:guard`
- `npm test -- --all`

------
https://chatgpt.com/codex/tasks/task_e_68a045f8f1688330b3721fd0df40da8c