### PR TITLE
Add verification ecology concept article

### DIFF
--- a/src/content/concepts/verification-is-an-ecology.md
+++ b/src/content/concepts/verification-is-an-ecology.md
@@ -1,0 +1,235 @@
+---
+title: 'Verification Is an Ecology'
+layout: 'layout.njk'
+date: 2025-08-20
+status: Draft
+certainty: exploratory
+importance: 3
+tags:
+  - verification
+  - information-ecology
+  - human-machine
+  - trust
+  - risk
+  - doubt
+  - reputation-systems
+  - decision-theory
+spark_type: field-guide
+target: Verification roles in human–machine systems
+analytic_lens:
+  - information-ecology
+  - labor-economics
+  - risk-design
+  - human-algorithm-teaming
+  - reputation-mechanisms
+memory_ref:
+  - [verification]
+  - [human-algorithm]
+  - [risk-management]
+  - [reputation-systems]
+  - [decision-theory]
+preamble:
+  classification: '[CONCEPT] Verification dynamics in hybrid ecosystems'
+  version: '1.0-draft'
+---
+
+Hypothesis. In mixed human–machine environments, verification is not a step in a checklist; it is an ecological force. It shapes which claims are born, which survive, and which go sterile. Some actors evolve toward risk and discovery; others evolve toward scrutiny and containment. When the balance holds, the system learns; when it tilts—toward credulity or toward veto—knowledge decays. Verification is less about proof than the fair distribution of doubt so the organism doesn’t poison itself.^[1]^[2]
+
+What follows is a field guide rather than a theorem: a way to see how doubt moves through communities that use agentic tools, how skepticism can be both protective and predatory, how “show your work” is a labor market, and how we can build habitats where verification produces more light than heat.
+
+---
+
+### The Predator, the Scavenger, and the Gardener
+
+Every living system generates roles. Verification ecosystems are no different.
+
+Predators specialize in the high-friction kill. They pounce on weak claims, demand receipts, press for replication. Their presence restores selection pressure; their absence invites sugary stories and confident hallucinations. Scientific peer review, for all its flaws, exists to institutionalize this predator function: it slows, questions, and filters so that downstream readers do not drown in unvetted assertions.^[3] In social systems, strong reputation mechanisms play a similar part, making it costly to bluff and cheaper to be honest.^[5]^[6]
+
+Scavengers digest what others leave behind. They link sources, reconcile numbers, translate jargon, reproduce steps, and note caveats. They are the engine of hybrid intelligence: people plus machines turning scattered signals into usable food. In practice this looks like small acts with big payoffs—re-running a query, checking a timestamp, diffing a shortlist against a second pass—work that rarely wins arguments but quietly prevents future errors. Information quality, in this sense, is not a single property of a datum but a bundle of dimensions (accuracy, timeliness, lineage) that scavengers maintain.^[4]
+
+Gardeners cultivate. They build the tools and norms that keep pathogens in check: logging standards; “no source, no claim” rules; reproducibility kits; proxy settings to match user geography; risk tiers for when to escalate to a human. Predators punish. Gardeners prevent. Reputation systems are their compost bins and trellises: simple structures—ratings, histories, identity binding—that reduce the rate at which the vines of misinformation strangle the tomatoes.^[5]^[6]
+
+A healthy ecology needs all three. An overrun of predators produces a chilling plain—nothing explores, every sprout is bitten off at the soil. A glut of gardeners without predators yields polite compost heaps no one uses. Scavengers without either become overworked undertakers. The lesson is simple and hard to institutionalize: verification is a role distribution, not a personality. Professionalize the roles and you get a functioning habitat. Personalize them and you get a culture war.
+
+---
+
+### The Labor Politics of Doubt
+
+Verification costs work. Who pays?
+
+“Prove it” is not only epistemology; it is economics. Sometimes it is fair: burden of proof belongs with the one making the strong claim. Sometimes it becomes abusive: a demand for impossible proof that functions as a denial-of-service attack. The difference is scope. “Best within this listed set of sources, under this region, at this time, with a ledger and screenshots” is a claim that can be checked. “Prove global best” is not a request for evidence; it is a way to ensure that no evidence is ever enough.
+
+Communities rarely talk about the distribution of verification labor, but they live with the consequences. Doubt can be weaponized—outsourced upward to whoever happens to be enthusiastic or conscientious in the moment—or it can be budgeted, with roles and caps. Philosophers of knowledge have a name for the unequal distribution of credibility burdens—epistemic injustice—and it appears wherever some groups are routinely asked to verify more, explain more, or carry skepticism others are spared.^[7] Designing for fairness means scoping claims, budgeting the audit, and publishing the work so that doubt stops being a free externality.
+
+The moral isn’t to shame skepticism. It’s to meter doubt so it fertilizes the field instead of salting it.
+
+---
+
+### The Theatre of Trust
+
+People do not verify only to be correct. They verify to perform reliability to one another.
+
+In public spaces, “verify” is a costume as much as a method. Some wear it to signal competence: I don’t fall for shiny demos. Some wear it to signal belonging: our tribe values skepticism. Some wear it to signal dominance: explain yourself to me. The performance matters; it determines which claims are legible, whose time is considered valuable, and how standards drift.
+
+The performance can be healthy. Habitual requesters of receipts push norms toward screenshots over vibes and logs over gestures. It can also be corrosive: a permanent posture of “prove everything to me” that escalates until the only winning move is silence. Once you see the theatre, you can redirect it. The status game becomes, “who can build a verification kit others adopt,” not who can sneer the loudest. Sociologists called this long ago: trust is a staged arrangement, and the staging can be designed.^[8]^[9] Behavioral science gives the same counsel in plainer words: social proof is powerful, so aim it at practices that actually improve signal, not at applause lines.^[8]
+
+---
+
+### Two Games on One Board
+
+Many fights about verification are really fights about which game we’re playing.
+
+The finite game prizes safety now. Its goal is to prevent harm today: no wrong charge on the card, no fake listing in the cart, no made-up statistic in the brief. It wants small, guaranteed wins and hates tails.
+
+The infinite game prizes learning. Its goal is to grow capacity: try the tool, instrument it, accept bounded errors to discover new techniques. It wants sustained improvement and hates stagnation.
+
+Both games are valid. Trouble begins when one insists on the other’s turf. The finite player treats every purchase like heart surgery and bans experimentation everywhere. The infinite player treats every purchase like a sandbox and shrugs at losses others have to bear. Human–algorithm studies point to the same truce: where stakes are tight and feedback is sparse, human oversight dominates; where exploration pays and errors are cheap, the team of human plus model outperforms either alone.^[12]^[13] Decision theory and risk work add the tail warning: when losses are heavy-tailed, you cordon off the domain rather than argue about optimism.^[10]^[11]
+
+The fix is not a manifesto; it’s a scheduler. Make risk tiers explicit:
+
+- **Red:** identity, payment, high-stakes purchases. Human or certified pipeline only.
+- **Amber:** moderate stakes. The machine can explore but must abstain on uncertainty, pin sources, and escalate on anomalies.
+- **Green:** trivial or refundable. The machine can roam; a few sample checks suffice; we care about average time saved and discoverability.
+
+Assign the game to the tier. Now “verify” means different things in different places, by design rather than by personality.
+
+---
+
+### How Machines Change the Surface Area of Doubt
+
+Before agentic tools, most people compared a handful of options before buying. Machines blow that search open. They can crawl boutiques and outlet mirrors, regional storefronts and forum deals—surfacing options a human would never see. More discovery brings more doubt. The frontier moves, and with it the potential for missing a better deal.
+
+This is where precision at the top matters more than covering the world. If the first few candidates the system returns are almost always real, in-stock, and fairly priced, then the rest of the distribution can be ignored without regret. That is measurable and unglamorous:
+
+1. Keep a ledger of what the system returns as its top few picks.
+2. For a sample, check whether those picks were valid and faithfully represented.
+3. Calculate how often the shortlist is trustworthy (shortlist precision).
+4. Track the price gap between the chosen item and the best found in a second, independent pass (regret).
+
+Information retrieval has lived on precision/recall trade-offs for decades; the twist here is to focus the metric where human attention actually lands—at the top of the list.^[14] On the model side, don’t rely on detectors to catch every fabrication. The most robust gains tend to come from abstention and source pinning: if a page can’t be read, say so; if a value isn’t backed, don’t guess; if the context is ambiguous, escalate.^[15]^[16]^[17] These are design choices, not personality traits.
+
+A community can live happily with high shortlist precision and low regret, even if it never proves global optimality. It cannot live with plausible fabrications at the top, even if “on average” the system does well. The doubter’s instincts are right at the top of the list; the explorer’s instincts are right about the value of seeing more of the map. The metrics let each side check the part that matters to them.
+
+---
+
+### Engineering a Habitat Where Verification Works
+
+Theories are nice. Habitats feed people. A few design moves tame the worst pathologies without turning every errand into a dissertation.
+
+1. Ban absolute claims. Replace “lowest price” with scoped assertions: “best found within listed sources, under stated region, at given time,” plus a ledger and screenshots. People read what you write; make the boundary part of the sentence.^[4]^[5]
+2. “No source, no claim.” If a step failed, the system says so. If a page can’t be read, it defers rather than fabricates a plausible fill. Abstention and refusal reduce exposure to hallucination more reliably than any single detector.^[15]^[16]^[17]
+3. Proxy parity. When prices depend on geography or login state, the system matches the user’s conditions or declares that it can’t. Partial truth labeled as partial truth is honest.
+4. Shortlist precision before breadth. Tune for trustworthy top results, not for exhaustive coverage. Discovery is valuable only if the first options aren’t rotten.^[14]
+5. Risk router. Red/amber/green is not a metaphor. It’s a policy. Publish which categories sit where and move them only after measurement.^[10]^[11]^[12]
+6. Public numbers. Once a month, publish the two figures that matter: shortlist precision and regret by category. These keep everyone honest without requiring a statistics degree.^[4]^[5]^[14]
+7. Veto budgets and auditor roles. Give dedicated skeptics explicit powers and limits. After a set number of vetoes, they must propose concrete fixes—proxy parity, coupon-landing checks—or step back. Authority comes with obligations. This is ecology translated into governance: predators, yes; apex-predators-only, no.^[1]^[2]^[6]
+
+This is how you convert a culture war into maintenance. The predator now hunts by rule; the gardener plants by spec; the scavenger recycles into shared kits. The ecology becomes legible and the fights shrink from metaphysics to operations.
+
+---
+
+### Failure Modes Worth Respecting
+
+Any honest habitat admits its predators bite the wrong necks.
+
+- **Heavy tails.** Some domains hide catastrophic downside. One miss costs more than a thousand small wins. These belong in red tiers until proven otherwise.^[10]^[11]
+- **Spec theatre.** People can fake ledgers and screenshots. Audit occasionally and expel cheats without drama.^[5]^[6]
+- **Metrics drift.** Shortlist precision can look fine while the world changes underfoot. Re-sample. Rotate auditors. Plan to be surprised.^[14]
+- **Bureaucratic creep.** A good badge spec can colonize the entire forest. Keep it short. Kill accretions.^[4]
+
+The point isn’t to eliminate failure. The point is to bound it and to learn from it without burning the habitat down.
+
+---
+
+### Coda: Living With Doubt
+
+Verification will never be finished because the world never stops moving. That is not a defect; it is the price of being alive in a place where options multiply faster than certainties. The job is not to build an oracle. The job is to build an ecology where doubt is strong enough to keep us honest and gentle enough to let good ideas grow.
+
+---
+
+### Annotated Appendix
+
+[^1]: **[C. O’Connor & J. Weatherall (2019)]** – _The Misinformation Age: How False Beliefs Spread_.
+> _Epistemic Note (Primary):_ Explains how misinformation propagates through social systems, grounding the ecology metaphor.
+> **Source Type:** Primary
+> - **URL:** `https://press.princeton.edu/books/hardcover/9780691179232/the-misinformation-age`
+
+[^2]: **[D. Centola (2018)]** – _How Behavior Spreads: The Science of Complex Contagions_.
+> _Epistemic Note (Primary):_ Introduces complex contagion theory used to model verification dynamics.
+> **Source Type:** Primary
+> - **URL:** `https://press.princeton.edu/books/hardcover/9780691175319/how-behavior-spreads`
+
+[^3]: **[M. Ware & M. Monkman (2015)]** – _Peer Review: An Introduction and Guide_.
+> _Epistemic Note (Conceptual):_ Provides institutional context for predator roles in verification.
+> **Source Type:** Conceptual
+> - **URL:** `https://publishingresearchconsortium.com/index.php/102-prc-guides/peer-review-an-introduction-and-guide`
+
+[^4]: **[R. Y. Wang & D. M. Strong (1996)]** – “Beyond Accuracy: What Data Quality Means to Data Consumers.”
+> _Epistemic Note (Primary):_ Defines multi-dimensional data quality, basis for scavenger duties.
+> **Source Type:** Primary
+> - **URL:** `https://doi.org/10.1080/07421222.1996.11518099`
+
+[^5]: **[P. Resnick & R. Zeckhauser (2002)]** – “Trust Among Strangers in Internet Transactions: Empirical Analysis of eBay’s Reputation System.”
+> _Epistemic Note (Primary):_ Empirical evidence for reputation systems as verification infrastructure.
+> **Source Type:** Primary
+> - **URL:** `https://doi.org/10.1016/S0167-6245(01)00062-4`
+
+[^6]: **[C. Dellarocas (2003)]** – “The Digitization of Word of Mouth: Promise and Challenges of Online Feedback Mechanisms.”
+> _Epistemic Note (Primary):_ Extends reputation mechanics to digital marketplaces, informing gardener roles.
+> **Source Type:** Primary
+> - **URL:** `https://doi.org/10.1287/mnsc.49.10.1407.17378`
+
+[^7]: **[M. Fricker (2007)]** – _Epistemic Injustice: Power and the Ethics of Knowing_.
+> _Epistemic Note (Conceptual):_ Frames verification labor as a question of justice and distribution.
+> **Source Type:** Conceptual
+> - **URL:** `https://global.oup.com/academic/product/epistemic-injustice-9780198237907`
+
+[^8]: **[R. B. Cialdini (2009)]** – _Influence: Science and Practice_.
+> _Epistemic Note (Primary):_ Classic experiments on social proof underpin the theatre of trust.
+> **Source Type:** Primary
+> - **URL:** `https://www.pearson.com/en-us/subject-catalog/p/influence/P200000006695/9780205609994`
+
+[^9]: **[E. Goffman (1959)]** – _The Presentation of Self in Everyday Life_.
+> _Epistemic Note (Conceptual):_ Provides the dramaturgical lens for trust performances.
+> **Source Type:** Conceptual
+> - **URL:** `https://monoskop.org/images/1/19/Goffman_Erving_The_Presentation_of_Self_in_Everyday_Life.pdf`
+
+[^10]: **[N. N. Taleb (2012)]** – _Antifragile: Things That Gain from Disorder_.
+> _Epistemic Note (Conceptual):_ Introduces heavy-tail risk framing for red-tier domains.
+> **Source Type:** Conceptual
+> - **URL:** `https://www.penguinrandomhouse.com/books/215462/antifragile-by-nassim-nicholas-taleb/`
+
+[^11]: **[D. Kahneman & A. Tversky (1979)]** – “Prospect Theory: An Analysis of Decision under Risk.”
+> _Epistemic Note (Primary):_ Establishes bounded rationality underlying risk tiers.
+> **Source Type:** Primary
+> - **URL:** `https://doi.org/10.2307/1914185`
+
+[^12]: **[J. Kleinberg et al. (2018)]** – “Human Decisions and Machine Predictions.”
+> _Epistemic Note (Primary):_ Demonstrates complementarity between humans and algorithms.
+> **Source Type:** Primary
+> - **URL:** `https://doi.org/10.1093/qje/qjx032`
+
+[^13]: **[V. Lai, C. Chen, & C. Tan (2019/2021)]** – “On Human-AI Complementarity.”
+> _Epistemic Note (Primary):_ Empirical grounding for mixed oversight models.
+> **Source Type:** Primary
+> - **URL:** `https://arxiv.org/abs/2112.04237`
+
+[^14]: **[C. D. Manning, P. Raghavan, & H. Schütze (2008)]** – _Introduction to Information Retrieval_.
+> _Epistemic Note (Conceptual):_ Standard text on precision/recall, source for shortlist metrics.
+> **Source Type:** Conceptual
+> - **URL:** `https://doi.org/10.1017/CBO9780511809071`
+
+[^15]: **[Z. Ji et al. (2023)]** – “Survey of Hallucination in Natural Language Generation.”
+> _Epistemic Note (Primary):_ Catalogs failure modes motivating abstention strategies.
+> **Source Type:** Primary
+> - **URL:** `https://arxiv.org/abs/2302.02430`
+
+[^16]: **[J. Maynez et al. (2020)]** – “On Faithfulness and Factuality in Abstractive Summarization.”
+> _Epistemic Note (Primary):_ Evaluates fidelity in summarization systems, supporting source pinning.
+> **Source Type:** Primary
+> - **URL:** `https://doi.org/10.18653/v1/2020.acl-main.450`
+
+[^17]: **[S. Kadavath et al. (2022)]** – “Language Models (Mostly) Know What They Know.”
+> _Epistemic Note (Primary):_ Shows models’ awareness of uncertainty, justifying abstention mechanisms.
+> **Source Type:** Primary
+> - **URL:** `https://arxiv.org/abs/2207.05221`


### PR DESCRIPTION
## Summary
- move "Verification Is an Ecology" to the concepts section and classify as a concept
- convert source list into an annotated appendix with epistemic notes and source types

## Testing
- `npm test` *(fails: ENOENT .dead-links.json, missing product metadata, availability assertion, docs:links JSON parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68a58dffff888330a30058486a193d00