### PR TITLE
Fix Nunjucks spec sheet and series permalink issues

### DIFF
--- a/src/_includes/components/products/SpecSheet.njk
+++ b/src/_includes/components/products/SpecSheet.njk
@@ -66,7 +66,13 @@
     <div class="stats stats-vertical sm:stats-horizontal w-full bg-base-200/40 rounded-xl border border-base-300/50">
       <div class="stat">
         <div class="stat-title opacity-70">Release</div>
-        <div class="stat-value text-xl">{{ releaseDate ? (releaseDate | humanDate | safe) : 'TBD' }}</div>
+        <div class="stat-value text-xl">
+          {% if releaseDate %}
+            {{ releaseDate | humanDate | safe }}
+          {% else %}
+            TBD
+          {% endif %}
+        </div>
         {% if p.size and (p.size.h or p.size.w or p.size.d) %}
           <div class="stat-desc">
             {{ p.size.h }}
@@ -84,14 +90,18 @@
             {{ primaryMarket.currency }} {{ primaryMarket.price }}
           {% elseif msrpMap %}
             {% for ccy, amt in msrpMap %}
-              {{ ccy }} {{ amt }}{% break %}
+              {% if loop.first %}
+                {{ ccy }} {{ amt }}
+              {% endif %}
             {% endfor %}
           {% else %}—{% endif %}
         </div>
         {% if secRange %}
           <div class="stat-desc">
             {% for ccy, rng in secRange %}
-              Secondary: {{ ccy }} {{ rng }}{% break %}
+              {% if loop.first %}
+                Secondary: {{ ccy }} {{ rng }}
+              {% endif %}
             {% endfor %}
           </div>
         {% endif %}

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
@@ -4,7 +4,7 @@ pagination:
   data: collections.monstersSeries
   size: 1
   alias: series
-permalink: "/archives/collectables/designer-toys/pop-mart/the-monsters/series/{{ series.data.slug }}/index.html"
+permalink: "/archives/collectables/designer-toys/pop-mart/the-monsters/series/{{ series.data.slug or series.fileSlug or pagination.pageNumber }}/index.html"
 ---
 <h1 class="text-2xl font-bold mb-2">{{ series.data.title }}</h1>
 <p class="mb-4">{{ series.data.notes }}</p>


### PR DESCRIPTION
## Summary
- avoid Nunjucks parser errors by replacing JS-style ternary and break tags in spec sheet
- ensure series pages use fallback slug to prevent duplicate permalink conflicts

## Testing
- `npx @11ty/eleventy --input=src --output=_site --quiet`
- `npm test` *(fails: long-running build did not complete within allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68a44ea44b00833091f5e86a1b1c8ebf