### PR TITLE
feat: migrate codebase to esm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ _Effusion Labs — Operating Rails for Autonomous Coding Agents (Codex-style)_
 
 This is the **in-repo operating spec** for autonomous coding agents that run bash, read/write files, and iterate quickly. It complements the upstream system charter (Mission Anchor, No-Ask, single final message) — keep that in mind and use this as the on-disk contract.
 
+> **Note:** The repository is ESM-first (`type: "module"`). Use `import`/`export` syntax for Node.js files. Any modules that must remain CommonJS use the `.cjs` extension explicitly.
+
 ---
 
 ## 0) Runtime Augmentation (one command)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Effusion Labs is a static site built with:
 
 Output is emitted to `_site/`, suitable for direct static hosting or containerization. GitHub Actions drive deploys and link checks.
 
-**Runtime target:** Node.js **24+** (honor `.nvmrc` if present).
+**Runtime target:** Node.js **24+** (honor `.nvmrc` if present). The repository is ESM-first (`package.json` sets `"type": "module"`); use `import`/`export` syntax. Configuration files that must stay CommonJS are suffixed with `.cjs`.
 
 ---
 

--- a/cjs-report.json
+++ b/cjs-report.json
@@ -1,0 +1,198 @@
+[
+  {
+    "file": "lib/archive-nav.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/config.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/plugins.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/outboundProxy.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/build-info.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/constants.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/seeded.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/filters.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/webpageToMarkdown.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/eleventy/archive-collections.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/markdown/links.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/markdown/index.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/eleventy/register.js",
+    "status": "Unresolved"
+  },
+  {
+    "file": "lib/markdown/footnotes.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/utils.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/homepage.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/markdown/inlineMacros.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/postcss.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/markdownGateway.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/concept-map.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/shortcodes.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/postcssPlugins.js",
+    "status": "Unresolved"
+  },
+  {
+    "file": "lib/flareClient.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/proxyAgent.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "lib/wikilinks/filter-dead-links.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "tailwind.config.cjs",
+    "status": "Kept as .cjs (compat)"
+  },
+  {
+    "file": "src/work.11tydata.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "src/_data/archivesNav.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "src/_data/eleventyComputed.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "src/_data/branding.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "src/_data/nav.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "test/integration/feed-build-meta.spec.mjs",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "test/lib/markdownGateway.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "test/lib/concept-map.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "test/src/_data/nav.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "test/unit/design-tokens.test.mjs",
+    "status": "Unresolved"
+  },
+  {
+    "file": "scripts/npm-utils.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "scripts/merge-golden.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "postcss.config.cjs",
+    "status": "Kept as .cjs (compat)"
+  },
+  {
+    "file": "src/styles/app.tailwind.css",
+    "status": "Unresolved"
+  },
+  {
+    "file": "src/index.11tydata.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "src/work/latest.11ty.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "src/work/drop.11ty.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "tools/select.mjs",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "tools/synthesize-archive.mjs",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "tools/build-vendor-index.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "tools/synthesize.mjs",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "tools/validate-docs.js",
+    "status": "Converted or Removed"
+  },
+  {
+    "file": "tools/merge-golden.mjs",
+    "status": "Converted or Removed"
+  }
+]

--- a/cjs-report.md
+++ b/cjs-report.md
@@ -1,0 +1,51 @@
+# CJS Discovery Report
+
+- lib/archive-nav.js: Converted or Removed
+- lib/config.js: Converted or Removed
+- lib/plugins.js: Converted or Removed
+- lib/outboundProxy.js: Converted or Removed
+- lib/build-info.js: Converted or Removed
+- lib/constants.js: Converted or Removed
+- lib/seeded.js: Converted or Removed
+- lib/filters.js: Converted or Removed
+- lib/webpageToMarkdown.js: Converted or Removed
+- lib/eleventy/archive-collections.js: Converted or Removed
+- lib/markdown/links.js: Converted or Removed
+- lib/markdown/index.js: Converted or Removed
+- lib/eleventy/register.js: Unresolved
+- lib/markdown/footnotes.js: Converted or Removed
+- lib/utils.js: Converted or Removed
+- lib/homepage.js: Converted or Removed
+- lib/markdown/inlineMacros.js: Converted or Removed
+- lib/postcss.js: Converted or Removed
+- lib/markdownGateway.js: Converted or Removed
+- lib/concept-map.js: Converted or Removed
+- lib/shortcodes.js: Converted or Removed
+- lib/postcssPlugins.js: Unresolved
+- lib/flareClient.js: Converted or Removed
+- lib/proxyAgent.js: Converted or Removed
+- lib/wikilinks/filter-dead-links.js: Converted or Removed
+- tailwind.config.cjs: Kept as .cjs (compat)
+- src/work.11tydata.js: Converted or Removed
+- src/_data/archivesNav.js: Converted or Removed
+- src/_data/eleventyComputed.js: Converted or Removed
+- src/_data/branding.js: Converted or Removed
+- src/_data/nav.js: Converted or Removed
+- test/integration/feed-build-meta.spec.mjs: Converted or Removed
+- test/lib/markdownGateway.js: Converted or Removed
+- test/lib/concept-map.js: Converted or Removed
+- test/src/_data/nav.js: Converted or Removed
+- test/unit/design-tokens.test.mjs: Unresolved
+- scripts/npm-utils.js: Converted or Removed
+- scripts/merge-golden.js: Converted or Removed
+- postcss.config.cjs: Kept as .cjs (compat)
+- src/styles/app.tailwind.css: Unresolved
+- src/index.11tydata.js: Converted or Removed
+- src/work/latest.11ty.js: Converted or Removed
+- src/work/drop.11ty.js: Converted or Removed
+- tools/select.mjs: Converted or Removed
+- tools/synthesize-archive.mjs: Converted or Removed
+- tools/build-vendor-index.js: Converted or Removed
+- tools/synthesize.mjs: Converted or Removed
+- tools/validate-docs.js: Converted or Removed
+- tools/merge-golden.mjs: Converted or Removed

