### PR TITLE
fix: ensure dead link report writes to project root

### DIFF
--- a/lib/eleventy/register.js
+++ b/lib/eleventy/register.js
@@ -32,6 +32,7 @@ module.exports = function register(eleventyConfig) {
 
   eleventyConfig.on('eleventy.after', () => {
     const root = process.env.ELEVENTY_ROOT || process.cwd();
+    process.env.ELEVENTY_ROOT = root;
     const deadLinksPath = path.join(root, '.dead-links.json');
     if (!fs.existsSync(deadLinksPath)) return;
     const data = JSON.parse(fs.readFileSync(deadLinksPath, 'utf8'));


### PR DESCRIPTION
## Summary
- set `ELEVENTY_ROOT` to project root when absent so Eleventy dead link report is written consistently

## Testing
- `npm test` *(fails: process left running after completion; terminated manually after verifying all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f8e34ccc83309c6845ff8738e068