### PR TITLE
Handle negative ordinal suffix and document utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates
 - Home page presents a multi-column Work feed with filter toolbar, interactive concept map CTA, and animated lab seal flourish.
 - Dedicated `/work` section aggregates projects, concepts, and sparks with category filters and deep links.
 - Product pages now surface provenance metadata sourced from bundled JSONL files.
+- Utility helpers provide ordinal suffixes and file caching; ordinal suffix now supports negative numbers.
 ### npm Scripts
 - `npm run dev` – start Eleventy with live reload.
 - `npm run build` – compile the production site to `_site/`.

--- a/docs/knowledge/docs-links.md
+++ b/docs/knowledge/docs-links.md
@@ -1,0 +1,8 @@
+## docs links check
+
+Command: `npm run docs:links`
+
+Excerpt:
+```
+14 links checked.
+```

--- a/docs/knowledge/utils-test-green.md
+++ b/docs/knowledge/utils-test-green.md
@@ -1,0 +1,10 @@
+## utils test success
+
+Command: `node --test test/unit/utils.test.mjs`
+
+Excerpt:
+```
+ok 1 - ordinalSuffix handles negative numbers
+ok 2 - ordinalSuffix uses "th" for teens
+ok 3 - readFileCached returns null for nonexistent path
+```

--- a/docs/knowledge/utils-test-red.md
+++ b/docs/knowledge/utils-test-red.md
@@ -1,0 +1,11 @@
+## utils test failure
+
+Command: `npm run test:guard`
+
+Excerpt:
+```
+✖ ordinalSuffix handles negative numbers (3.274455ms)
+AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+
+  'th' !== 'st'
+```

--- a/docs/reports/utils-ordinal-suffix-continue.md
+++ b/docs/reports/utils-ordinal-suffix-continue.md
@@ -1,0 +1,22 @@
+# Continuation: utils-ordinal-suffix
+
+## Recap
+Added targeted unit tests for utility helpers, fixed ordinalSuffix to handle negative numbers, refactored file cache logic, and synchronized documentation.
+
+## Next Steps
+1. Expand utilities test coverage for caching behavior when files change or are deleted.
+2. Integrate utilities module into additional filters to reduce duplication.
+
+## Trigger
+`node --test test/unit/utils.test.mjs`
+
+## Environment
+- Effort: R3
+- Toggles: none
+
+## Reads
+- Files: 20
+- Surfaces: lib, test, docs
+
+## Capture Hashes
+- See ledger for artifact hashes.

