### PR TITLE
fix: deconflict archive permalinks

### DIFF
--- a/artifacts/patches/20250821T044405Z.patch
+++ b/artifacts/patches/20250821T044405Z.patch
@@ -1,0 +1,58 @@
+diff --git a/.dead-links.json b/.dead-links.json
+new file mode 100644
+index 0000000..cd712dd
+--- /dev/null
++++ b/.dead-links.json
+@@ -0,0 +1 @@
++{"/archives/collectables/designer-toys/{{ companySlug }}/{{ line.slug }}/":["./src/test/wikilinks-ignore.md"],"/archives/collectables/designer-toys/{{ companySlug }}/{{ lineSlug }}/products/{{ p.data.productSlug }}/":["./src/test/wikilinks-ignore.md"],"/archives/collectables/designer-toys/{{ companySlug }}/{{ lineSlug }}/characters/{{ c.data.charSlug }}/":["./src/test/wikilinks-ignore.md"],"/archives/collectables/designer-toys/{{ companySlug }}/{{ lineSlug }}/series/{{ s.data.seriesSlug }}/":["./src/test/wikilinks-ignore.md"],"[[missing-node]]":["./src/test/wikilinks-ignore.md"],"/archives/collectables/designer-toys/pop-mart/the-monsters/products/{{ p.data.product_id }}/":["./src/test/wikilinks-ignore.md"]}
+\ No newline at end of file
+diff --git a/src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk b/src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+index 44eede8..c0eec88 100644
+--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
++++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+@@ -4 +4 @@ pagination:
+-  data: collections.archiveCharacters
++  data: collections.archiveCharacters | byCompany('pop-mart') | byLine('the-monsters') | byLocale('en')
+@@ -10 +10 @@ eleventyComputed:
+-  charSlug: "{{ character.data.charSlug }}"
++  charSlug: "{{ character.data.charSlug or (character.data.name | slug) }}"
+diff --git a/src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk b/src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+index 0ad01a9..c71b185 100644
+--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
++++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+@@ -7,3 +7,3 @@ eleventyComputed:
+-  lineProducts: "{{ collections.archiveProducts | byCompany(companySlug) | byLine(lineSlug) }}"
+-  lineCharacters: "{{ collections.archiveCharacters | byCompany(companySlug) | byLine(lineSlug) }}"
+-  lineSeries: "{{ collections.archiveSeries | byCompany(companySlug) | byLine(lineSlug) }}"
++  lineProducts: "{{ collections.archiveProducts | byCompany(companySlug) | byLine(lineSlug) | byLocale('en') }}"
++  lineCharacters: "{{ collections.archiveCharacters | byCompany(companySlug) | byLine(lineSlug) | byLocale('en') }}"
++  lineSeries: "{{ collections.archiveSeries | byCompany(companySlug) | byLine(lineSlug) | byLocale('en') }}"
+diff --git a/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk b/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+index 31a484c..8c9e340 100644
+--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
++++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+@@ -4 +4 @@ pagination:
+-  data: collections.archiveProducts
++  data: collections.archiveProducts | byCompany('pop-mart') | byLine('the-monsters') | byLocale('en')
+@@ -9,2 +9,2 @@ eleventyComputed:
+-  lineSlug: "{{ product.data.lineSlug }}"
+-  productSlug: "{{ product.data.productSlug }}"
++  lineSlug: "{{ product.data.lineSlug or 'the-monsters' }}"
++  productSlug: "{{ product.data.productSlug or (product.data.product_id | slug) }}"
+diff --git a/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk b/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+index 512d90b..f1e3c15 100644
+--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
++++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+@@ -4 +4 @@ pagination:
+-  data: collections.archiveSeries
++  data: collections.archiveSeries | byCompany('pop-mart') | byLine('the-monsters') | byLocale('en')
+@@ -10 +10 @@ eleventyComputed:
+-  seriesSlug: "{{ series.data.seriesSlug }}"
++  seriesSlug: "{{ series.data.seriesSlug or (series.data.title | slug) }}"
+diff --git a/src/styles/app.tailwind.css b/src/styles/app.tailwind.css
+index 43c4841..493259f 100644
+--- a/src/styles/app.tailwind.css
++++ b/src/styles/app.tailwind.css
+@@ -269 +269 @@
+-    @apply relative w-full rounded-xl border p-4 md:p-5 shadow-sm not-prose;
++    @apply relative w-full rounded-xl border p-4 md:p-5 shadow-sm;

--- a/logs/ckpt-20250821T044405Z.log
+++ b/logs/ckpt-20250821T044405Z.log
@@ -1,0 +1,13 @@
+commit 880c3062759eeb72cb9e30f5a1ec9c46b21461af
+Author: Codex <codex@openai.com>
+Date:   Thu Aug 21 04:48:17 2025 +0000
+
+    fix: scope archive pages by locale and remove unsupported class
+
+ .dead-links.json                                                             | 1 +
+ src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk | 4 ++--
+ src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk      | 6 +++---
+ src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk   | 6 +++---
+ src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk     | 4 ++--
+ src/styles/app.tailwind.css                                                  | 2 +-
+ 6 files changed, 12 insertions(+), 11 deletions(-)

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/characters.njk
@@ -1,13 +1,13 @@
 ---
 layout: "layout.njk"
 pagination:
