### PR TITLE
chore: remove silent flags from init scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Effusion Labs is a static digital garden built with Eleventy, Nunjucks templates
 - `npm run deps:playwright` – install the Chromium browser for Playwright.
 - `npm run deps:system` – install system dependencies for Playwright.
 - `npm run proxy:chain` – run the proxy chain helper.
-- `npm run prepare-docs` – ensure `fd` is installed for repository search; `rg` must be installed separately.
+- `npm run prepare-docs` – ensure `fd` is installed for repository search (shows install progress); `rg` must be installed separately.
 - `npm run docs:links` – check this README for broken links.
 
 ### Eleventy Plugins
@@ -65,7 +65,7 @@ git clone https://github.com/effusion-labs/effusion-labs.git
 cd effusion-labs
 npm install
 cp .env.example .env          # OUTBOUND_MARKDOWN_ENABLED, OUTBOUND_MARKDOWN_USER, OUTBOUND_MARKDOWN_PASS, OUTBOUND_MARKDOWN_URL, OUTBOUND_MARKDOWN_PORT, OUTBOUND_MARKDOWN_API_KEY, OUTBOUND_MARKDOWN_TIMEOUT
-npm run prepare-docs          # installs fd if missing
+npm run prepare-docs          # installs fd if missing (shows progress)
 npm run dev                   # Eleventy + live reload
 npm run build                 # production output in _site/
 npm test                      # run test suite

--- a/docs/knowledge/no-silent-ops-green.log
+++ b/docs/knowledge/no-silent-ops-green.log
@@ -1,0 +1,16 @@
+TAP version 13
+# Subtest: scripts avoid silent operations and /dev/null redirects
+ok 1 - scripts avoid silent operations and /dev/null redirects
+  ---
+  duration_ms: 3.231765
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 185.794351

--- a/docs/knowledge/no-silent-ops-red.log
+++ b/docs/knowledge/no-silent-ops-red.log
@@ -1,0 +1,30 @@
+TAP version 13
+# Subtest: scripts avoid silent operations and /dev/null redirects
+not ok 1 - scripts avoid silent operations and /dev/null redirects
+  ---
+  duration_ms: 3.684047
+  type: 'test'
+  location: '/workspace/effusion-labs/test/unit/no-silent-ops.test.mjs:7:1'
+  failureType: 'testCodeFailure'
+  error: 'prepare-docs script contains banned pattern: /\\/dev\\/null/'
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: true
+  actual: false
+  operator: '=='
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/no-silent-ops.test.mjs:11:7)
+    Test.runInAsyncScope (node:async_hooks:214:14)
+    Test.run (node:internal/test_runner/test:1047:25)
+    Test.start (node:internal/test_runner/test:944:17)
+    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 195.751504

--- a/docs/reports/continuous-output-continue.md
+++ b/docs/reports/continuous-output-continue.md
@@ -1,0 +1,13 @@
+# Continuous Output Continuation
+- recap: silent flags and /dev/null redirects removed from init scripts; progress flag added; tests enforce visibility.
+- next:
+  1. audit remaining scripts and Docker files for quiet flags.
+  2. extend CI to fail on detected silent patterns.
+- trigger: `node --test test/unit/no-silent-ops.test.mjs`
+- env: default
+- effort: R3
+- reads: 8 files
+- surfaces: package.json, scripts/llm-bootstrap.sh, README.md, test/unit/no-silent-ops.test.mjs
+- capture hashes:
+  - logs/no-silent-ops-red.log: 5439d2f19bf82d7536568d8b3c8225c9a7f6c7b806b89b0850bbb7f035739920
+  - logs/no-silent-ops-green.log: 45760c491ee0c34bb910f905e13d132333c062ae918579a628a445ff51854353

--- a/docs/reports/continuous-output-ledger.md
+++ b/docs/reports/continuous-output-ledger.md
@@ -1,0 +1,29 @@
+# Continuous Output Ledger
+- time: 2025-08-18T17:31:55Z
+- diffstat:
+```
+README.md                              |  4 ++--
+docs/knowledge/no-silent-ops-green.log | 16 ++++++++++++++++
+docs/knowledge/no-silent-ops-red.log   | 30 ++++++++++++++++++++++++++++++
+logs/no-silent-ops-green.log           | 16 ++++++++++++++++
+logs/no-silent-ops-red.log             | 30 ++++++++++++++++++++++++++++++
+package.json                           |  2 +-
+scripts/llm-bootstrap.sh               | 26 +++++++++++++-------------
+test/unit/no-silent-ops.test.mjs       | 19 +++++++++++++++++++
+8 files changed, 127 insertions(+), 16 deletions(-)
+```
+- proofs:
+  - failing: logs/no-silent-ops-red.log
+  - passing: logs/no-silent-ops-green.log
+- knowledge captures:
+  - docs/knowledge/no-silent-ops-red.log (sha256: 5439d2f19bf82d7536568d8b3c8225c9a7f6c7b806b89b0850bbb7f035739920)
+  - docs/knowledge/no-silent-ops-green.log (sha256: 45760c491ee0c34bb910f905e13d132333c062ae918579a628a445ff51854353)
+- commit graph:
+```
+ae3f0bc docs:init-scripts sync docs with repo state
+b08c2fd refactor:init-scripts unify and modernize
+46bf26e feat:init-scripts implement fix to green
+afc7348 ci:init-scripts record failing proofs
+5271a9e test:init-scripts define acceptance + property + contract
+```
+- rollback: `git reset --hard 5271a9e`

