### PR TITLE
feat: wire tailwind v4 with daisyui v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Nothing exotic—just a normal Eleventy dev loop, with nicer defaults if you opt
 * `src/` — All content & templates used by Eleventy (Markdown, Nunjucks, data, assets).
 * `lib/` — Reusable app/library code (helpers, transforms, utilities).
 * `.eleventy.js` — Eleventy config (collections, filters/shortcodes, passthrough).
-* `tailwind.config.cjs` / `postcss.config.cjs` — Styling pipeline config (Tailwind + PostCSS).
+* `src/styles/app.tailwind.css` — Tailwind v4 entry with `@plugin` and `@source` directives.
+* `tailwind.config.cjs` / `postcss.config.cjs` — Theme tokens and PostCSS pipeline.
 
 ## 2) Automation, Tooling & Guardrails
 
@@ -179,7 +180,7 @@ Nothing exotic—just a normal Eleventy dev loop, with nicer defaults if you opt
 
   * Collections via `addCollection` in `.eleventy.js`
   * Static assets via `addPassthroughCopy`
-* **Tailwind/DaisyUI**: theme in `tailwind.config.cjs`
+* **Tailwind/DaisyUI**: plugins/themes in `src/styles/app.tailwind.css`, tokens in `tailwind.config.cjs`
 * **Node version**: respect `.nvmrc`
 
 ---

--- a/lib/eleventy/register.js
+++ b/lib/eleventy/register.js
@@ -164,6 +164,9 @@ module.exports = function register(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ 'src/assets/css': 'assets/css' });
   eleventyConfig.addWatchTarget('src/styles');
   eleventyConfig.addWatchTarget('src/assets/static');
+  // Rebuild when Tailwind/PostCSS configs change
+  eleventyConfig.addWatchTarget('tailwind.config.cjs');
+  eleventyConfig.addWatchTarget('postcss.config.cjs');
 
   eleventyConfig.setBrowserSyncConfig({
     index: 'index.html',

--- a/src/styles/app.tailwind.css
+++ b/src/styles/app.tailwind.css
@@ -299,4 +299,4 @@
 }
 
 /* If you see utility gaps, explicitly hint sources for Tailwind v4 */
-@source "./src/**/*.{njk,md,html,js}";
+@source "../**/*.{njk,md,html,js}";

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,6 @@
 /*  tailwind.config.cjs  (CommonJS so the plugin’s require() always works) */
+// Tailwind v4: templates are declared via `@source` in CSS, and plugins via `@plugin`.
 module.exports = {
-    content: ['./src/**/*.{njk,md,html,js}','./src/content/archives/**/*.{njk,md,html}','./src/_includes/**/*.{njk,md,html,js}'],
   theme: {
     extend: {
       colors: {
@@ -24,28 +24,5 @@ module.exports = {
         mono: ["'Roboto Mono'", "monospace"]
       }
     }
-  },
-  // Plugins are loaded via @plugin directives in CSS
-  daisyui: {
-    themes: [
-      {
-        dark: {
-          primary: "#0A84FF",
-          neutral: "#1a1a1a",
-          "base-100": "#000000",
-          "base-200": "#1a1a1a",
-          "base-300": "#2a2a2a"
-        }
-      },
-      {
-        light: {
-          primary: "#0A84FF",
-          neutral: "#1a1a1a",
-          "base-100": "#ffffff",
-          "base-200": "#f0f0f0",
-          "base-300": "#d9d9d9"
-        }
-      }
-    ]
   }
 };


### PR DESCRIPTION
## Summary
- remove legacy Tailwind v3 config and move plugin/theme setup to CSS
- rebuild Eleventy watch pipeline and docs for Tailwind v4 + daisyUI v5

## Testing
- `npm test`
- `npm run build`
- `npm run dev` *(fails: Playwright browser missing)*


------
https://chatgpt.com/codex/tasks/task_e_68a6335204e88330b08f24e9329f8795