### PR TITLE
chore: align tailwind pipeline with daisyui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ tools/search2serp/package-lock.json
 tmp/
 coverage/
 .llm-bash-env
+
+# Generated CSS
+src/assets/css/*
+!src/assets/css/.gitkeep

--- a/lib/eleventy/register.js
+++ b/lib/eleventy/register.js
@@ -161,6 +161,8 @@ module.exports = function register(eleventyConfig) {
     'node_modules/lucide/dist/umd/lucide.min.js': 'assets/js/lucide.min.js'
   });
   eleventyConfig.addPassthroughCopy({ 'src/assets/static': 'assets' });
+  eleventyConfig.addPassthroughCopy({ 'src/assets/css': 'assets/css' });
+  eleventyConfig.addWatchTarget('src/styles');
   eleventyConfig.addWatchTarget('src/assets/static');
 
   eleventyConfig.setBrowserSyncConfig({
@@ -173,7 +175,7 @@ module.exports = function register(eleventyConfig) {
   if (!isTest) {
     eleventyConfig.on('eleventy.before', async () => {
       console.log('🚀 Eleventy build starting with enhanced footnote system...');
-      await runPostcss('src/styles/app.tailwind.css', '_site/assets/css/app.css');
+      await runPostcss('src/styles/app.tailwind.css', 'src/assets/css/app.css');
     });
     eleventyConfig.on('eleventy.after', ({ results }) => {
       console.log(`✅ Eleventy build completed. Generated ${results.length} files.`);

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,6 @@
 /*  tailwind.config.cjs  (CommonJS so the plugin’s require() always works) */
 module.exports = {
-  content: ["./src/**/*.{njk,md,html,js}"],
+    content: ['./src/**/*.{njk,md,html,js}','./src/content/archives/**/*.{njk,md,html}','./src/_includes/**/*.{njk,md,html,js}'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- ensure Tailwind scans archive and include templates
- compile Tailwind via PostCSS into versioned CSS bundle and watch styles
- track generated CSS outside repo with .gitkeep placeholder

## Testing
- `npm test` *(fails: missing product fixture, availability text, wikilinks placeholder, docs:links JSON parse)*
- `npx @11ty/eleventy --input=src --output=_site --quiet`
- `node verification script`

------
https://chatgpt.com/codex/tasks/task_e_68a4ba40e7c48330a2011966c3bb5cb1