--- a/logs/no-silent-ops-green.log
+++ b/logs/no-silent-ops-green.log
@@ -1,0 +1,16 @@
+TAP version 13
+# Subtest: scripts avoid silent operations and /dev/null redirects
+ok 1 - scripts avoid silent operations and /dev/null redirects
+  ---
+  duration_ms: 3.231765
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 185.794351

--- a/logs/no-silent-ops-red.log
+++ b/logs/no-silent-ops-red.log
@@ -1,0 +1,30 @@
+TAP version 13
+# Subtest: scripts avoid silent operations and /dev/null redirects
+not ok 1 - scripts avoid silent operations and /dev/null redirects
+  ---
+  duration_ms: 3.684047
+  type: 'test'
+  location: '/workspace/effusion-labs/test/unit/no-silent-ops.test.mjs:7:1'
+  failureType: 'testCodeFailure'
+  error: 'prepare-docs script contains banned pattern: /\\/dev\\/null/'
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: true
+  actual: false
+  operator: '=='
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/no-silent-ops.test.mjs:11:7)
+    Test.runInAsyncScope (node:async_hooks:214:14)
+    Test.run (node:internal/test_runner/test:1047:25)
+    Test.start (node:internal/test_runner/test:944:17)
+    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 195.751504

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deps:playwright": "npx playwright install chromium || true",
     "deps:system": "npx playwright install-deps || true",
     "proxy:chain": "node tools/shared/chain-proxy.mjs",
-    "prepare-docs": "npm exec fd --version >/dev/null 2>&1 || npm install --save-dev fd-find || true",
+    "prepare-docs": "npm exec fd --version || npm install --save-dev fd-find --progress || true",
     "docs:links": "markdown-link-check -c link-check.config.json README.md",
     "format": "prettier -w ."
   },

--- a/scripts/llm-bootstrap.sh
+++ b/scripts/llm-bootstrap.sh
@@ -21,7 +21,7 @@ else
     DEPS_HASH_FILE="$repo_root/tmp/.llm_deps_hash"
     mkdir -p "$repo_root/tmp"
 
-    current_hash=$(cat "$repo_root/package-lock.json" "$repo_root/markdown_gateway/requirements.txt" 2>/dev/null | sha256sum | awk '{print $1}')
+    current_hash=$(cat "$repo_root/package-lock.json" "$repo_root/markdown_gateway/requirements.txt" | sha256sum | awk '{print $1}')
     stored_hash=""
     if [ -f "$DEPS_HASH_FILE" ]; then
         stored_hash=$(cat "$DEPS_HASH_FILE")
@@ -63,7 +63,7 @@ smart_cat() {
         yml|yaml) parser="yaml" ;;
         *) command cat -vt "$file_path" | fold -w 100 -s; return ;;
     esac
-    if command -v npx &> /dev/null; then
+    if command -v npx; then
         command cat "$file_path" | npx --no-install prettier --parser "$parser" --print-width 100
     else
         command cat -vt "$file_path" | fold -w 100 -s
@@ -98,8 +98,8 @@ export -f llm_shell_hb
 export -f _llm_hijack
 
 if [[ "${CI:-}" == "true" || "${LLM_SHELL_HEARTBEAT:-}" == "1" ]]; then
-  if [[ -z "${_LLM_HB_PID:-}" ]] || ! kill -0 "$_LLM_HB_PID" 2>/dev/null; then
-    llm_shell_hb &; export _LLM_HB_PID=$!; trap 'kill "$_LLM_HB_PID" 2>/dev/null' EXIT;
+  if [[ -z "${_LLM_HB_PID:-}" ]] || ! kill -0 "$_LLM_HB_PID"; then
+    llm_shell_hb &; export _LLM_HB_PID=$!; trap 'kill "$_LLM_HB_PID"' EXIT;
   fi
 fi
 trap _llm_hijack DEBUG
