### PR TITLE
Add ordinal suffix tests and fix product permalink template

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates
 - `npm run build` – compile the production site to `_site/`.
 - `npm test` – run tests related to changed files.
 - `npm run test:all` – execute the full test suite.
+- `npm run test:guard` – run the test suite with guardrails.
 - `npm run proxy:health` – check the Markdown proxy service.
 - `npm run docs:validate` – verify documentation hashes.
 - `npm run docs:reindex` – rebuild the vendor documentation index.

--- a/docs/knowledge/test-failures.txt
+++ b/docs/knowledge/test-failures.txt
@@ -1,0 +1,1 @@
+Eleventy template error in src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk line 5 column 104: expected variable end.

--- a/docs/reports/tests-green-continue.md
+++ b/docs/reports/tests-green-continue.md
@@ -1,0 +1,10 @@
+# Continuation for tests-green
+
+Recap: Added ordinal suffix tests and attempted to fix template errors.
+Next Steps:
+1. Investigate remaining Eleventy template parsing failures.
+2. Ensure guardrail script outputs logs reliably.
+Trigger Command: npm run test:guard
+Environment: default
+Effort: R3
+Reads: pending

--- a/docs/reports/tests-green-ledger.md
+++ b/docs/reports/tests-green-ledger.md
@@ -1,0 +1,10 @@
+# Ledger for tests-green
+
+- Time: 2025-08-17T23:43:49Z
+- Commits:
+  - test:utils define acceptance + property + contract
+  - ci:tests record failing proofs
+  - feat:products implement fix to green
+  - refactor:utils unify and modernize
+  - docs:tests sync docs with repo state
+- Failing proof: see logs/test.log

--- a/logs/test.log
+++ b/logs/test.log
@@ -1,0 +1,54 @@
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 5, Column 104]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseIf (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:339:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:466:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 78 Wrote 0 files in 3.71 seconds (v3.1.2)
+✖ archive nav exposes child counts (3725.015672ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 5, Column 104]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseIf (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:339:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:466:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 8 Wrote 0 files in 3.52 seconds (v3.1.2)
+✖ layout exposes build timestamp (3543.639622ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 5, Column 104]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseIf (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:339:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:466:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 75 Wrote 0 files in 3.07 seconds (v3.1.2)
+✖ code blocks expose copy control (3083.543393ms)

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
@@ -4,7 +4,7 @@ pagination:
   data: collections.monstersProducts
   size: 1
   alias: product
-permalink: /archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ product.data.product_id }}/index.html
+permalink: "{{ '/archives/collectables/designer-toys/pop-mart/the-monsters/products/' + product.data.product_id + '/index.html' }}"
 ---
 {% from "components/products/SpecSheet.njk" import specSheet %}
 {% from "components/products/MarketTable.njk" import marketTable %}

--- a/test/unit/utils.test.mjs
+++ b/test/unit/utils.test.mjs
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ordinalSuffix } from '../../lib/utils.js';
+
+// Acceptance example: ordinalSuffix returns 'st' for 1
+await test('ordinalSuffix(1) returns st', () => {
+  assert.equal(ordinalSuffix(1), 'st');
+});
+
+// Property: ordinalSuffix outputs a valid suffix for 1..31
+await test('ordinalSuffix emits valid suffix for 1..31', () => {
+  for (const i of Array.from({ length: 31 }, (_, n) => n + 1)) {
+    assert.match(ordinalSuffix(i), /^(st|nd|rd|th)$/);
+  }
+});
+
+// Contract: numbers ending in 11,12,13 use th suffix
+await test('ordinalSuffix handles teens with th', () => {
+  for (const n of [11, 12, 13]) {
+    assert.equal(ordinalSuffix(n), 'th');
+  }
+});


### PR DESCRIPTION
## Summary
- add acceptance tests for ordinalSuffix utility
- fix monsters product template permalink resolution
- document guardrail test command

## Testing
- `node tools/runner.mjs --all` *(fails: TemplateContentRenderError in products.njk)*

------
https://chatgpt.com/codex/tasks/task_e_68a26780e6dc8330813d75705afc7083