--- a/docs/reports/utils-ordinal-suffix-ledger.md
+++ b/docs/reports/utils-ordinal-suffix-ledger.md
@@ -1,0 +1,45 @@
+# Ledger: utils-ordinal-suffix
+
+- Time Anchor: Sun Aug 17 23:39:58 UTC 2025
+- Diffstat:
+```
+README.md                          |    1 +
+docs/knowledge/docs-links.md       |    8 +
+docs/knowledge/utils-test-green.md |   10 +
+docs/knowledge/utils-test-red.md   |   11 +
+lib/utils.js                       |   11 +-
+logs/docs-links.log                |   23 ++
+logs/test-utils-green.log          |   28 +++
+logs/test-utils-red.log            | 1149 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+test/unit/utils.test.mjs           |   24 ++
+9 files changed, 1260 insertions(+), 5 deletions(-)
+```
+- Files Changed: lib/utils.js, test/unit/utils.test.mjs, README.md, docs/knowledge/*.md, logs/*.log
+- Proofs:
+  - Failing: logs/test-utils-red.log
+  - Passing: logs/test-utils-green.log
+  - Docs Links: logs/docs-links.log
+- Acceptance Map:
+  - ordinalSuffix handles negative numbers → test/unit/utils.test.mjs
+  - ordinalSuffix uses "th" for teens → test/unit/utils.test.mjs
+  - readFileCached returns null for nonexistent path → test/unit/utils.test.mjs
+- Commit Graph:
+```
+831acd8 docs:utils sync docs with repo state
+f3d5486 refactor:utils unify and modernize
+acadd71 feat:utils implement fix to green
+121ee95 ci:utils record failing proofs
+eb561b6 test:utils define acceptance + property + contract
+4c160d8 ci(monsters-product-metadata): capture failing green run
+```
+- Artifact Hashes:
+```
+bf69d581d8c1ab6759d748e5f1e4764edf312fbd03212bf708fc7ecfeca8fbc6  logs/test-utils-red.log
+1770bea0f37720506ce01fd46b8c6e31cdb0bc28e29c9e5a7f52da1948cbdae7  logs/test-utils-green.log
+f13671568040182d054b7dce248859d6174f9645b7896219305a2a1c76b4e3e3  logs/docs-links.log
+d7aa5ef97b9d39898820faca3326bc8496148032cea00f7e123d33e60aff18cc  docs/knowledge/utils-test-red.md
+7b79e88918666d21f42c2db9484110a145871fe2e305a2353b0841d44e4cfaac  docs/knowledge/utils-test-green.md
+c1f3f294aab5118fd4b1775399dba5429a1466ea18a2d525ded55f74ad4cf75f  docs/knowledge/docs-links.md
+```
+- Network Route: direct
+- Rollback: git reset --hard 4c160d8236b416e4781000a148c3aae4ac25823b

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,8 +15,9 @@ const fileCache = new Map();
  * @returns {string}
  */
 function ordinalSuffix(n) {
-  if (n % 100 >= 11 && n % 100 <= 13) return 'th';
-  return ['th', 'st', 'nd', 'rd'][n % 10] || 'th';
+  const abs = Math.abs(n);
+  if (abs % 100 >= 11 && abs % 100 <= 13) return 'th';
+  return ['th', 'st', 'nd', 'rd'][abs % 10] || 'th';
 }
 
 /**
@@ -27,13 +28,13 @@ function ordinalSuffix(n) {
  */
 function readFileCached(p) {
   try {
-    const stat = fs.statSync(p);
+    const { mtimeMs } = fs.statSync(p);
     const cached = fileCache.get(p);
-    if (cached && cached.mtimeMs === stat.mtimeMs) {
+    if (cached?.mtimeMs === mtimeMs) {
       return cached.data;
     }
     const data = fs.readFileSync(p, 'utf8');
-    fileCache.set(p, { mtimeMs: stat.mtimeMs, data });
+    fileCache.set(p, { mtimeMs, data });
     return data;
   } catch {
     return null;

--- a/logs/docs-links.log
+++ b/logs/docs-links.log
@@ -1,0 +1,23 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 docs:links
+> markdown-link-check -c link-check.config.json README.md
+
+
+FILE: README.md
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml
+  [✓] ./LICENSE
+  [✓] #-project-overview
+  [✓] #-key-features
+  [✓] #-quickstart
+  [✓] #-project-layout
+  [✓] #-deployment
+  [✓] #-quality-assurance
+  [✓] #-contributing
+  [✓] #-license
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/deploy.yml/badge.svg
+  [/] https://github.com/effusion-labs/effusion-labs/actions/workflows/link-check.yml/badge.svg
+  [✓] https://img.shields.io/badge/license-ISC-blue.svg
+
+  14 links checked.

--- a/logs/test-utils-green.log
+++ b/logs/test-utils-green.log
@@ -1,0 +1,28 @@
+TAP version 13
+# Subtest: ordinalSuffix handles negative numbers
+ok 1 - ordinalSuffix handles negative numbers
+  ---
+  duration_ms: 1.379429
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix uses "th" for teens
+ok 2 - ordinalSuffix uses "th" for teens
+  ---
+  duration_ms: 0.426009
+  type: 'test'
+  ...
+# Subtest: readFileCached returns null for nonexistent path
+ok 3 - readFileCached returns null for nonexistent path
+  ---
+  duration_ms: 0.55632
+  type: 'test'
+  ...
+1..3
+# tests 3
+# suites 0
+# pass 3
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 1076.500089

--- a/logs/test-utils-red.log
+++ b/logs/test-utils-red.log
@@ -1,0 +1,1149 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test:guard
+> bash scripts/test-with-guardrails.sh
+
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 test
+> c8 --reporter=text-summary --reporter=lcov node tools/runner.mjs
+
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 78 Wrote 0 files in 5.95 seconds (v3.1.2)
+✖ archive nav exposes child counts (5954.001227ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 78 Wrote 0 files in 5.79 seconds (v3.1.2)
+✖ layout exposes build timestamp (5795.69677ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 78 Wrote 0 files in 5.26 seconds (v3.1.2)
+✖ code blocks expose copy control (5263.286383ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 78 Wrote 0 files in 5.56 seconds (v3.1.2)
+✖ collection pages expose section metadata (5565.30172ms)
+✔ concept map JSON-LD export generates @context and @graph (7.054345ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 77 Wrote 0 files in 5.59 seconds (v3.1.2)
+✖ feed exposes build metadata (5595.161461ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 75 Wrote 0 files in 5.42 seconds (v3.1.2)
+✖ home page header includes primary nav landmark (5421.714828ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 77 Wrote 0 files in 4.61 seconds (v3.1.2)
+✖ homepage work list mixes types (4617.035191ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 78 Wrote 0 files in 4.73 seconds (v3.1.2)
+✖ homepage hero and work filters (4737.647375ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 12 Wrote 0 files in 4.88 seconds (v3.1.2)
+✖ logo image transforms to avif and webp (4885.622668ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 77 Wrote 0 files in 5.57 seconds (v3.1.2)
+✖ markdown headings include anchor ids (5575.271748ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 75 Wrote 0 files in 5.55 seconds (v3.1.2)
+✖ monsters hub lists products and cross-links product and character pages (5550.910017ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 75 Wrote 0 files in 5.59 seconds (v3.1.2)
+✖ product page exposes full metadata (acceptance) (5597.735661ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Wrote 0 files in 2.99 seconds (v3.1.2)
+✖ rendered prices use ISO code and two decimals (property) (2997.963522ms)
+::notice:: LLM-safe: tests alive @ 2025-08-17T23:38:12.705Z
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Wrote 0 files in 3.12 seconds (v3.1.2)
+✖ table and spec semantics hold (contract) (3124.715046ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Wrote 0 files in 3.36 seconds (v3.1.2)
+✖ markets render as chips when present (acceptance) (3367.890497ms)
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './node_modules/lucide/dist/umd/lucide.min.js'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--best-of-luck--plush--std--20231230--reg-cn.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box--single--20250124.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--pendant--std--17cm--20240712.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--forest-fairy-tale-china--figure--std--20250526--reg-cn.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--flip-with-me--plush--std--40cm--20240712.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/characters/zimomo.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--coca-cola--blind-box-set--sealed--20250124.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box-set--sealed--20241027.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--big-into-energy--blind-box-set--sealed--20250425.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--dress-be-latte--plush--std--20231026.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--exciting-macaron--blind-box--single--20241027.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box--single--15cm--20240712.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--have-a-seat--blind-box-set--sealed--15cm--20240712.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--pendant--std--17cm--20250207.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--happy-halloween-party-sitting-pumpkin--pendant--sitting-pumpkin--20241025.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--hide-and-seek-in-singapore--figure--std--17.5cm--reg-sg.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--good-lucky-to-you-thailand--figure--std--20241220--reg-th.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--lets-checkmate--plush-doll--std--37cm--20250207.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--walk-by-fortune--plush--std--20231229.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-be-fancy-now--plush--std--20240315.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fortune--pendant--std--20241004.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--pronounce-wings-of-fantasy--plush--std--20241004.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--pendant--std--17cm.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--blue-diamond--pendant--std--17cm--20240618.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--wacky-mart-china--figure--std--20250612--reg-cn.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--close-to-sweet-v1--plush--std.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--time-to-chill--plush--std--20221031.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--plush--std--20240308.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--angel-in-clouds-v2--plush--std--58cm--20241025.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--jump-for-joy--plush--std--20230525.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/big-into-energy.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/blue-diamond.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--fall-into-spring--pendant--std--17cm--20240308.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/best-of-luck.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--fall-in-wild--plush-doll--std--40cm--20240712.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/close-to-sweet-v1.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-into-spring.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/coca-cola.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/exciting-macaron.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--magic-of-pumpkin--pendant--std--17cm--20241027.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/forest-fairy-tale-china.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/flip-with-me.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--mokoko--twinkly-fairy-tale--pendant--std--17cm--20241128.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/fall-in-wild.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/dress-be-latte.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/happy-halloween-party-sitting-pumpkin.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/hide-and-seek-in-singapore.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/have-a-seat.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-be-fancy-now.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/lets-checkmate.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/i-found-you-v1.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/jump-for-joy.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fortune.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/pronounce-wings-of-fantasy.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/twinkly-fairy-tale.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/walk-by-fortune.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/time-to-chill.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/magic-of-pumpkin.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/wacky-mart-china.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/good-lucky-to-you-thailand.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--zimomo--i-found-you-v1--plush--std--58cm--20231215.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "rendered prices use ISO code and two decimals (property)" at test/integration/monsters-product-metadata.spec.mjs:43:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/angel-in-clouds-v2.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "table and spec semantics hold (contract)" at test/integration/monsters-product-metadata.spec.mjs:49:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/products/pop-mart--the-monsters--labubu--best-of-luck--plush--std--20231230--reg-cn.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "table and spec semantics hold (contract)" at test/integration/monsters-product-metadata.spec.mjs:49:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/series/angel-in-clouds-v2.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "table and spec semantics hold (contract)" at test/integration/monsters-product-metadata.spec.mjs:49:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/i18n/zh/series/fall-in-wild.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+ℹ Error: Test "table and spec semantics hold (contract)" at test/integration/monsters-product-metadata.spec.mjs:49:1 generated asynchronous activity after the test ended. This activity created the error "TemplatePassthroughManagerCopyError: Having trouble copying './src/content/archives/collectables/designer-toys/pop-mart/the-monsters/i18n/zh/products/pop-mart--the-monsters--labubu--fall-in-wild--plush-doll--std--40cm--20240712.json'" and would have caused the test to fail, but instead triggered an unhandledRejection event.
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 9 Wrote 0 files in 4.81 seconds (v3.1.2)
+✖ overlay root exists and carries defaults (4823.899203ms)
+✔ seed generation modes (5.21366ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 74 Wrote 0 files in 5.79 seconds (v3.1.2)
+✖ main nav marks current page and is labelled (5789.133417ms)
+✔ navigation items are sequentially ordered (1.825504ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 77 Wrote 0 files in 5.74 seconds (v3.1.2)
+✖ buildLean sets env and output directory (5745.111491ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 10 Wrote 0 files in 5.94 seconds (v3.1.2)
+✖ spark listings reveal status text (5943.870016ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 78 Wrote 0 files in 5.50 seconds (v3.1.2)
+✖ wikilinks ignore templated paths (5502.482371ms)
+[11ty] Problem writing Eleventy templates:
+[11ty] 1. Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk (via TemplateContentRenderError)
+[11ty] 2. (./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk) [Line 17, Column 55]
+[11ty]   expected variable end (via Template render error)
+[11ty] 
+[11ty] Original error stack trace: Error: expected variable end
+[11ty]     at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+[11ty]     at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+[11ty]     at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+[11ty]     at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+[11ty]     at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+[11ty]     at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+[11ty]     at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+[11ty]     at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+[11ty]     at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22)
+[11ty] Copied 75 Wrote 0 files in 5.87 seconds (v3.1.2)
+✖ work pages build and latest redirects (5873.370133ms)
+✖ deploy workflow does not trigger on pull_request (2.847712ms)
+✖ build job runs only on push events (0.505366ms)
+✔ defines improved background colors (2.332609ms)
+✔ text contrast meets WCAG AA (8.398769ms)
+✔ tailwind exposes readable fonts (0.230089ms)
+✔ includes fluid type scale tokens (0.294147ms)
+✔ docs:links reports no broken links (2144.835917ms)
+✔ package-lock.json defines lockfileVersion (9.818956ms)
+✔ footnote popover separates source line (348.687305ms)
+✔ projects computed picks latest entries by date (3.496014ms)
+✔ keepalive emits heartbeat to stderr (6515.325956ms)
+✔ keepalive ignores first SIGINT (495.330798ms)
+✔ gateway reads SOLVER_URL from environment (2.194583ms)
+✔ gateway retains default solver URL (0.329862ms)
+✔ external link renders with arrow and class (20.184106ms)
+✔ internal link keeps text without external markers (2.958301ms)
+✔ external link starting with arrow does not duplicate (28.504592ms)
+✔ provenanceSources parses JSONL provenance files (2.768851ms)
+✔ provenanceSources returns [] when file missing (2.046464ms)
+✔ devDependencies omit @vscode/ripgrep (1.718258ms)
+✔ prepare-docs avoids ripgrep install (0.215507ms)
+✔ merges tag-like metadata into unified tags and categories (5.548783ms)
+✔ deduplicates tag values (0.442736ms)
+✔ categories returns empty array when spark_type absent (0.192044ms)
+✔ time to chill includes size with height in cm (2.295025ms)
+✔ time to chill height is positive (0.301882ms)
+✖ ordinalSuffix handles negative numbers (3.274455ms)
+✔ ordinalSuffix uses "th" for teens (0.669851ms)
+✔ readFileCached returns null for nonexistent path (0.591857ms)
+✔ filterDeadLinks removes templated links (5.78259ms)
+✔ result has no templated links (0.557204ms)
+✔ filterDeadLinks does not mutate input (0.593215ms)
+✔ GitHub workflows use latest action versions (2.241511ms)
+ℹ tests 57
+ℹ suites 0
+ℹ pass 33
+ℹ fail 24
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 58665.329658
+
+✖ failing tests:
+
+test at test/integration/archive-nav-count.spec.mjs:7:1
+✖ archive nav exposes child counts (5954.001227ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/build-timestamp.spec.mjs:8:1
+✖ layout exposes build timestamp (5795.69677ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/code-copy.spec.mjs:8:1
+✖ code blocks expose copy control (5263.286383ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/collection-layout.spec.mjs:9:1
+✖ collection pages expose section metadata (5565.30172ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/feed-build-meta.spec.mjs:11:1
+✖ feed exposes build metadata (5595.161461ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/header-nav-aria.spec.mjs:10:1
+✖ home page header includes primary nav landmark (5421.714828ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/homepage-latest.spec.mjs:8:1
+✖ homepage work list mixes types (4617.035191ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/homepage.spec.mjs:19:1
+✖ homepage hero and work filters (4737.647375ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/logo-image.spec.mjs:9:1
+✖ logo image transforms to avif and webp (4885.622668ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/markdown-anchor.spec.mjs:8:1
+✖ markdown headings include anchor ids (5575.271748ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/monsters-hub.spec.mjs:7:1
+✖ monsters hub lists products and cross-links product and character pages (5550.910017ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/monsters-product-metadata.spec.mjs:26:1
+✖ product page exposes full metadata (acceptance) (5597.735661ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/monsters-product-metadata.spec.mjs:43:1
+✖ rendered prices use ISO code and two decimals (property) (2997.963522ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/monsters-product-metadata.spec.mjs:49:1
+✖ table and spec semantics hold (contract) (3124.715046ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/monsters-product-metadata.spec.mjs:65:1
+✖ markets render as chips when present (acceptance) (3367.890497ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/mschf-overlay.spec.mjs:9:1
+✖ overlay root exists and carries defaults (4823.899203ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/nav-aria.spec.mjs:7:1
+✖ main nav marks current page and is labelled (5789.133417ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/runner.spec.mjs:10:1
+✖ buildLean sets env and output directory (5745.111491ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/sparks-status.spec.mjs:7:1
+✖ spark listings reveal status text (5943.870016ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/wikilinks-ignore-template.spec.mjs:8:1
+✖ wikilinks ignore templated paths (5502.482371ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/integration/work-pages.spec.mjs:7:1
+✖ work pages build and latest redirects (5873.370133ms)
+  Error [TemplateContentRenderError]: Having trouble rendering njk template ./src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+      at Template._render (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateContent.js:660:6)
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:390:9
+      at async Promise.all (index 0)
+      at async TemplateMap.populateContentDataInMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:380:4)
+      at async TemplateMap.cache (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateMap.js:291:3)
+      at async TemplateWriter._createTemplateMap (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:352:3)
+      at async TemplateWriter.generateTemplates (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:382:3)
+      at async TemplateWriter.write (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/TemplateWriter.js:430:38)
+      at async Eleventy.executeBuild (file:///workspace/effusion-labs/node_modules/@11ty/eleventy/src/Eleventy.js:1438:19) {
+    originalError: Error: expected variable end
+        at new TemplateError (/workspace/effusion-labs/node_modules/nunjucks/src/lib.js:74:17)
+        at Parser.error (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:63:12)
+        at Parser.fail (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:66:16)
+        at Parser.advanceAfterVariableEnd (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:122:12)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:990:14)
+        at Parser.parse (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:1002:42)
+        at Parser.parseUntilBlocks (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:952:20)
+        at Parser.parseMacro (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:178:22)
+        at Parser.parseStatement (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:480:21)
+        at Parser.parseNodes (/workspace/effusion-labs/node_modules/nunjucks/src/parser.js:982:22) {
+      [cause]: undefined
+    }
+  }
+
+test at test/unit/deploy-workflow.test.mjs:7:1
+✖ deploy workflow does not trigger on pull_request (2.847712ms)
+  AssertionError [ERR_ASSERTION]: pull_request trigger should be absent
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/deploy-workflow.test.mjs:8:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.start (node:internal/test_runner/test:944:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17) {
+    generatedMessage: false,
+    code: 'ERR_ASSERTION',
+    actual: 'name: Build, Scan, and Deploy to GHCR\n\non:\n  push:\n    branches: [main]\n  pull_request:\n    branches: [main]\n  workflow_dispatch:\n\n# Cancel superseded runs (keeps things snappy for solo dev)\nconcurrency:\n  group: ${{ github.workflow }}-${{ github.ref }}\n  cancel-in-progress: true\n\n# Default least privilege; jobs bump as needed\npermissions:\n  contents: read\n\njobs:\n  tests:\n    name: Unit tests (Node ${{ matrix.node }})\n    runs-on: ubuntu-latest\n    timeout-minutes: 12\n    strategy:\n      fail-fast: false\n      matrix:\n        node: [\'20\', \'22\']   # current + next LTS\n    permissions:\n      contents: read\n    steps:\n      - name: Checkout\n        uses: actions/checkout@v4\n      - name: Setup Node\n        uses: actions/setup-node@v4\n        with:\n          node-version: ${{ matrix.node }}\n          cache: \'npm\'\n          cache-dependency-path: |\n            package-lock.json\n            tools/**/package-lock.json\n      - run: echo "$PWD/bin" >> "$GITHUB_PATH"\n      - run: npm ci --no-audit --no-fund\n      - run: npm test\n      - name: Upload coverage\n        uses: actions/upload-artifact@v4\n        with:\n          name: coverage-${{ matrix.node }}\n          path: coverage/lcov.info\n          retention-days: 7\n          if-no-files-found: ignore\n\n  build_and_deploy:\n    name: Build → SBOM/Provenance → Scan → Deploy\n    if: github.event_name == \'push\'\n    needs: tests\n    runs-on: ubuntu-latest\n    timeout-minutes: 25\n    # This DOES NOT require reviewers by itself; it only takes effect if you ever add rules later.\n    environment:\n      name: production\n    permissions:\n      contents: read\n      packages: write       # push to GHCR\n      id-token: write       # needed for provenance from buildx\n    env:\n      DOCKER_BUILDKIT: 1\n      OWNER_SLUG: ${{ github.repository_owner }}\n    steps:\n      - name: Checkout\n        uses: actions/checkout@v4\n\n      - name: Setup Node\n        uses: actions/setup-node@v4\n        with:\n          node-version: \'20\'\n          cache: \'npm\'\n\n      - name: Install deps\n        run: npm ci --ignore-scripts --no-audit --no-fund\n\n      - name: Build Eleventy\n        run: npx @11ty/eleventy\n\n      - name: Login to GHCR\n        uses: docker/login-action@v3\n        with:\n          registry: ghcr.io\n          username: ${{ github.actor }}\n          password: ${{ secrets.GITHUB_TOKEN }}\n\n      - name: Setup Buildx\n        uses: docker/setup-buildx-action@v3\n\n      - name: Compute image prefix (lowercase)\n        id: slug\n        shell: bash\n        run: |\n          owner_lc="$(echo "${OWNER_SLUG}" | tr \'[:upper:]\' \'[:lower:]\')"\n          echo "prefix=ghcr.io/${owner_lc}" >> "$GITHUB_OUTPUT"\n\n      # ---------- Build & push image 1 (with SBOM + provenance) ----------\n      - name: Build & push effusion-labs\n        id: eff\n        uses: docker/build-push-action@v6\n        with:\n          context: .\n          file: ./.portainer/Dockerfile\n          push: true\n          platforms: linux/amd64\n          tags: ${{ steps.slug.outputs.prefix }}/effusion-labs:latest\n          cache-from: type=registry,ref=${{ steps.slug.outputs.prefix }}/effusion-labs:cache\n          cache-to:   type=registry,ref=${{ steps.slug.outputs.prefix }}/effusion-labs:cache,mode=max\n          sbom: true\n          provenance: true\n\n      # ---------- Build & push image 2 (with SBOM + provenance) ----------\n      - name: Build & push markdown_gateway\n        id: mdgw\n        uses: docker/build-push-action@v6\n        with:\n          context: ./markdown_gateway\n          push: true\n          platforms: linux/amd64\n          tags: ${{ steps.slug.outputs.prefix }}/markdown_gateway:latest\n          cache-from: type=registry,ref=${{ steps.slug.outputs.prefix }}/markdown_gateway:cache\n          cache-to:   type=registry,ref=${{ steps.slug.outputs.prefix }}/markdown_gateway:cache,mode=max\n          sbom: true\n          provenance: true\n\n      # ---------- Repo-level SBOM artifact (optional but handy) ----------\n      - name: Generate SBOM (workspace)\n        uses: anchore/sbom-action@v0\n        with:\n          format: spdx-json\n          artifact-name: workspace-sbom.spdx.json\n          upload-artifact: true\n\n      # ---------- Vulnerability scans (fail on HIGH/CRIT) ----------\n      - name: Scan effusion-labs image\n        uses: aquasecurity/trivy-action@0.32.0\n        with:\n          image-ref: ${{ steps.slug.outputs.prefix }}/effusion-labs@${{ steps.eff.outputs.digest }}\n          severity: HIGH,CRITICAL\n          ignore-unfixed: true\n          format: table\n          exit-code: \'1\'\n      - name: Scan markdown_gateway image\n        uses: aquasecurity/trivy-action@0.32.0\n        with:\n          image-ref: ${{ steps.slug.outputs.prefix }}/markdown_gateway@${{ steps.mdgw.outputs.digest }}\n          severity: HIGH,CRITICAL\n          ignore-unfixed: true\n          format: table\n          exit-code: \'1\'\n\n      # ---------- Deploy via Portainer webhook ----------\n      - name: Trigger effusion-labs redeploy (Portainer)\n        env:\n          HOOK: ${{ secrets.PORTAINER_WEBHOOK_EFFUSION }}\n        run: |\n          curl --fail --retry 5 --retry-all-errors --retry-delay 2 -X POST "$HOOK"\n\n  browser-checks:\n    if: github.event_name == \'workflow_dispatch\'\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    permissions:\n      contents: read\n    container:\n      image: mcr.microsoft.com/playwright:v1.45.2-jammy\n    steps:\n      - uses: actions/checkout@v4\n      - uses: actions/setup-node@v4\n        with:\n          node-version: \'20\'\n          cache: \'npm\'\n      - run: npm ci --ignore-scripts --no-audit --no-fund\n      - run: NODE_OPTIONS=--import=./test/setup/http.mjs npm run test:browser\n',
+    expected: /pull_request:/,
+    operator: 'doesNotMatch'
+  }
+
+test at test/unit/deploy-workflow.test.mjs:11:1
+✖ build job runs only on push events (0.505366ms)
+  AssertionError [ERR_ASSERTION]: build job missing push-only condition
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/deploy-workflow.test.mjs:12:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)
+      at Test.postRun (node:internal/test_runner/test:1173:19)
+      at Test.run (node:internal/test_runner/test:1101:12)
+      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
+    generatedMessage: false,
+    code: 'ERR_ASSERTION',
+    actual: 'name: Build, Scan, and Deploy to GHCR\n\non:\n  push:\n    branches: [main]\n  pull_request:\n    branches: [main]\n  workflow_dispatch:\n\n# Cancel superseded runs (keeps things snappy for solo dev)\nconcurrency:\n  group: ${{ github.workflow }}-${{ github.ref }}\n  cancel-in-progress: true\n\n# Default least privilege; jobs bump as needed\npermissions:\n  contents: read\n\njobs:\n  tests:\n    name: Unit tests (Node ${{ matrix.node }})\n    runs-on: ubuntu-latest\n    timeout-minutes: 12\n    strategy:\n      fail-fast: false\n      matrix:\n        node: [\'20\', \'22\']   # current + next LTS\n    permissions:\n      contents: read\n    steps:\n      - name: Checkout\n        uses: actions/checkout@v4\n      - name: Setup Node\n        uses: actions/setup-node@v4\n        with:\n          node-version: ${{ matrix.node }}\n          cache: \'npm\'\n          cache-dependency-path: |\n            package-lock.json\n            tools/**/package-lock.json\n      - run: echo "$PWD/bin" >> "$GITHUB_PATH"\n      - run: npm ci --no-audit --no-fund\n      - run: npm test\n      - name: Upload coverage\n        uses: actions/upload-artifact@v4\n        with:\n          name: coverage-${{ matrix.node }}\n          path: coverage/lcov.info\n          retention-days: 7\n          if-no-files-found: ignore\n\n  build_and_deploy:\n    name: Build → SBOM/Provenance → Scan → Deploy\n    if: github.event_name == \'push\'\n    needs: tests\n    runs-on: ubuntu-latest\n    timeout-minutes: 25\n    # This DOES NOT require reviewers by itself; it only takes effect if you ever add rules later.\n    environment:\n      name: production\n    permissions:\n      contents: read\n      packages: write       # push to GHCR\n      id-token: write       # needed for provenance from buildx\n    env:\n      DOCKER_BUILDKIT: 1\n      OWNER_SLUG: ${{ github.repository_owner }}\n    steps:\n      - name: Checkout\n        uses: actions/checkout@v4\n\n      - name: Setup Node\n        uses: actions/setup-node@v4\n        with:\n          node-version: \'20\'\n          cache: \'npm\'\n\n      - name: Install deps\n        run: npm ci --ignore-scripts --no-audit --no-fund\n\n      - name: Build Eleventy\n        run: npx @11ty/eleventy\n\n      - name: Login to GHCR\n        uses: docker/login-action@v3\n        with:\n          registry: ghcr.io\n          username: ${{ github.actor }}\n          password: ${{ secrets.GITHUB_TOKEN }}\n\n      - name: Setup Buildx\n        uses: docker/setup-buildx-action@v3\n\n      - name: Compute image prefix (lowercase)\n        id: slug\n        shell: bash\n        run: |\n          owner_lc="$(echo "${OWNER_SLUG}" | tr \'[:upper:]\' \'[:lower:]\')"\n          echo "prefix=ghcr.io/${owner_lc}" >> "$GITHUB_OUTPUT"\n\n      # ---------- Build & push image 1 (with SBOM + provenance) ----------\n      - name: Build & push effusion-labs\n        id: eff\n        uses: docker/build-push-action@v6\n        with:\n          context: .\n          file: ./.portainer/Dockerfile\n          push: true\n          platforms: linux/amd64\n          tags: ${{ steps.slug.outputs.prefix }}/effusion-labs:latest\n          cache-from: type=registry,ref=${{ steps.slug.outputs.prefix }}/effusion-labs:cache\n          cache-to:   type=registry,ref=${{ steps.slug.outputs.prefix }}/effusion-labs:cache,mode=max\n          sbom: true\n          provenance: true\n\n      # ---------- Build & push image 2 (with SBOM + provenance) ----------\n      - name: Build & push markdown_gateway\n        id: mdgw\n        uses: docker/build-push-action@v6\n        with:\n          context: ./markdown_gateway\n          push: true\n          platforms: linux/amd64\n          tags: ${{ steps.slug.outputs.prefix }}/markdown_gateway:latest\n          cache-from: type=registry,ref=${{ steps.slug.outputs.prefix }}/markdown_gateway:cache\n          cache-to:   type=registry,ref=${{ steps.slug.outputs.prefix }}/markdown_gateway:cache,mode=max\n          sbom: true\n          provenance: true\n\n      # ---------- Repo-level SBOM artifact (optional but handy) ----------\n      - name: Generate SBOM (workspace)\n        uses: anchore/sbom-action@v0\n        with:\n          format: spdx-json\n          artifact-name: workspace-sbom.spdx.json\n          upload-artifact: true\n\n      # ---------- Vulnerability scans (fail on HIGH/CRIT) ----------\n      - name: Scan effusion-labs image\n        uses: aquasecurity/trivy-action@0.32.0\n        with:\n          image-ref: ${{ steps.slug.outputs.prefix }}/effusion-labs@${{ steps.eff.outputs.digest }}\n          severity: HIGH,CRITICAL\n          ignore-unfixed: true\n          format: table\n          exit-code: \'1\'\n      - name: Scan markdown_gateway image\n        uses: aquasecurity/trivy-action@0.32.0\n        with:\n          image-ref: ${{ steps.slug.outputs.prefix }}/markdown_gateway@${{ steps.mdgw.outputs.digest }}\n          severity: HIGH,CRITICAL\n          ignore-unfixed: true\n          format: table\n          exit-code: \'1\'\n\n      # ---------- Deploy via Portainer webhook ----------\n      - name: Trigger effusion-labs redeploy (Portainer)\n        env:\n          HOOK: ${{ secrets.PORTAINER_WEBHOOK_EFFUSION }}\n        run: |\n          curl --fail --retry 5 --retry-all-errors --retry-delay 2 -X POST "$HOOK"\n\n  browser-checks:\n    if: github.event_name == \'workflow_dispatch\'\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    permissions:\n      contents: read\n    container:\n      image: mcr.microsoft.com/playwright:v1.45.2-jammy\n    steps:\n      - uses: actions/checkout@v4\n      - uses: actions/setup-node@v4\n        with:\n          node-version: \'20\'\n          cache: \'npm\'\n      - run: npm ci --ignore-scripts --no-audit --no-fund\n      - run: NODE_OPTIONS=--import=./test/setup/http.mjs npm run test:browser\n',
+    expected: /build:\n\s+if: github\.event_name == 'push'/,
+    operator: 'match'
+  }
+
+test at test/unit/utils.test.mjs:9:7
+✖ ordinalSuffix handles negative numbers (3.274455ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  
+  'th' !== 'st'
+  
+      at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/utils.test.mjs:10:10)
+      at Test.runInAsyncScope (node:async_hooks:214:14)
+      at Test.run (node:internal/test_runner/test:1047:25)
+      at Test.start (node:internal/test_runner/test:944:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+      at async file:///workspace/effusion-labs/test/unit/utils.test.mjs:9:1 {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 'th',
+    expected: 'st',
+    operator: 'strictEqual'
+  }
+Executed 35 tests
+
+=============================== Coverage summary ===============================
+Statements   : 84.11% ( 1366/1624 )
+Branches     : 81.75% ( 233/285 )
+Functions    : 71.42% ( 70/98 )
+Lines        : 84.11% ( 1366/1624 )
+================================================================================

--- a/test/unit/utils.test.mjs
+++ b/test/unit/utils.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import utils from '../../lib/utils.js';
+const { ordinalSuffix, readFileCached } = utils;
+
+// Acceptance example: negative numbers yield correct suffix
+await test('ordinalSuffix handles negative numbers', () => {
+  assert.equal(ordinalSuffix(-1), 'st');
+});
+
+// Property: teen values always use "th" suffix
+await test('ordinalSuffix uses "th" for teens', () => {
+  [11, 12, 13, -11, -12, -13].forEach((n) => {
+    assert.equal(ordinalSuffix(n), 'th');
+  });
+});
+
+// Contract: missing files return null from cache reader
+await test('readFileCached returns null for nonexistent path', () => {
+  const p = path.join(process.cwd(), 'nonexistent-file.txt');
+  assert.equal(readFileCached(p), null);
+});


### PR DESCRIPTION
## Summary
- add targeted unit tests for ordinalSuffix and file cache helpers
- support negative numbers in ordinalSuffix and modernize file cache
- document utilities and record provenance

## Testing
- `node --test test/unit/utils.test.mjs`
- `npm run docs:links`

------
https://chatgpt.com/codex/tasks/task_e_68a2673e697c833096830c7a8db88358