@@ -113,7 +113,7 @@ for hook in post-checkout post-merge; do
 #!/usr/bin/env bash
 # Auto-restores LLM guardrails. To apply to your current shell, run:
 # source scripts/llm-bootstrap.sh
-bash scripts/llm-bootstrap.sh >/dev/null 2>&1
+bash scripts/llm-bootstrap.sh 
 EOH
   chmod +x "$hook_path"
 done
@@ -157,7 +157,7 @@ smart_cat() {
         yml|yaml) parser="yaml" ;;
         *) command cat -vt "$file_path" | fold -w 100 -s; return ;;
     esac
-    if command -v npx &> /dev/null; then
+    if command -v npx; then
         command cat "$file_path" | npx --no-install prettier --parser "$parser" --print-width 100
     else
         command cat -vt "$file_path" | fold -w 100 -s
@@ -192,8 +192,8 @@ export -f llm_shell_hb
 export -f _llm_hijack
 
 if [[ "${CI:-}" == "true" || "${LLM_SHELL_HEARTBEAT:-}" == "1" ]]; then
-  if [[ -z "${_LLM_HB_PID:-}" ]] || ! kill -0 "$_LLM_HB_PID" 2>/dev/null; then
-    llm_shell_hb &; export _LLM_HB_PID=$!; trap 'kill "$_LLM_HB_PID" 2>/dev/null' EXIT;
+  if [[ -z "${_LLM_HB_PID:-}" ]] || ! kill -0 "$_LLM_HB_PID"; then
+    llm_shell_hb &; export _LLM_HB_PID=$!; trap 'kill "$_LLM_HB_PID"' EXIT;
   fi
 fi
 trap _llm_hijack DEBUG
@@ -207,7 +207,7 @@ for hook in post-checkout post-merge; do
 #!/usr/bin/env bash
 # Auto-restores LLM guardrails. To apply to your current shell, run:
 # source scripts/llm-bootstrap.sh
-bash scripts/llm-bootstrap.sh >/dev/null 2>&1
+bash scripts/llm-bootstrap.sh 
 EOH
   chmod +x "$hook_path"
 done
@@ -243,7 +243,7 @@ for hook in post-checkout post-merge; do
 #!/usr/bin/env bash
 # Auto-restores LLM guardrails. To apply to your current shell, run:
 # source scripts/llm-bootstrap.sh
-bash scripts/llm-bootstrap.sh >/dev/null 2>&1
+bash scripts/llm-bootstrap.sh 
 EOH
   chmod +x "$hook_path"
 done
@@ -282,8 +282,8 @@ printf "\n\n"
 }
 
 if [[ "${CI:-}" == "true" || "${LLM_SHELL_HEARTBEAT:-}" == "1" ]]; then
-  if [[ -z "${_LLM_HB_PID:-}" ]] || ! kill -0 "$_LLM_HB_PID" 2>/dev/null; then
-    llm_shell_hb &; export _LLM_HB_PID=$!; trap 'kill "$_LLM_HB_PID" 2>/dev/null' EXIT;
+  if [[ -z "${_LLM_HB_PID:-}" ]] || ! kill -0 "$_LLM_HB_PID"; then
+    llm_shell_hb &; export _LLM_HB_PID=$!; trap 'kill "$_LLM_HB_PID"' EXIT;
   fi
 fi
 trap _llm_hijack DEBUG
@@ -297,7 +297,7 @@ for hook in post-checkout post-merge; do
 #!/usr/bin/env bash
 # Auto-restores LLM guardrails. To apply to your current shell, run:
 # source scripts/llm-bootstrap.sh
-bash scripts/llm-bootstrap.sh >/dev/null 2>&1
+bash scripts/llm-bootstrap.sh 
 EOH
   chmod +x "$hook_path"
 done

--- a/test/unit/no-silent-ops.test.mjs
+++ b/test/unit/no-silent-ops.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+const banned = [/--silent\b/, /--quiet\b/, /\s-q\b/, /\/dev\/null/];
+
+test('scripts avoid silent operations and /dev/null redirects', () => {
+  const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url)));
+  for (const [name, cmd] of Object.entries(pkg.scripts)) {
+    for (const rule of banned) {
+      assert(!rule.test(cmd), `${name} script contains banned pattern: ${rule}`);
+    }
+  }
+
+  const bootstrap = readFileSync(new URL('../../scripts/llm-bootstrap.sh', import.meta.url), 'utf8');
+  for (const rule of banned) {
+    assert(!rule.test(bootstrap), `llm-bootstrap.sh contains banned pattern: ${rule}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add regression test to ensure scripts avoid silent flags and /dev/null redirects
- remove dev/null and quiet flags from bootstrap and prepare-docs
- document prepare-docs progress output

## Testing
- `node --test test/unit/no-silent-ops.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a35f8919f88330bfdfaad8882d6851