### PR TITLE
feat: unify callout footnotes with page pipeline

### DIFF
--- a/artifacts/patches/20250823T092012Z.patch
+++ b/artifacts/patches/20250823T092012Z.patch
@@ -1,0 +1,33 @@
+diff --git a/eleventy.config.mjs b/eleventy.config.mjs
+index 13e3f02..886af6f 100644
+--- a/eleventy.config.mjs
++++ b/eleventy.config.mjs
+@@ -56,5 +56,5 @@ export function createCalloutShortcode(eleventyConfig) {
+-    const rendered = md.render(String(content), this.ctx ?? {});
+-    const body = rendered
+-      .replace(/<section class="footnotes"[\s\S]*?<\/section>/, "")
+-      .replace(/<div class="footnotes-hybrid"[\s\S]*?<\/div>/, "")
+-      .trim();
++    const env = this.ctx ?? {};
++    const tokens = md.parse(String(content), env);
++    const footnoteStart = tokens.findIndex((t) => t.type === "footnote_block_open");
++    const bodyTokens = footnoteStart >= 0 ? tokens.slice(0, footnoteStart) : tokens;
++    const body = md.renderer.render(bodyTokens, md.options, env).trim();
+diff --git a/test/unit/callout-shortcode.test.mjs b/test/unit/callout-shortcode.test.mjs
+index 0384d4f..24bee62 100644
+--- a/test/unit/callout-shortcode.test.mjs
++++ b/test/unit/callout-shortcode.test.mjs
+@@ -8 +8 @@ import { createCalloutShortcode } from '../../eleventy.config.mjs';
+-test('callout renders content without inner footnotes block', () => {
++test('callout merges footnotes into page pipeline', () => {
+@@ -12 +12,2 @@ test('callout renders content without inner footnotes block', () => {
+-  const ctx = { env: { filters: { escape: (s) => s } } };
++  const env = {};
++  const ctx = { ctx: env, env: { filters: { escape: (s) => s } } };
+@@ -15 +15,0 @@ test('callout renders content without inner footnotes block', () => {
+-  assert.ok(!html.includes('footnotes-hybrid'), 'no inner footnotes block');
+@@ -16,0 +17,4 @@ test('callout renders content without inner footnotes block', () => {
++  assert.equal(env.footnotes?.list?.length, 1, 'footnote captured in env');
++  const tokens = env.footnotes?.list?.[0]?.tokens;
++  const hasNote = tokens?.some((t) => t.content?.includes('note'));
++  assert.ok(hasNote, 'footnote definition carried over');

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -53,11 +53,11 @@ export function createCalloutShortcode(eleventyConfig) {
         ? `<span class="callout-icon" aria-hidden="true">${envEscape(icon)}</span>`
         : "";
 
-    const rendered = md.render(String(content), this.ctx ?? {});
-    const body = rendered
-      .replace(/<section class="footnotes"[\s\S]*?<\/section>/, "")
-      .replace(/<div class="footnotes-hybrid"[\s\S]*?<\/div>/, "")
-      .trim();
+    const env = this.ctx ?? {};
+    const tokens = md.parse(String(content), env);
+    const footnoteStart = tokens.findIndex((t) => t.type === "footnote_block_open");
+    const bodyTokens = footnoteStart >= 0 ? tokens.slice(0, footnoteStart) : tokens;
+    const body = md.renderer.render(bodyTokens, md.options, env).trim();
 
     return `
 <aside class="${classes}" role="note" aria-labelledby="${safeId}">

--- a/logs/ckpt-20250823T092012Z.log
+++ b/logs/ckpt-20250823T092012Z.log
@@ -1,0 +1,9 @@
+commit 061044b2d4a4feb3d671515bb9f0067c7ab052e6
+Author: Codex <codex@openai.com>
+Date:   Sat Aug 23 09:23:38 2025 +0000
+
+    feat: merge callout footnotes into global pipeline
+
+ eleventy.config.mjs                  | 10 +++++-----
+ test/unit/callout-shortcode.test.mjs | 10 +++++++---
+ 2 files changed, 12 insertions(+), 8 deletions(-)

--- a/test/unit/callout-shortcode.test.mjs
+++ b/test/unit/callout-shortcode.test.mjs
@@ -5,13 +5,17 @@ import markdownItFootnote from 'markdown-it-footnote';
 import { applyMarkdownExtensions } from '../../lib/markdown/index.js';
 import { createCalloutShortcode } from '../../eleventy.config.mjs';
 
-test('callout renders content without inner footnotes block', () => {
+test('callout merges footnotes into page pipeline', () => {
   const md = applyMarkdownExtensions(new MarkdownIt().use(markdownItFootnote));
   const config = { markdownLibrary: md };
   const callout = createCalloutShortcode(config);
-  const ctx = { env: { filters: { escape: (s) => s } } };
+  const env = {};
+  const ctx = { ctx: env, env: { filters: { escape: (s) => s } } };
   const html = callout.call(ctx, 'Check[^1]\n\n[^1]: note');
   assert.ok(/annotation-ref/.test(html), 'footnote reference rendered');
-  assert.ok(!html.includes('footnotes-hybrid'), 'no inner footnotes block');
   assert.ok(!html.includes('<section class="footnotes">'), 'no footnotes section rendered');
+  assert.equal(env.footnotes?.list?.length, 1, 'footnote captured in env');
+  const tokens = env.footnotes?.list?.[0]?.tokens;
+  const hasNote = tokens?.some((t) => t.content?.includes('note'));
+  assert.ok(hasNote, 'footnote definition carried over');
 });


### PR DESCRIPTION
## Summary
- render callout inner markdown through global env without duplicating footnote sections
- test that callout footnotes merge into page footnotes
- include checkpoint artifacts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a986e2dba883308682c725c9a6b51a