### PR TITLE
feat: expand npm utilities for package discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,26 +136,23 @@ Act on these; don’t ignore them.
 
 ## Package Choice Mandate (reuse-first)
 
-Before implementing new functionality, search the registry and prefer reuse:
+Before implementing new functionality, search the registry and prefer reuse. Use the helper script:
 
 ```bash
-node scripts/npm-utils.js <package>
+node scripts/npm-utils.js search '<keywords>'       # list matching packages
+node scripts/npm-utils.js view <pkg>               # show package metadata
+node scripts/npm-utils.js analyze '<keywords>'    # summarize candidates
+node scripts/npm-utils.js install <pkg>           # install with exact pin
 ```
 
-* This prints latest versions via registry search. If that tool is unavailable, minimally do:
+If the helper is unavailable, minimally run:
 
 ```bash
-npm view <package> version
 npm search --searchlimit 20 '<keywords>'
+npm view <package> --json
 ```
 
 Choose an existing package when suitable; write bespoke code only if you can name the gaps.
-
-Install with exact pins:
-
-```bash
-npm install <pkg>@<version> --save-exact
-```
 
 ---
 

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -1,25 +1,60 @@
 #!/usr/bin/env node
 const libnpmsearch = require('libnpmsearch');
 const npmFetch = require('npm-registry-fetch');
+const { execSync } = require('child_process');
 
-async function getLatestVersion(pkg) {
-  const results = await libnpmsearch(pkg, { size: 1 });
-  if (results.length === 0 || results[0].name !== pkg) {
-    throw new Error(`Package "${pkg}" not found`);
+async function search(keyword) {
+  const results = await libnpmsearch(keyword, { size: 20 });
+  for (const r of results) {
+    console.log(`${r.name}@${r.version} - ${r.description}`);
   }
+}
+
+async function view(pkg) {
   const info = await npmFetch.json(pkg);
-  return info['dist-tags']?.latest || info.version;
+  console.log(JSON.stringify(info, null, 2));
+}
+
+async function analyze(keyword) {
+  const results = await libnpmsearch(keyword, { size: 10, detailed: true });
+  const enriched = [];
+  for (const r of results) {
+    const pkg = r.package || r;
+    try {
+      const info = await npmFetch.json(pkg.name);
+      const lastPublish = info.time?.modified || info.time?.[pkg.version] || 'unknown';
+      enriched.push({
+        name: pkg.name,
+        version: pkg.version,
+        description: pkg.description,
+        lastPublish,
+        score: r.score?.final ?? 0,
+      });
+    } catch {
+      // ignore packages we cannot fetch
+    }
+  }
+  enriched.sort((a, b) => b.score - a.score);
+  console.log(JSON.stringify(enriched, null, 2));
+}
+
+async function install(pkg) {
+  const info = await npmFetch.json(pkg);
+  const version = info['dist-tags']?.latest || info.version;
+  execSync(`npm install ${pkg}@${version} --save-exact`, { stdio: 'inherit' });
 }
 
 async function main() {
-  const [, , pkg] = process.argv;
-  if (!pkg) {
-    console.error('Usage: npm-utils <package>');
+  const [, , cmd, arg] = process.argv;
+  if (!cmd || !arg || !['search', 'view', 'analyze', 'install'].includes(cmd)) {
+    console.error('Usage: npm-utils <search|view|analyze|install> <arg>');
     process.exit(1);
   }
   try {
-    const version = await getLatestVersion(pkg);
-    console.log(version);
+    if (cmd === 'search') await search(arg);
+    else if (cmd === 'view') await view(arg);
+    else if (cmd === 'analyze') await analyze(arg);
+    else if (cmd === 'install') await install(arg);
   } catch (err) {
     console.error(err.message);
     process.exit(1);


### PR DESCRIPTION
## Summary
- extend `scripts/npm-utils.js` with `search`, `view`, `analyze`, and `install` commands
- document npm package discovery workflow in `AGENTS.md`

## Testing
- `npm search npm-registry`
- `npm view libnpmsearch --json`
- `node scripts/npm-utils.js search npm-registry`
- `node scripts/npm-utils.js analyze npm-registry`
- `npm test` *(hangs after extended idle, interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68a417983014833088c4928718dbde21