### PR TITLE
fix: stabilize failbox rendering

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -184,6 +184,7 @@ export default function (eleventyConfig) {
       open,
       iconMarkup,
     } = normalizeBoxOpts(this, titleOrOpts, kicker);
+  const contentInner = content.trim();
 
     const headerInner = `
       <div class="failbox-head">
@@ -193,7 +194,7 @@ export default function (eleventyConfig) {
 
     const bodyInner = `
       <div class="failbox-body">
-        ${content}
+        ${contentInner}
       </div>`.trim();
 
     if (collapsible) {
@@ -202,15 +203,15 @@ export default function (eleventyConfig) {
   <details class="failbox-collapse"${open ? " open" : ""}>
     <summary class="failbox-summary">${headerInner}</summary>
     ${bodyInner}
-  </details>
-</aside>`;
+  </details></aside><!-- -->
+`.trimStart();
     }
 
     return `
 <aside class="${boxClasses}" role="note" aria-labelledby="${safeId}">
   ${headerInner}
-  ${bodyInner}
-</aside>`;
+  ${bodyInner}</aside><!-- -->
+`.trimStart();
   });
 
   eleventyConfig.addPairedShortcode("failitem", function (content, labelOrOpts = "") {
@@ -218,14 +219,15 @@ export default function (eleventyConfig) {
     const heading = hasLabel
       ? `<div class="failitem-label"><strong>${iconMarkup}${safeLabel}</strong></div>`
       : "";
+    const inner = content.trim();
 
     return `
 <section class="${classes}">
   ${heading}
   <div class="failitem-content">
-    ${content}
+    ${inner}
   </div>
-</section>`;
+</section>`.trim();
   });
 
   // ---- Global data ----

--- a/src/content/concepts/verification-is-an-ecology.md
+++ b/src/content/concepts/verification-is-an-ecology.md
@@ -159,7 +159,6 @@ Translate that into social practice and the culture war deflates into maintenanc
 
   Bound the damage. Learn from the mess. Then keep moving.
 {% endfailbox %}
-
 ## CODA: LIVING WITH DOUBT
 
 Doubt isn’t a virtue so much as a survival tactic, and the modern internet is its habitat. In any given thread, “verification” rarely looks like truth-seeking; it looks like ritualized suspicion, petty demands for proof, the pile-on that turns skepticism into theater. But remove those frictions and the ecosystem collapses: unchecked claims congeal into lore, lore hardens into fact, and the cycle accelerates until even obvious nonsense acquires a pedigree. The constant drag of doubt is the only thing that slows the churn.

--- a/src/styles/app.tailwind.css
+++ b/src/styles/app.tailwind.css
@@ -25,6 +25,7 @@
   h2 { @apply font-heading text-[var(--step-3)] mb-6; }
   h3 { @apply font-heading text-[var(--step-2)] mb-4; }
   p, ul, ol, blockquote { @apply mb-4; }
+  p:empty { display: none; }
 
   .heading-anchor { @apply mr-2 no-underline text-gray-400; }
 


### PR DESCRIPTION
## Summary
- trim failbox/failitem shortcode content
- hide stray empty paragraphs with CSS

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a80ab1ca7483308bcb1dbe1a9c1a08