--- a/lib/archive-nav.js
+++ b/lib/archive-nav.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const path = require('path');
-const { baseContentPath } = require('./constants');
+import fs from 'node:fs';
+import path from 'node:path';
+import { baseContentPath } from './constants.js';
 
 /**
  * Convert a directory name to a human-friendly title.
@@ -48,9 +48,9 @@ function buildMap(dir, url, acc = {}) {
  * Build navigation map for archives based on folder structure.
  * @returns {Object}
  */
-function buildArchiveNav() {
+export function buildArchiveNav() {
   const root = path.join(process.cwd(), baseContentPath, 'archives');
   return buildMap(root, '/archives/');
 }
 
-module.exports = { buildArchiveNav };
+export default { buildArchiveNav };

--- a/lib/build-info.js
+++ b/lib/build-info.js
@@ -1,7 +1,7 @@
 // lib/build-info.js
 // A simple, synchronous utility to get build information without relying on Git.
 
-function getBuildInfo() {
+export function getBuildInfo() {
   const date = new Date();
   const isCI = process.env.GITHUB_ACTIONS === 'true';
 
@@ -27,4 +27,4 @@ function getBuildInfo() {
   };
 }
 
-module.exports = { getBuildInfo };
+export default { getBuildInfo };

--- a/lib/concept-map.js
+++ b/lib/concept-map.js
@@ -72,7 +72,7 @@ function buildEdges(pages) {
  * @param {Array<Object>} pages
  * @returns {Object}
  */
-function generateConceptMapJSONLD(pages) {
+export default function generateConceptMapJSONLD(pages) {
   const nodes = buildNodes(pages);
   const edges = buildEdges(pages);
   return {
@@ -80,5 +80,3 @@ function generateConceptMapJSONLD(pages) {
     '@graph': [...nodes, ...edges]
   };
 }
-
-module.exports = generateConceptMapJSONLD;

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,11 +4,11 @@
  */
 
 /** Eleventy directory settings */
-const dirs = {
+export const dirs = {
   input: 'src',
   output: process.env.ELEVENTY_TEST_OUTPUT || '_site',
   includes: '_includes',
-  data: '_data'
+  data: '_data',
 };
 
-module.exports = { dirs };
+export default { dirs };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,15 +3,14 @@
  * @module constants
  */
 
-const path = require('node:path');
+import path from 'node:path';
 
 /** Root directory for markdown content */
-const baseContentPath = 'src/content';
+export const baseContentPath = 'src/content';
 
 /** Absolute path to concepts directory */
-const CONCEPTS_DIR = path.join(baseContentPath, 'concepts');
+export const CONCEPTS_DIR = path.join(baseContentPath, 'concepts');
 
 /** Primary content areas used for collections and navigation */
-const CONTENT_AREAS = ['sparks', 'concepts', 'projects', 'archives', 'meta'];
-
-module.exports = { baseContentPath, CONTENT_AREAS, CONCEPTS_DIR };
+export const CONTENT_AREAS = ['sparks', 'concepts', 'projects', 'archives', 'meta'];
+export default { baseContentPath, CONTENT_AREAS, CONCEPTS_DIR };

--- a/lib/eleventy/archive-collections.js
+++ b/lib/eleventy/archive-collections.js
@@ -1,10 +1,10 @@
-const fs = require("fs");
-const path = require("path");
+import fs from 'node:fs';
+import path from 'node:path';
 
 const TYPES = ["products", "series", "characters"];
 const fsJoin = path.join;
 
-function camelize(slug) {
+export function camelize(slug) {
   return slug
     .replace(/^the-/, "")
     .split("-")
@@ -12,7 +12,7 @@ function camelize(slug) {
     .join("");
 }
 
-function registerArchiveCollections(eleventyConfig) {
+export default function registerArchiveCollections(eleventyConfig) {
   const fsBase = fsJoin("src", "content", "archives");
 
   function scan(dirFs, parts = []) {
@@ -46,6 +46,3 @@ function registerArchiveCollections(eleventyConfig) {
     scan(fsBase, []);
   }
 }
-
-module.exports = registerArchiveCollections;
-module.exports._camelize = camelize;

--- a/lib/eleventy/register.js
+++ b/lib/eleventy/register.js
@@ -1,21 +1,21 @@
-const markdownItFootnote = require('markdown-it-footnote');
-const markdownItAttrs = require('markdown-it-attrs');
-const markdownItAnchor = require('markdown-it-anchor');
-const { eleventyImageTransformPlugin } = require('@11ty/eleventy-img');
-const path = require('node:path');
-const fs = require('node:fs');
-const slugify = require('slugify');
-const { dirs } = require('../config');
-const { filterDeadLinks } = require('../wikilinks/filter-dead-links');
-const cliProgress = require('cli-progress');
+import markdownItFootnote from 'markdown-it-footnote';
+import markdownItAttrs from 'markdown-it-attrs';
+import markdownItAnchor from 'markdown-it-anchor';
+import { eleventyImageTransformPlugin } from '@11ty/eleventy-img';
+import path from 'node:path';
+import fs from 'node:fs';
+import slugify from 'slugify';
+import { dirs } from '../config.js';
+import { filterDeadLinks } from '../wikilinks/filter-dead-links.js';
+import cliProgress from 'cli-progress';
 const pMap = async (...args) => (await import('p-map')).default(...args);
 
-const getPlugins = require('../plugins');
-const filters = require('../filters');
-const { applyMarkdownExtensions } = require('../markdown');
-const { specnote } = require('../shortcodes');
-const { CONTENT_AREAS, baseContentPath } = require('../constants');
-const runPostcss = require('../postcss');
+import getPlugins from '../plugins.js';
+import filters from '../filters.js';
+import { applyMarkdownExtensions } from '../markdown/index.js';
+import { specnote } from '../shortcodes.js';
+import { CONTENT_AREAS, baseContentPath } from '../constants.js';
+import runPostcss from '../postcss.js';
 
 const glob = d => `${baseContentPath}/${d}/**/*.md`;
 
@@ -23,7 +23,7 @@ const glob = d => `${baseContentPath}/${d}/**/*.md`;
  * Register plugins, filters and other behaviour on the given Eleventy config.
  * @param {import('@11ty/eleventy/src/EleventyConfig')} eleventyConfig
  */
-module.exports = function register(eleventyConfig) {
+export default function register(eleventyConfig) {
   const plugins = getPlugins();
   plugins.forEach(([plugin, opts = {}]) => eleventyConfig.addPlugin(plugin, opts));
 
@@ -184,4 +184,4 @@ module.exports = function register(eleventyConfig) {
       console.log(`✅ Eleventy build completed. Generated ${results.length} files.`);
     });
   }
-};
+}

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,7 +1,7 @@
-const generateConceptMapJSONLD = require("./concept-map");
-const { DateTime } = require('luxon');
-const path = require('node:path');
-const { ordinalSuffix, readFileCached, webpageToMarkdown } = require('./utils');
+import generateConceptMapJSONLD from './concept-map.js';
+import { DateTime } from 'luxon';
+import path from 'node:path';
+import { ordinalSuffix, readFileCached, webpageToMarkdown } from './utils.js';
 
 const toStr = v => String(v ?? '');
 
@@ -175,7 +175,7 @@ function conceptMapJSONLD(pages = []) {
   return JSON.stringify(generateConceptMapJSONLD(pages));
 }
 
-module.exports = {
+export {
   conceptMapJSONLD,
   readableDate,
   htmlDateString,
@@ -192,5 +192,25 @@ module.exports = {
   humanDate,
   titleizeSlug,
   hostname,
-  provenanceSources
+  provenanceSources,
+};
+
+export default {
+  conceptMapJSONLD,
+  readableDate,
+  htmlDateString,
+  limit,
+  jsonify,
+  readingTime,
+  slugify,
+  truncate,
+  webpageToMarkdown,
+  isNew,
+  shout,
+  money,
+  yesNo,
+  humanDate,
+  titleizeSlug,
+  hostname,
+  provenanceSources,
 };

--- a/lib/flareClient.js
+++ b/lib/flareClient.js
@@ -1,7 +1,7 @@
-let { fetch, ProxyAgent } = require('undici');
-const { loadOutboundProxy } = require('./outboundProxy');
+import { fetch, ProxyAgent } from 'undici';
+import { loadOutboundProxy } from './outboundProxy.js';
 
-function __setUndici(u){
+export function __setUndici(u) {
   fetch = u.fetch;
   ProxyAgent = u.ProxyAgent;
 }
@@ -48,9 +48,9 @@ async function send(cmd, url, opts={}){
   }
 }
 
-const request = {
+export const request = {
   get: (url, opts={}) => send('request.get', url, opts),
-  post: (url, opts={}) => send('request.post', url, opts)
+  post: (url, opts={}) => send('request.post', url, opts),
 };
 
-module.exports = { request, __setUndici };
+export default { request, __setUndici };

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -1,7 +1,7 @@
-const { dailySeed, seededShuffle } = require('./seeded');
-const fs = require('node:fs');
-const path = require('node:path');
-const { baseContentPath } = require('./constants');
+import { dailySeed, seededShuffle } from './seeded.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { baseContentPath } from './constants.js';
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -30,23 +30,23 @@ function selectToday(items, seed) {
   return selected;
 }
 
-function getToday(items, { seed, limit = 3 } = {}) {
+export function getToday(items, { seed, limit = 3 } = {}) {
   return selectToday(items, seed).slice(0, limit);
 }
 
-function getTryNow(items, { limit = 3 } = {}) {
+export function getTryNow(items, { limit = 3 } = {}) {
   return items.slice(0, limit);
 }
 
-function tagNormalize(tags = []) {
+export function tagNormalize(tags = []) {
   return tags.map((t) => String(t).toLowerCase());
 }
 
-function safeUrl(item) {
+export function safeUrl(item) {
   return item && item.url ? item.url : '#';
 }
 
-function countEntries(coll, folder) {
+export function countEntries(coll, folder) {
   if (Array.isArray(coll)) {
     return coll.filter((p) => {
       const stem = p.filePathStem || '';
@@ -63,7 +63,7 @@ function countEntries(coll, folder) {
   }
 }
 
-function buildIdeaPathways(collections, { seed, limit = 3 } = {}) {
+export function buildIdeaPathways(collections, { seed, limit = 3 } = {}) {
   const concepts = collections.concepts || [];
   const projects = collections.projects || [];
   const sparks = collections.sparks || [];
@@ -89,7 +89,7 @@ function buildIdeaPathways(collections, { seed, limit = 3 } = {}) {
   });
 }
 
-function exploreLinks(collections) {
+export function exploreLinks(collections) {
   const defs = [
     { title: 'Projects', url: '/projects/', key: 'projects' },
     { title: 'Concepts', url: '/concepts/', key: 'concepts' },
@@ -103,7 +103,19 @@ function exploreLinks(collections) {
   }));
 }
 
-module.exports = {
+export {
+  dailySeed,
+  seededShuffle,
+  getToday,
+  getTryNow,
+  buildIdeaPathways,
+  exploreLinks,
+  tagNormalize,
+  safeUrl,
+  countEntries,
+};
+
+export default {
   dailySeed,
   seededShuffle,
   getToday,

--- a/lib/markdown/footnotes.js
+++ b/lib/markdown/footnotes.js
@@ -230,10 +230,18 @@ function disableFootnoteTail(md) {
   // Leave footnote_tail enabled so footnotes render where they are in the markdown
 }
 
-module.exports = {
+export {
   hybridFootnoteDefinitions,
   footnotePopover,
   collectFootnoteTokens,
   connectFootnoteBlockquotes,
-  disableFootnoteTail
+  disableFootnoteTail,
+};
+
+export default {
+  hybridFootnoteDefinitions,
+  footnotePopover,
+  collectFootnoteTokens,
+  connectFootnoteBlockquotes,
+  disableFootnoteTail,
 };

--- a/lib/markdown/index.js
+++ b/lib/markdown/index.js
@@ -1,7 +1,13 @@
-const { hybridFootnoteDefinitions, footnotePopover, collectFootnoteTokens, connectFootnoteBlockquotes, disableFootnoteTail } = require('./footnotes');
-const { audioEmbed, qrEmbed } = require('./inlineMacros');
-const { externalLinks } = require('./links');
-const markdownItAnchor = require('markdown-it-anchor');
+import {
+  hybridFootnoteDefinitions,
+  footnotePopover,
+  collectFootnoteTokens,
+  connectFootnoteBlockquotes,
+  disableFootnoteTail,
+} from './footnotes.js';
+import { audioEmbed, qrEmbed } from './inlineMacros.js';
+import { externalLinks } from './links.js';
+import markdownItAnchor from 'markdown-it-anchor';
 
 function anchors(md) {
   md.use(markdownItAnchor);
@@ -24,7 +30,7 @@ const mdItExtensions = [
  * Apply all markdown-it extensions to the given instance.
  * @param {import('markdown-it')} md - markdown-it instance
  */
-function applyMarkdownExtensions(md) {
+export function applyMarkdownExtensions(md) {
   mdItExtensions.forEach(fn => {
     try {
       fn(md);
@@ -35,7 +41,7 @@ function applyMarkdownExtensions(md) {
   return md;
 }
 
-module.exports = {
+export {
   hybridFootnoteDefinitions,
   footnotePopover,
   collectFootnoteTokens,
@@ -45,5 +51,17 @@ module.exports = {
   qrEmbed,
   externalLinks,
   mdItExtensions,
-  applyMarkdownExtensions
+};
+
+export default {
+  hybridFootnoteDefinitions,
+  footnotePopover,
+  collectFootnoteTokens,
+  connectFootnoteBlockquotes,
+  disableFootnoteTail,
+  audioEmbed,
+  qrEmbed,
+  externalLinks,
+  mdItExtensions,
+  applyMarkdownExtensions,
 };

--- a/lib/markdown/inlineMacros.js
+++ b/lib/markdown/inlineMacros.js
@@ -4,7 +4,7 @@
  * @param {string} after - rule to insert after
  * @param {(value:string)=>string} toHtml - HTML generator
  */
-const inlineMacro = (name, after, toHtml) => md => {
+export const inlineMacro = (name, after, toHtml) => md => {
   const regex = new RegExp(`^@${name}\\(([^)]+)\\)`);
   md.inline.ruler.after(after, name, (state, silent) => {
     const m = state.src.slice(state.pos).match(regex);
@@ -16,12 +16,12 @@ const inlineMacro = (name, after, toHtml) => md => {
 };
 
 /** Inline audio embedding macro */
-const audioEmbed = inlineMacro('audio', 'emphasis', src => `<audio controls class="audio-embed" src="${src}"></audio>`);
+export const audioEmbed = inlineMacro('audio', 'emphasis', src => `<audio controls class="audio-embed" src="${src}"></audio>`);
 
 /** Inline QR-code embedding macro */
-const qrEmbed = inlineMacro('qr', 'audio', s => {
+export const qrEmbed = inlineMacro('qr', 'audio', s => {
   const src = encodeURIComponent(s);
   return `<img class="qr-code" src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${src}" alt="QR code">`;
 });
 
-module.exports = { inlineMacro, audioEmbed, qrEmbed };
+export default { inlineMacro, audioEmbed, qrEmbed };

--- a/lib/markdown/links.js
+++ b/lib/markdown/links.js
@@ -2,7 +2,7 @@
  * Add an external-link class and arrow to outbound links.
  * @param {import('markdown-it')} md - markdown-it instance
  */
-function externalLinks(md) {
+export function externalLinks(md) {
   const base = md.renderer.rules.link_open || ((t, i, o, e, s) => s.renderToken(t, i, o));
   md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
     const href = tokens[idx].attrGet('href') || '';
@@ -18,4 +18,4 @@ function externalLinks(md) {
   };
 }
 
-module.exports = { externalLinks };
+export default { externalLinks };

--- a/lib/markdownGateway.js
+++ b/lib/markdownGateway.js
@@ -1,4 +1,4 @@
-const { fetch } = require('undici');
+import { fetch } from 'undici';
 
 function resolveUrl(input){
   let url = input;
@@ -13,7 +13,7 @@ function resolveUrl(input){
   return u.toString();
 }
 
-async function fetchMarkdown(url){
+export async function fetchMarkdown(url) {
   const gateway = process.env.OUTBOUND_MARKDOWN_URL || 'http://localhost:5000';
   const apiKey = process.env.OUTBOUND_MARKDOWN_API_KEY || '';
   const finalUrl = resolveUrl(url);
@@ -31,4 +31,4 @@ async function fetchMarkdown(url){
   return res.json();
 }
 
-module.exports = { fetchMarkdown };
+export default { fetchMarkdown };

--- a/lib/outboundProxy.js
+++ b/lib/outboundProxy.js
@@ -2,7 +2,7 @@ function truthy(value){
   return ['1','true','TRUE'].includes(String(value));
 }
 
-function loadOutboundProxy(env = process.env){
+export function loadOutboundProxy(env = process.env) {
   if(!truthy(env.OUTBOUND_PROXY_ENABLED)){
     return { enabled:false };
   }
@@ -22,4 +22,4 @@ function loadOutboundProxy(env = process.env){
   return { enabled:true, url, auth:authState };
 }
 
-module.exports = { loadOutboundProxy };
+export default { loadOutboundProxy };

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,16 +1,16 @@
-const interlinker = require('@photogabble/eleventy-plugin-interlinker');
-const navigation = require('@11ty/eleventy-navigation');
-const rss = require('@11ty/eleventy-plugin-rss');
-const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
-const sitemap = require('@quasibit/eleventy-plugin-sitemap');
-const schema = require('@quasibit/eleventy-plugin-schema');
+import interlinker from '@photogabble/eleventy-plugin-interlinker';
+import navigation from '@11ty/eleventy-navigation';
+import rss from '@11ty/eleventy-plugin-rss';
+import syntaxHighlight from '@11ty/eleventy-plugin-syntaxhighlight';
+import sitemap from '@quasibit/eleventy-plugin-sitemap';
+import schema from '@quasibit/eleventy-plugin-schema';
 
 /**
  * Return the plugin configuration list for Eleventy.
  * Each item is `[plugin, options]`.
  * @returns {Array<[Function, Object]>}
  */
-function getPlugins() {
+export default function getPlugins() {
   return [
     [
       interlinker,
@@ -34,5 +34,3 @@ function getPlugins() {
     [schema]
   ];
 }
-
-module.exports = getPlugins;

--- a/lib/postcss.js
+++ b/lib/postcss.js
@@ -1,7 +1,7 @@
-const fs = require('fs');
-const path = require('path');
-const postcss = require('postcss');
-const loadPostcssPlugins = require('./postcssPlugins');
+import fs from 'node:fs';
+import path from 'node:path';
+import postcss from 'postcss';
+import loadPostcssPlugins from './postcssPlugins.js';
 
 /**
  * Compile a CSS file using PostCSS with plugins from the project config.
@@ -11,7 +11,7 @@ const loadPostcssPlugins = require('./postcssPlugins');
  * @param {string} outputPath destination path
  * @returns {Promise<void>}
  */
-module.exports = async function runPostcss(inputPath, outputPath) {
+export default async function runPostcss(inputPath, outputPath) {
   const inputStat = fs.statSync(inputPath);
   const outStat = fs.existsSync(outputPath) ? fs.statSync(outputPath) : null;
   if (outStat && outStat.mtimeMs >= inputStat.mtimeMs) {
@@ -19,7 +19,7 @@ module.exports = async function runPostcss(inputPath, outputPath) {
   }
 
   const css = fs.readFileSync(inputPath, 'utf8');
-  const plugins = loadPostcssPlugins();
+  const plugins = await loadPostcssPlugins();
   const result = await postcss(plugins).process(css, {
     from: inputPath,
     to: outputPath,
@@ -28,4 +28,4 @@ module.exports = async function runPostcss(inputPath, outputPath) {
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, result.css);
-};
+}

--- a/lib/postcssPlugins.js
+++ b/lib/postcssPlugins.js
@@ -1,14 +1,9 @@
-/**
- * Load PostCSS plugins defined in `postcss.config.cjs`.
- * @returns {Array<import('postcss').Plugin>}
- */
-function loadPostcssPlugins() {
-  const config = require('../postcss.config.cjs');
+export default async function loadPostcssPlugins() {
+  const { default: config } = await import('../postcss.config.cjs');
   const plugins = config.plugins || [];
-  if (Array.isArray(plugins)) {
-    return plugins;
-  }
-  return Object.entries(plugins).map(([name, opts]) => require(name)(opts));
+  if (Array.isArray(plugins)) return plugins;
+  const loaded = await Promise.all(
+    Object.entries(plugins).map(async ([name, opts]) => (await import(name)).default(opts)),
+  );
+  return loaded;
 }
-
-module.exports = loadPostcssPlugins;

--- a/lib/proxyAgent.js
+++ b/lib/proxyAgent.js
@@ -1,5 +1,5 @@
-const { setGlobalDispatcher, ProxyAgent, Agent } = require('undici');
-const { loadOutboundProxy } = require('./outboundProxy');
+import { setGlobalDispatcher, ProxyAgent, Agent } from 'undici';
+import { loadOutboundProxy } from './outboundProxy.js';
 
 function isLocalhost(target){
   try{
@@ -10,7 +10,7 @@ function isLocalhost(target){
   }
 }
 
-async function configureProxyFromEnv(env = process.env, targetUrl){
+export async function configureProxyFromEnv(env = process.env, targetUrl) {
   const proxy = loadOutboundProxy(env);
   if(targetUrl && isLocalhost(targetUrl)){
     setGlobalDispatcher(new Agent());
@@ -25,4 +25,4 @@ async function configureProxyFromEnv(env = process.env, targetUrl){
   }
 }
 
-module.exports = { configureProxyFromEnv };
+export default { configureProxyFromEnv };

--- a/lib/seeded.js
+++ b/lib/seeded.js
@@ -1,6 +1,6 @@
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
-function dailySeed(utcDate) {
+export function dailySeed(utcDate) {
   if (process.env.HOMEPAGE_SEED) return process.env.HOMEPAGE_SEED;
   const date = utcDate || new Date().toISOString().slice(0, 10);
   const hash = process.env.BUILD_HASH || process.env.GITHUB_SHA || '';
@@ -24,7 +24,7 @@ function createRng(seedStr) {
   return mulberry32(h);
 }
 
-function seededShuffle(arr, seedStr) {
+export function seededShuffle(arr, seedStr) {
   const rng = createRng(seedStr);
   const a = arr.slice();
   for (let i = a.length - 1; i > 0; i--) {
@@ -34,4 +34,4 @@ function seededShuffle(arr, seedStr) {
   return a;
 }
 
-module.exports = { dailySeed, seededShuffle };
+export default { dailySeed, seededShuffle };

--- a/lib/shortcodes.js
+++ b/lib/shortcodes.js
@@ -11,7 +11,7 @@
  * @param {string} [tooltip] - Optional tooltip text
  * @returns {string} HTML string
  */
-function specnote(variant, content, tooltip) {
+export function specnote(variant, content, tooltip) {
   const cls = {
     soft: 'spec-note-soft',
     subtle: 'spec-note-subtle',
@@ -24,4 +24,4 @@ function specnote(variant, content, tooltip) {
   return `<span class="${cls}" title="${safeTooltip}">${content}</span>`;
 }
 
-module.exports = { specnote };
+export default { specnote };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,8 +3,8 @@
  * @module utils
  */
 
-const fs = require('fs');
-const { webpageToMarkdown } = require('./webpageToMarkdown');
+import fs from 'node:fs';
+import { webpageToMarkdown } from './webpageToMarkdown.js';
 
 /** Simple file cache keyed by path */
 const fileCache = new Map();
@@ -14,7 +14,7 @@ const fileCache = new Map();
  * @param {number} n
  * @returns {string}
  */
-function ordinalSuffix(n) {
+export function ordinalSuffix(n) {
   const abs = Math.abs(n);
   if (abs % 100 >= 11 && abs % 100 <= 13) return 'th';
   return ['th', 'st', 'nd', 'rd'][abs % 10] || 'th';
@@ -26,7 +26,7 @@ function ordinalSuffix(n) {
  * @param {string} p
  * @returns {string|null}
  */
-function readFileCached(p) {
+export function readFileCached(p) {
   try {
     const { mtimeMs } = fs.statSync(p);
     const cached = fileCache.get(p);
@@ -41,4 +41,6 @@ function readFileCached(p) {
   }
 }
 
-module.exports = { ordinalSuffix, readFileCached, webpageToMarkdown };
+export { webpageToMarkdown };
+
+export default { ordinalSuffix, readFileCached, webpageToMarkdown };

--- a/lib/webpageToMarkdown.js
+++ b/lib/webpageToMarkdown.js
@@ -1,13 +1,13 @@
-const { JSDOM } = require('jsdom');
+import { JSDOM } from 'jsdom';
 let Readability;
 try {
-  ({ Readability } = require('@mozilla/readability'));
+  ({ Readability } = await import('@mozilla/readability'));
 } catch {
   Readability = null;
 }
 let TurndownService;
 try {
-  TurndownService = require('turndown');
+  ({ default: TurndownService } = await import('turndown'));
 } catch {
   TurndownService = class {
     turndown(html) {
@@ -15,21 +15,21 @@ try {
     }
   };
 }
-const { request } = require('./flareClient');
+import { request } from './flareClient.js';
 
 /**
  * Fetch a webpage and convert its main content to Markdown.
  * @param {string} url
  * @returns {Promise<string>}
  */
-async function webpageToMarkdown(url) {
+export async function webpageToMarkdown(url) {
   if (!url) throw new Error('URL is required');
   const { realisticHeaders } = await import('../tools/shared/cf.mjs');
   const res = await request.get(url, { headers: realisticHeaders() });
   return htmlToMarkdown(res.body, res.url);
 }
 
-function htmlToMarkdown(html, url = 'about:blank') {
+export function htmlToMarkdown(html, url = 'about:blank') {
   const dom = new JSDOM(html, { url });
   let source = dom.serialize();
   if (Readability) {
@@ -41,4 +41,4 @@ function htmlToMarkdown(html, url = 'about:blank') {
   return turndownService.turndown(source);
 }
 
-module.exports = { webpageToMarkdown, htmlToMarkdown };
+export default { webpageToMarkdown, htmlToMarkdown };

--- a/lib/wikilinks/filter-dead-links.js
+++ b/lib/wikilinks/filter-dead-links.js
@@ -1,14 +1,14 @@
-const TEMPLATE_SYNTAX = /\{\{.*\}\}/;
+export const TEMPLATE_SYNTAX = /\{\{.*\}\}/;
 
 /**
  * Remove templated wikilinks from a dead link report object.
  * @param {Record<string,string[]>} deadLinks
  * @returns {Record<string,string[]>}
  */
-function filterDeadLinks(deadLinks) {
+export function filterDeadLinks(deadLinks) {
   return Object.fromEntries(
     Object.entries(deadLinks).filter(([link]) => !TEMPLATE_SYNTAX.test(link)),
   );
 }
 
-module.exports = { filterDeadLinks, TEMPLATE_SYNTAX };
+export default { filterDeadLinks, TEMPLATE_SYNTAX };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "@11ty/eleventy": "^3.1.2",
     "@11ty/eleventy-img": "^6.0.4",

--- a/scripts/merge-golden.js
+++ b/scripts/merge-golden.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
-const { glob } = require('glob');
-const slugify = require('slugify');
-const crypto = require('crypto');
+import fs from 'node:fs';
+import path from 'node:path';
+import { glob } from 'glob';
+import slugify from 'slugify';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 
 const args = process.argv.slice(2);
 const options = {
@@ -13,7 +14,7 @@ const options = {
   verbose: args.includes('--verbose'),
 };
 
-const repoRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 function log(...msg) {
   console.log(...msg);

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-const libnpmsearch = require('libnpmsearch');
-const npmFetch = require('npm-registry-fetch');
-const { execSync } = require('child_process');
+import libnpmsearch from 'libnpmsearch';
+import npmFetch from 'npm-registry-fetch';
+import { execSync } from 'node:child_process';
 
 async function search(keyword) {
   const results = await libnpmsearch(keyword, { size: 20 });

--- a/src/_data/archivesNav.js
+++ b/src/_data/archivesNav.js
@@ -1,2 +1,2 @@
-const { buildArchiveNav } = require('../../lib/archive-nav');
-module.exports = buildArchiveNav();
+import { buildArchiveNav } from '../../lib/archive-nav.js';
+export default buildArchiveNav();

--- a/src/_data/branding.js
+++ b/src/_data/branding.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   logoSrc: '/assets/static/logo.png',
   logoAlt: 'Effusion Labs logo',
   logoSizes: '(max-width: 640px) 112px, 160px'

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -1,6 +1,6 @@
 const toArray = v => (Array.isArray(v) ? v : v ? [v] : []);
 
-module.exports = {
+export default {
   tags: data => {
     const merged = [
       ...toArray(data.tags),

--- a/src/_data/nav.js
+++ b/src/_data/nav.js
@@ -1,4 +1,4 @@
-const { CONTENT_AREAS } = require("../../lib/constants");
+import { CONTENT_AREAS } from '../../lib/constants.js';
 
 const areaLinks = CONTENT_AREAS.map((a) => ({
   title: a.charAt(0).toUpperCase() + a.slice(1),
@@ -6,9 +6,9 @@ const areaLinks = CONTENT_AREAS.map((a) => ({
 }));
 
 const nav = [
-  { title: "Showcase", url: "/" },
+  { title: 'Showcase', url: '/' },
   ...areaLinks,
-  { title: "Map", url: "/map/" },
+  { title: 'Map', url: '/map/' },
 ].map((item, idx) => ({ ...item, order: idx + 1 }));
 
-module.exports = nav;
+export default nav;

--- a/src/index.11tydata.js
+++ b/src/index.11tydata.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   title: "Experimental R&D you can actually use.",
   lede: "Prototypes, systems, and notes from the lab.",
   ctas: [

--- a/src/work.11tydata.js
+++ b/src/work.11tydata.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   eleventyComputed: {
     work: data => data.collections.work
   }

--- a/src/work/drop.11ty.js
+++ b/src/work/drop.11ty.js
@@ -1,4 +1,4 @@
-exports.data = {
+export const data = {
   layout: "layouts/redirect.njk",
   permalink: "/work/drop/index.html",
   eleventyComputed: {
@@ -9,4 +9,4 @@ exports.data = {
   }
 };
 
-exports.render = () => '';
+export const render = () => '';

--- a/src/work/latest.11ty.js
+++ b/src/work/latest.11ty.js
@@ -1,4 +1,4 @@
-exports.data = {
+export const data = {
   layout: "layouts/redirect.njk",
   permalink: "/work/latest/index.html",
   eleventyComputed: {
@@ -9,4 +9,4 @@ exports.data = {
   }
 };
 
-exports.render = () => '';
+export const render = () => '';

--- a/test/integration/feed-build-meta.spec.mjs
+++ b/test/integration/feed-build-meta.spec.mjs
@@ -6,7 +6,7 @@ import { createRequire } from 'module';
 import { buildLean } from '../helpers/eleventy-env.mjs';
 
 const require = createRequire(import.meta.url);
-const dateToRfc822 = require('@11ty/eleventy-plugin-rss/src/dateRfc822.js');
+import dateToRfc822 from '@11ty/eleventy-plugin-rss/src/dateRfc822.js';
 
 test('feed exposes build metadata', async () => {
   const outDir = await buildLean('feed-build-meta');

--- a/test/lib/concept-map.js
+++ b/test/lib/concept-map.js
@@ -1,2 +1,2 @@
-const generateConceptMapJSONLD = require('../../lib/concept-map.js');
-module.exports = generateConceptMapJSONLD;
+import generateConceptMapJSONLD from '../../lib/concept-map.js';
+export default generateConceptMapJSONLD;

--- a/test/lib/markdownGateway.js
+++ b/test/lib/markdownGateway.js
@@ -1,6 +1,6 @@
-const { fetch } = require('undici');
+import { fetch } from 'undici';
 
-async function fetchMarkdown(targetUrl) {
+export async function fetchMarkdown(targetUrl) {
   const gateway = process.env.OUTBOUND_MARKDOWN_URL || 'http://gateway';
   const res = await fetch(`${gateway}/convert`, {
     method: 'POST',
@@ -10,4 +10,4 @@ async function fetchMarkdown(targetUrl) {
   return res.json();
 }
 
-module.exports = { fetchMarkdown };
+export default { fetchMarkdown };

--- a/test/src/_data/nav.js
+++ b/test/src/_data/nav.js
@@ -1,1 +1,1 @@
-module.exports = require('../../../src/_data/nav.js');
+export { default } from '../../../src/_data/nav.js';

--- a/tools/build-vendor-index.js
+++ b/tools/build-vendor-index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-const fs = require('node:fs/promises');
-const path = require('node:path');
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 const VENDOR_DIR = process.env.VENDOR_DOCS_DIR || path.join('docs','vendors');
 async function main(){

--- a/tools/cjs-report.mjs
+++ b/tools/cjs-report.mjs
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+
+function pathsFromScan(file) {
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+  const paths = new Set();
+  for (const line of lines) {
+    const evt = JSON.parse(line);
+    if (evt.type === 'match') paths.add(evt.data.path.text);
+  }
+  return paths;
+}
+
+const include = /^(lib|src|scripts|tools|test|tailwind\.config\.cjs|postcss\.config\.cjs)/;
+const before = [...pathsFromScan('tmp/cjs-scan.json')].filter(p => include.test(p));
+const after = new Set([...pathsFromScan('tmp/cjs-scan-post.json')].filter(p => include.test(p)));
+const report = [];
+for (const p of before) {
+  let status;
+  if (!after.has(p)) status = 'Converted or Removed';
+  else if (p.endsWith('.cjs')) status = 'Kept as .cjs (compat)';
+  else status = 'Unresolved';
+  report.push({ file: p, status });
+}
+fs.writeFileSync('cjs-report.json', JSON.stringify(report, null, 2));
+let md = '# CJS Discovery Report\n\n';
+for (const r of report) md += `- ${r.file}: ${r.status}\n`;
+fs.writeFileSync('cjs-report.md', md);

--- a/tools/merge-golden.mjs
+++ b/tools/merge-golden.mjs
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
-import fs from "fs/promises";
-import fss from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import fs from 'node:fs/promises';
+import fss from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const repoRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 const DEFAULT_ARCHIVES_ROOT = path.join(
   repoRoot,

--- a/tools/select.mjs
+++ b/tools/select.mjs
@@ -5,8 +5,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 // Use the promise-based exec when available; fall back to promisified exec
 const exec = cp.promises ? cp.promises.exec : promisify(cp.exec);

--- a/tools/synthesize-archive.mjs
+++ b/tools/synthesize-archive.mjs
@@ -1,11 +1,8 @@
 // tools/synthesized-archive.mjs
-import fs from 'fs';
-import fsp from 'fs/promises';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // Schema fields in numbered order (1..N) as they appear in the source docs
 const schemaFields = [
@@ -201,7 +198,7 @@ function bestPriority(sources) {
 
 async function main() {
   // Read all three sources (relative to repo root)
-  const base = path.join(__dirname, '..');
+  const base = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
   const payloads = await Promise.all(
     sourceFiles.map(async (rel) => {
       const full = path.join(base, rel);

--- a/tools/synthesize.mjs
+++ b/tools/synthesize.mjs
@@ -1,12 +1,9 @@
 // tools/synthesize.mjs
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import MarkdownIt from 'markdown-it';
 import Ajv from 'ajv';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
+import { fileURLToPath } from 'node:url';
 
 const md = new MarkdownIt();
 
@@ -31,7 +28,7 @@ function toRows(obj, source) {
 }
 
 export function synthesize() {
-  const baseDir = path.join(__dirname, '..', 'research');
+  const baseDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'research');
   const files = [
     'PRIMARY TARGETS — Completed(1).txt',
     'PRIMARY TARGETS — Completed(2).txt',
@@ -87,7 +84,7 @@ export function synthesize() {
   }
 
   const timestamp = new Date().toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-  const outDir = path.join(__dirname, '..', 'docs', 'knowledge');
+  const outDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'docs', 'knowledge');
   fs.mkdirSync(outDir, { recursive: true });
   const outPath = path.join(outDir, `synthesized_archive_${timestamp}.json`);
   const payload = JSON.stringify([final], null, 2);

--- a/tools/validate-docs.js
+++ b/tools/validate-docs.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-const fs = require('node:fs/promises');
-const path = require('node:path');
-const crypto = require('node:crypto');
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
 
 const VENDOR_DIR = process.env.VENDOR_DOCS_DIR || path.join('docs','vendors');
 async function main(){


### PR DESCRIPTION
## Summary
- convert repository to ES modules with type: module and ESM syntax
- document ESM setup and generate CommonJS discovery report
- ensure build and test pass under Node 24+

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63acd26a483309c014804cea93812