-  data: collections.archiveCharacters
+  data: collections.archiveCharacters | byCompany('pop-mart') | byLine('the-monsters') | byLocale('en')
   size: 1
   alias: character
 eleventyComputed:
   companySlug: "{{ character.data.companySlug or character.data.company or 'pop-mart' }}"
   lineSlug: "{{ character.data.lineSlug or character.data.line or 'the-monsters' }}"
-  charSlug: "{{ character.data.charSlug }}"
+  charSlug: "{{ character.data.charSlug or (character.data.name | slug) }}"
   title: "{{ (character.data.name or charSlug) ~ ' — ' ~ (lineSlug | replace('-', ' ') | title) ~ ' — POP MART' }}"
 permalink: "/archives/collectables/designer-toys/{{ companySlug }}/{{ lineSlug }}/characters/{{ charSlug }}/index.html"
 ---

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
@@ -4,9 +4,9 @@ eleventyComputed:
   companySlug: "pop-mart"
   lineSlug: "the-monsters"
   title: "POP MART — The Monsters"
-  lineProducts: "{{ collections.archiveProducts | byCompany(companySlug) | byLine(lineSlug) }}"
-  lineCharacters: "{{ collections.archiveCharacters | byCompany(companySlug) | byLine(lineSlug) }}"
-  lineSeries: "{{ collections.archiveSeries | byCompany(companySlug) | byLine(lineSlug) }}"
+  lineProducts: "{{ collections.archiveProducts | byCompany(companySlug) | byLine(lineSlug) | byLocale('en') }}"
+  lineCharacters: "{{ collections.archiveCharacters | byCompany(companySlug) | byLine(lineSlug) | byLocale('en') }}"
+  lineSeries: "{{ collections.archiveSeries | byCompany(companySlug) | byLine(lineSlug) | byLocale('en') }}"
 ---
 
 <header class="mb-6">

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.njk
@@ -1,13 +1,13 @@
 ---
 layout: "layout.njk"
 pagination:
-  data: collections.archiveProducts
+  data: collections.archiveProducts | byCompany('pop-mart') | byLine('the-monsters') | byLocale('en')
   size: 1
   alias: product
 eleventyComputed:
   companySlug: "{{ product.data.companySlug or 'pop-mart' }}"
-  lineSlug: "{{ product.data.lineSlug }}"
-  productSlug: "{{ product.data.productSlug }}"
+  lineSlug: "{{ product.data.lineSlug or 'the-monsters' }}"
+  productSlug: "{{ product.data.productSlug or (product.data.product_id | slug) }}"
   title: "POP MART — {{ lineSlug | replace('-', ' ') | title }} — {{ product.data.product_id or product.data.title or productSlug }}"
 permalink: "/archives/collectables/designer-toys/{{ companySlug }}/{{ lineSlug }}/products/{{ productSlug }}/index.html"
 ---

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/series.njk
@@ -1,13 +1,13 @@
 ---
 layout: "layout.njk"
 pagination:
-  data: collections.archiveSeries
+  data: collections.archiveSeries | byCompany('pop-mart') | byLine('the-monsters') | byLocale('en')
   size: 1
   alias: series
 eleventyComputed:
   companySlug: "{{ series.data.companySlug or series.data.company or 'pop-mart' }}"
   lineSlug: "{{ series.data.lineSlug or series.data.line or 'the-monsters' }}"
-  seriesSlug: "{{ series.data.seriesSlug }}"
+  seriesSlug: "{{ series.data.seriesSlug or (series.data.title | slug) }}"
   title: "{{ (series.data.title or seriesSlug) ~ ' — ' ~ (lineSlug | replace('-', ' ') | title) ~ ' — POP MART' }}"
 permalink: "/archives/collectables/designer-toys/{{ companySlug }}/{{ lineSlug }}/series/{{ seriesSlug }}/index.html"
 ---

--- a/src/styles/app.tailwind.css
+++ b/src/styles/app.tailwind.css
@@ -266,7 +266,7 @@
 @layer components {
   /* ——— Failure Box ------------------------------------------------------- */
   .failbox {
-    @apply relative w-full rounded-xl border p-4 md:p-5 shadow-sm not-prose;
+    @apply relative w-full rounded-xl border p-4 md:p-5 shadow-sm;
     background-color: hsl(var(--b1));
     border-color: hsl(var(--bc)/.14);
     color: hsl(var(--bc));


### PR DESCRIPTION
## Summary
- scope character, product, and series archive pages to English locale to prevent duplicate permalinks
- filter index page collections by locale to match new scope
- drop unsupported `not-prose` utility from Tailwind styles

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a3af29008330964032f8d1273a26