### PR TITLE
Surface provenance metadata for Pop Mart Monsters products

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates
 ## ✨ Key Features
 - Home page presents a multi-column Work feed with filter toolbar, interactive concept map CTA, and animated lab seal flourish.
 - Dedicated `/work` section aggregates projects, concepts, and sparks with category filters and deep links.
+- Product pages now surface provenance metadata sourced from bundled JSONL files.
 ### npm Scripts
 - `npm run dev` – start Eleventy with live reload.
 - `npm run build` – compile the production site to `_site/`.

--- a/docs/reports/pop-mart-provenance-continue.md
+++ b/docs/reports/pop-mart-provenance-continue.md
@@ -1,0 +1,13 @@
+# pop-mart-provenance continuation
+
+## Context Recap
+Provenance metadata from JSONL files is now surfaced on product pages.
+
+## Outstanding Items
+- None.
+
+## Execution Strategy
+N/A
+
+## Trigger Command
+`node --test test/unit/provenance-filter.test.mjs`

--- a/docs/reports/pop-mart-provenance-ledger.md
+++ b/docs/reports/pop-mart-provenance-ledger.md
@@ -1,0 +1,13 @@
+# pop-mart-provenance ledger
+
+## Criteria
+1. Provenance sources from JSONL files are exposed on product pages.
+
+## Proof
+- `test/unit/provenance-filter.test.mjs` validates parsing of provenance JSONL.
+
+## Index
+1/1
+
+## Rollback
+`git revert 00403fb` # revert refactor commit

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,5 +1,6 @@
 const generateConceptMapJSONLD = require("./concept-map");
 const { DateTime } = require('luxon');
+const path = require('node:path');
 const { ordinalSuffix, readFileCached, webpageToMarkdown } = require('./utils');
 
 const toStr = v => String(v ?? '');
@@ -78,6 +79,29 @@ function shout(str = '') {
 }
 
 /**
+ * Load provenance entries from a JSONL file reference.
+ * @param {string} ref - provenance_ref path stored on product data
+ * @returns {Array<Object>}
+ */
+function provenanceSources(ref = '') {
+  if (typeof ref !== 'string' || ref.trim() === '') return [];
+  const rel = ref.startsWith('/') ? ref.slice(1) : ref;
+  const full = path.join(process.cwd(), 'src', rel);
+  const raw = readFileCached(full);
+  if (raw === null) return [];
+  const lines = raw.trim().split('\n').filter(Boolean);
+  return lines
+    .map(line => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
  * Serialize collection data for graph visualisation.
  * @param {Array<Object>} data - eleventy page objects
  * @returns {string}
@@ -111,4 +135,4 @@ function conceptMapJSONLD(pages = []) {
   return JSON.stringify(generateConceptMapJSONLD(pages));
 }
 
-module.exports = { conceptMapJSONLD, readableDate, htmlDateString, limit, jsonify, readingTime, slugify, truncate, webpageToMarkdown, isNew, shout };
+module.exports = { conceptMapJSONLD, readableDate, htmlDateString, limit, jsonify, readingTime, slugify, truncate, webpageToMarkdown, isNew, shout, provenanceSources };

--- a/logs/provenance-filter-red.log
+++ b/logs/provenance-filter-red.log
@@ -1,0 +1,34 @@
+TAP version 13
+# file:///workspace/effusion-labs/test/unit/provenance-filter.test.mjs:3
+# import { provenanceSources } from '../../lib/filters.js';
+#          ^^^^^^^^^^^^^^^^^
+# SyntaxError: Named export 'provenanceSources' not found. The requested module '../../lib/filters.js' is a CommonJS module, which may not support all module.exports as named exports.
+# CommonJS modules can always be imported via the default export, for example using:
+# import pkg from '../../lib/filters.js';
+# const { provenanceSources } = pkg;
+#     at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)
+#     at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)
+#     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)
+#     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
+# Node.js v22.18.0
+# Subtest: test/unit/provenance-filter.test.mjs
+not ok 1 - test/unit/provenance-filter.test.mjs
+  ---
+  duration_ms: 99.855293
+  type: 'test'
+  location: '/workspace/effusion-labs/test/unit/provenance-filter.test.mjs:1:1'
+  failureType: 'testCodeFailure'
+  exitCode: 1
+  signal: ~
+  error: 'test failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 109.866797

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
@@ -10,3 +10,12 @@ permalink: "/archives/collectables/designer-toys/pop-mart/the-monsters/products/
 <h1 class="text-2xl font-bold mb-2">{{ product.data.product_id }}</h1>
 <p class="mb-4">Form: {{ product.data.form }} | Release: {{ product.data.release_date }}</p>
 {{ badge(product.data.character, "/archives/collectables/designer-toys/pop-mart/the-monsters/characters/" + product.data.character + "/") }}
+{% set sources = product.data.provenance_ref | provenanceSources %}
+{% if sources.length %}
+<h2 class="text-xl font-semibold mt-4 mb-2">Provenance</h2>
+<ul class="list-disc pl-5">
+{% for s in sources %}
+  <li><a href="{{ s.url }}" class="text-blue-600 underline">{{ s.url }}</a> <span class="text-sm text-gray-500">({{ s.retrieved_at }})</span></li>
+{% endfor %}
+</ul>
+{% endif %}

--- a/test/unit/provenance-filter.test.mjs
+++ b/test/unit/provenance-filter.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import filters from '../../lib/filters.js';
+const { provenanceSources } = filters;
+
+const sampleRef = '/content/archives/collectables/designer-toys/pop-mart/the-monsters/provenance/pop-mart--the-monsters--labubu--have-a-seat--blind-box--single--15cm--20240712.jsonl';
+
+test('provenanceSources parses JSONL provenance files', () => {
+  const sources = provenanceSources(sampleRef);
+  assert.ok(Array.isArray(sources), 'returns an array');
+  const first = sources[0] || {};
+  assert.equal(first.url, '/docs/knowledge/sources/the-monsters/seed-article.md');
+});
+
+test('provenanceSources returns [] when file missing', () => {
+  const sources = provenanceSources('/missing/file.jsonl');
+  assert.deepEqual(sources, []);
+});


### PR DESCRIPTION
## Summary
- parse product provenance JSONL files via new `provenanceSources` filter
- render provenance sources on Pop Mart Monsters product pages
- document provenance feature in README

## Testing
- `node --test test/unit/provenance-filter.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a12b927eec8330bd637bb62fb08ef2