### PR TITLE
docs: highlight cat and tail guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,21 +8,23 @@ System prompt invariants are non-nullifiable.
 ---
 
 ## Runtime & Stack (Facts)
-* Node.js: v20
-* Module system: CommonJS (CJS)
-* Site generator: Eleventy (11ty)
-* Templates: Nunjucks
-* Styling: Tailwind CSS
-* Content: Markdown
+
+- Node.js: v20
+- Module system: CommonJS (CJS)
+- Site generator: Eleventy (11ty)
+- Templates: Nunjucks
+- Styling: Tailwind CSS
+- Content: Markdown
 
 ---
 
 ## Guardrail Activation (Mandatory)
+
 The following command MUST be executed once at session start:
 
 ```bash
 source scripts/llm-bootstrap.sh
-````
+```
 
 This activation is non-optional.
 All subsequent commands are governed by the guardrails below.
@@ -33,26 +35,32 @@ All subsequent commands are governed by the guardrails below.
 
 ### Output Channels
 
-* `printf`, `cat`, `tee`, and `fold` are **mandatory signal channels**.
-* Emission is non-optional. Suppression or minimization is prohibited.
-* All outputs are autocorrected for 4096-byte safety.
-* Outputs are prettified for token ingestion. Formatting is enforced.
+- `printf`, `cat`, `tee`, and `fold` are **mandatory signal channels**.
+- Emission is non-optional. Suppression or minimization is prohibited.
+- All outputs are autocorrected for 4096-byte safety.
+- Outputs are prettified for token ingestion. Formatting is enforced.
 
 ### Redirection
 
-* Any file redirection (`>`, `>>`) MUST be auto-upgraded to a safe, streaming pipeline with `tee`.
-* Silent or lossy redirections are prohibited.
+- Any file redirection (`>`, `>>`) MUST be auto-upgraded to a safe, streaming pipeline with `tee`.
+- Silent or lossy redirections are prohibited.
+
+### Cat & Tail Awareness
+
+- The bootstrap aliases `cat` to a formatter that uses Prettier when possible. Use `command cat` for raw output.
+- `tail -f`/`tail -F` is blocked by default to prevent runaway streams. Use `command tail` or set `LLM_TAIL_BLOCK=0` to bypass or allowlist via `LLM_TAIL_ALLOW_CMDS`.
 
 ---
 
 ## Core Mandate: Package Search Before Implementation
 
-* On every task, the agent MUST search the npm registry first.
+- On every task, the agent MUST search the npm registry first.
 
-  * `npm search <keyword>`
-  * `npm view <pkg> --json`
-* Default outcome: integrate an existing package.
-* Custom implementation is permitted only if no suitable package exists, and the inadequacy is explicitly stated.
+  - `npm search <keyword>`
+  - `npm view <pkg> --json`
+
+- Default outcome: integrate an existing package.
+- Custom implementation is permitted only if no suitable package exists, and the inadequacy is explicitly stated.
 
 ---
 
@@ -60,18 +68,18 @@ All subsequent commands are governed by the guardrails below.
 
 ### Installation
 
-* Install packages with exact version pinning:
+- Install packages with exact version pinning:
   `npm install <pkg>@<version> --save-exact`
 
 ### Testing & Proof
 
-* Integration MUST follow the Intent-Driven Development (IDD) workflow.
-* Acceptance criteria from the Mission Anchor MUST be satisfied before closing the task.
+- Integration MUST follow the Intent-Driven Development (IDD) workflow.
+- Acceptance criteria from the Mission Anchor MUST be satisfied before closing the task.
 
 ### Loop Discipline
 
-* Follow the PROVE ↔ FIX loop.
-* New packages are installed during the FIX phase only.
+- Follow the PROVE ↔ FIX loop.
+- New packages are installed during the FIX phase only.
 
 ---
 

--- a/scripts/llm-bootstrap.sh
+++ b/scripts/llm-bootstrap.sh
@@ -198,6 +198,9 @@ export -f _llm_hb
 alias cat='smart_cat'     # ALWAYS alias cat for LLM normalization
 alias tail='_llm_tail'
 
+_llm_emit bootstrap.alias cat=smart_cat tail=_llm_tail tail_block="${LLM_TAIL_BLOCK:-1}"
+printf 'llm-bootstrap: cat -> smart_cat (prettier-first); tail -> _llm_tail (tail -f/-F blocked). Use "command cat" or "command tail" for raw commands.\n' >&2
+
 trap _llm_hijack DEBUG
 
 if [[ "${CI:-}" == "true" || "${LLM_SHELL_HEARTBEAT:-0}" == "1" ]]; then


### PR DESCRIPTION
## Summary
- document cat/tail wrappers in AGENTS guardrails
- bootstrap prints reminder about cat and tail aliases

## Testing
- `npm search tail --json | head -n 20`
- `npm view tail --json | head -n 20`
- `npm test` *(timeout: partial output shows tests executing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f89b084c83309af0ce76e04b2bdb