### PR TITLE
chore: add environment provisioning script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,11 +32,12 @@
         "c8": "10.1.3",
         "daisyui": "^5.0.50",
         "danfojs-node": "1.2.0",
-        "fd-find": "^1.2.0",
+        "fd-find": "1.2.0",
         "jsdom": "^26.1.0",
         "markdown-it": "14.1.0",
         "markdown-it-attrs": "^4.3.1",
         "markdown-link-check": "^3.13.7",
+        "pandas": "0.0.3",
         "playwright-extra": "^4.3.6",
         "postcss": "^8.5.6",
         "prettier": "3.3.3",
@@ -5791,6 +5792,13 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pandas": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/pandas/-/pandas-0.0.3.tgz",
+      "integrity": "sha512-b6b0XOuj8mvj2Kn6qfcvPmb0ILCcbuep5VYZche3730P9cXQcvarbbvWJxwXkxc3OXyGFYjJ4kozjX5ZXXMrsw==",
+      "dev": true,
+      "license": "WTFPL"
     },
     "node_modules/papaparse": {
       "version": "5.5.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "deps:setup": "npm run deps:playwright && npm run deps:system",
     "deps:playwright": "playwright install chromium || true",
     "deps:system": "playwright install-deps || true",
-    "proxy:health": "node scripts/proxy-health.mjs"
+    "proxy:health": "node scripts/proxy-health.mjs",
+    "deps:provision": "bash scripts/provision-env.sh"
   },
   "engines": {
     "node": ">=20"
@@ -51,12 +52,12 @@
     "c8": "10.1.3",
     "daisyui": "^5.0.50",
     "danfojs-node": "1.2.0",
-    "fd-find": "^1.2.0",
     "fd-find": "1.2.0",
     "jsdom": "^26.1.0",
     "markdown-it": "14.1.0",
     "markdown-it-attrs": "^4.3.1",
     "markdown-link-check": "^3.13.7",
+    "pandas": "0.0.3",
     "playwright-extra": "^4.3.6",
     "postcss": "^8.5.6",
     "prettier": "3.3.3",

--- a/scripts/provision-env.sh
+++ b/scripts/provision-env.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_cli_tool() {
+  local cmd="$1"
+  local npm_pkg="$2"
+  local apt_pkg="$3"
+  local pip_pkg="$4"
+
+  if command -v "$cmd" >/dev/null 2>&1; then
+    printf "%s already installed at %s\n" "$cmd" "$(command -v "$cmd")"
+    return
+  fi
+
+  if [ -n "$npm_pkg" ]; then
+    npm search "$npm_pkg" >/dev/null 2>&1 || true
+    local version
+    version=$(npm view "$npm_pkg" version 2>/dev/null || true)
+    if [ -n "$version" ]; then
+      npm install "$npm_pkg@$version" --save-dev --save-exact || true
+    fi
+    if command -v "$cmd" >/dev/null 2>&1; then return; fi
+  fi
+
+  sudo apt-get update && sudo apt-get install -y "$apt_pkg" || true
+  if command -v "$cmd" >/dev/null 2>&1; then return; fi
+
+  if [ -n "$pip_pkg" ]; then
+    pip install "$pip_pkg" || true
+  fi
+
+  if [ "$cmd" = "fd" ] && ! command -v fd >/dev/null 2>&1 && command -v fdfind >/dev/null 2>&1; then
+    sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+  fi
+}
+
+install_cli_tool "rg" "ripgrep" "ripgrep" "ripgrep"
+install_cli_tool "fd" "fd-find" "fd-find" "fd-find"
+install_cli_tool "jq" "jq" "jq" "jq"
+
+install_node_pkg() {
+  local pkg="$1"
+  npm search "$pkg" >/dev/null 2>&1 || true
+  local version
+  version=$(npm view "$pkg" version)
+  npm install "$pkg@$version" --save-dev --save-exact
+}
+
+install_node_pkg "markdown-it"
+install_node_pkg "danfojs-node"
+install_node_pkg "ajv"
+install_node_pkg "pandas"


### PR DESCRIPTION
## Summary
- add provision-env script to install required CLI tools and libraries
- wire provisioning command into package.json for reuse

## Testing
- `npm run deps:provision`
- `npm test` *(fails: ENOENT .dead-links.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f510949c8330ba0eb3df6660a1f3