### PR TITLE
feat: splice footnotes into callout shortcode

### DIFF
--- a/artifacts/patches/20250822T181046Z.patch
+++ b/artifacts/patches/20250822T181046Z.patch
@@ -1,0 +1,184 @@
+diff --git a/eleventy.config.mjs b/eleventy.config.mjs
+index c4f730b..42ec354 100644
+--- a/eleventy.config.mjs
++++ b/eleventy.config.mjs
+@@ -8,2 +7,0 @@ import fs from "node:fs";
+-import MarkdownIt from "markdown-it";
+-import markdownItFootnote from "markdown-it-footnote";
+@@ -29,0 +28,64 @@ const escapeHtml = (str) =>
++export function createCalloutShortcode(eleventyConfig) {
++  return function (content, opts = {}) {
++    const md = eleventyConfig.markdownLibrary;
++    const isObj = opts && typeof opts === "object" && !Array.isArray(opts);
++    const {
++      title = "",
++      kicker = "",
++      variant = "neutral",
++      position = "center",
++      icon = "",
++      headingLevel = 3,
++    } = isObj ? opts : { title: opts };
++    const envEscape = this?.env?.filters?.escape ?? escapeHtml;
++    const safeTitle = envEscape(title);
++    const safeKicker = kicker ? envEscape(kicker) : "";
++    const safeVariant = String(variant).toLowerCase().replace(/[^\w-]/g, "");
++    const safePosition = String(position).toLowerCase().replace(/[^\w-]/g, "");
++    const clampedLevel = Math.min(6, Math.max(2, Number(headingLevel) || 3));
++    const tag = `h${clampedLevel}`;
++    const id = `callout-${title ? slug(title) : Date.now()}`;
++    const safeId = envEscape(id);
++    const classes = ["callout", `callout--${safeVariant}`, `callout--dock-${safePosition}`].join(" ");
++    const iconMarkup =
++      icon && /^<svg[\s>]/.test(String(icon))
++        ? String(icon)
++        : icon
++        ? `<span class="callout-icon" aria-hidden="true">${envEscape(icon)}</span>`
++        : "";
++
++    const refs = [...String(content).matchAll(/\[\^([^\]]+)\]/g)].map((m) => m[1]);
++    const unique = [...new Set(refs)];
++    const defs = [];
++    if (unique.length) {
++      try {
++        const txt = fs.readFileSync(this.page.inputPath, "utf8");
++        const defRe = /^\[\^([^\]]+)\]:[\s\S]*?(?=\n\[\^[^\]]+\]:|$)/gm;
++        let m;
++        while ((m = defRe.exec(txt)) !== null) {
++          if (unique.includes(m[1])) defs.push(m[0].trim());
++        }
++      } catch {
++        /* ignore */
++      }
++    }
++    const rendered = md.render(`${content}\n\n${defs.join("\n\n")}`.trim());
++    const body = rendered
++      .replace(/<section class="footnotes"[\s\S]*?<\/section>/, "")
++      .replace(/<div class="footnotes-hybrid"[\s\S]*?<\/div>/, "")
++      .trim();
++
++    return `
++<aside class="${classes}" role="note" aria-labelledby="${safeId}">
++  <div class="callout-head">
++    <${tag} id="${safeId}" class="callout-title">${iconMarkup}${safeTitle}</${tag}>
++    ${safeKicker ? `<p class="callout-kicker">${safeKicker}</p>` : ''}
++  </div>
++  <div class="callout-body">
++    ${body}
++  </div>
++</aside><!-- -->
++`.trim();
++  };
++}
++
+@@ -35,0 +98,6 @@ export default function (eleventyConfig) {
++  // capture markdown library for shortcodes
++  eleventyConfig.amendLibrary('md', (md) => {
++    eleventyConfig.markdownLibrary = md;
++    return md;
++  });
++
+@@ -88,54 +156,2 @@ export default function (eleventyConfig) {
+-  const calloutShortcode = function (content, opts = {}) {
+-    const md = eleventyConfig.markdownLibrary || MarkdownIt().use(markdownItFootnote);
+-    const isObj = opts && typeof opts === 'object' && !Array.isArray(opts);
+-    const {
+-      title = '',
+-      kicker = '',
+-      variant = 'neutral',
+-      position = 'center',
+-      icon = '',
+-      headingLevel = 3,
+-    } = isObj ? opts : { title: opts };
+-    const envEscape = this?.env?.filters?.escape ?? escapeHtml;
+-    const safeTitle = envEscape(title);
+-    const safeKicker = kicker ? envEscape(kicker) : '';
+-    const safeVariant = String(variant).toLowerCase().replace(/[^\w-]/g, '');
+-    const safePosition = String(position).toLowerCase().replace(/[^\w-]/g, '');
+-    const clampedLevel = Math.min(6, Math.max(2, Number(headingLevel) || 3));
+-    const tag = `h${clampedLevel}`;
+-    const id = `callout-${title ? slug(title) : Date.now()}`;
+-    const safeId = envEscape(id);
+-    const classes = ['callout', `callout--${safeVariant}`, `callout--dock-${safePosition}`].join(' ');
+-    const iconMarkup =
+-      icon && /^<svg[\s>]/.test(String(icon))
+-        ? String(icon)
+-        : icon
+-          ? `<span class="callout-icon" aria-hidden="true">${envEscape(icon)}</span>`
+-          : '';
+-    const footnotes = (() => {
+-      try {
+-        const txt = fs.readFileSync(this.page.inputPath, 'utf8');
+-        return (
+-          txt.match(/\n\[\^[^\n]*?\]:.*?(?=\n\n|$)/gs) || []
+-        ).join('\n');
+-      } catch {
+-        return '';
+-      }
+-    })();
+-    const rendered = md.render(`${content}\n${footnotes}`);
+-    const body = rendered.replace(/<section class="footnotes"[\s\S]*<\/section>/, '');
+-
+-    return `
+-<aside class="${classes}" role="note" aria-labelledby="${safeId}">
+-  <div class="callout-head">
+-    <${tag} id="${safeId}" class="callout-title">${iconMarkup}${safeTitle}</${tag}>
+-    ${safeKicker ? `<p class="callout-kicker">${safeKicker}</p>` : ''}
+-  </div>
+-  <div class="callout-body">
+-    ${body.trim()}
+-  </div>
+-</aside><!-- -->
+-`.trim();
+-  };
+-
+-  eleventyConfig.addPairedShortcode('callout', calloutShortcode);
++  const callout = createCalloutShortcode(eleventyConfig);
++  eleventyConfig.addPairedShortcode('callout', callout);
+@@ -149 +165,6 @@ export default function (eleventyConfig) {
+-    return calloutShortcode.call(this, content, opts);
++    return callout.call(this, content, opts);
++  });
++  eleventyConfig.addPairedShortcode('failitem', function (content, label = '') {
++    const envEscape = this?.env?.filters?.escape ?? escapeHtml;
++    const safeLabel = label ? `**${envEscape(label)}** ` : '';
++    return `- ${safeLabel}${content}`.trim();
+@@ -151 +171,0 @@ export default function (eleventyConfig) {
+-  eleventyConfig.addPairedShortcode('failitem', (content) => content);
+diff --git a/test/unit/callout-shortcode.test.mjs b/test/unit/callout-shortcode.test.mjs
+new file mode 100644
+index 0000000..2400307
+--- /dev/null
++++ b/test/unit/callout-shortcode.test.mjs
+@@ -0,0 +1,20 @@
++import test from 'node:test';
++import assert from 'node:assert/strict';
++import MarkdownIt from 'markdown-it';
++import markdownItFootnote from 'markdown-it-footnote';
++import { applyMarkdownExtensions } from '../../lib/markdown/index.js';
++import { createCalloutShortcode } from '../../eleventy.config.mjs';
++import path from 'node:path';
++
++test('callout splices only referenced footnotes', () => {
++  const md = applyMarkdownExtensions(new MarkdownIt().use(markdownItFootnote));
++  const config = { markdownLibrary: md };
++  const callout = createCalloutShortcode(config);
++  const fixture = path.join('test', 'unit', 'fixtures', 'callout-page.md');
++  const ctx = { page: { inputPath: fixture }, env: { filters: { escape: (s) => s } } };
++  const html = callout.call(ctx, 'Check[^4]');
++  assert.ok(/annotation-ref/.test(html), 'footnote reference rendered');
++  assert.ok(!html.includes('[^4]'), 'raw footnote ref removed');
++  assert.ok(!html.includes('fn9'), 'unused footnote definition not included');
++  assert.ok(!/footnotes-hybrid/.test(html), 'no inner footnotes block');
++});
+diff --git a/test/unit/fixtures/callout-page.md b/test/unit/fixtures/callout-page.md
+new file mode 100644
+index 0000000..bfeefca
+--- /dev/null
++++ b/test/unit/fixtures/callout-page.md
+@@ -0,0 +1,6 @@
++Intro
++
++[^4]: Footnote four line one
++    second paragraph line
++
++[^9]: Footnote nine

--- a/logs/ckpt-20250822T181046Z.log
+++ b/logs/ckpt-20250822T181046Z.log
@@ -1,0 +1,10 @@
+commit 21a8ec4d3874b5d3131ac164a97c3cc562e6a8af
+Author: Codex <codex@openai.com>
+Date:   Fri Aug 22 18:10:48 2025 +0000
+
+    feat: splice footnotes into callout shortcode
+
+ eleventy.config.mjs                  | 136 ++++++++++++++++++++++++++++++++++++++++++++++++-----------------------------------
+ test/unit/callout-shortcode.test.mjs |  20 +++++++++++++
+ test/unit/fixtures/callout-page.md   |   6 ++++
+ 3 files changed, 104 insertions(+), 58 deletions(-)

--- a/test/unit/callout-shortcode.test.mjs
+++ b/test/unit/callout-shortcode.test.mjs
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import MarkdownIt from 'markdown-it';
+import markdownItFootnote from 'markdown-it-footnote';
+import { applyMarkdownExtensions } from '../../lib/markdown/index.js';
+import { createCalloutShortcode } from '../../eleventy.config.mjs';
+import path from 'node:path';
+
+test('callout splices only referenced footnotes', () => {
+  const md = applyMarkdownExtensions(new MarkdownIt().use(markdownItFootnote));
+  const config = { markdownLibrary: md };
+  const callout = createCalloutShortcode(config);
+  const fixture = path.join('test', 'unit', 'fixtures', 'callout-page.md');
+  const ctx = { page: { inputPath: fixture }, env: { filters: { escape: (s) => s } } };
+  const html = callout.call(ctx, 'Check[^4]');
+  assert.ok(/annotation-ref/.test(html), 'footnote reference rendered');
+  assert.ok(!html.includes('[^4]'), 'raw footnote ref removed');
+  assert.ok(!html.includes('fn9'), 'unused footnote definition not included');
+  assert.ok(!/footnotes-hybrid/.test(html), 'no inner footnotes block');
+});

--- a/test/unit/fixtures/callout-page.md
+++ b/test/unit/fixtures/callout-page.md
@@ -1,0 +1,6 @@
+Intro
+
+[^4]: Footnote four line one
+    second paragraph line
+
+[^9]: Footnote nine


### PR DESCRIPTION
## Summary
- render `{% callout %}` with site's markdown pipeline and splice footnotes from current page
- normalize `failbox` and convert `failitem` to markdown list items
- add unit test for callout footnote behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b0ef76548330b0f8409505e31346