### PR TITLE
fix: pin interlinker plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@11ty/eleventy-img": "^6.0.4",
         "@11ty/eleventy-navigation": "^1.0.4",
         "@11ty/eleventy-plugin-rss": "^2.0.4",
-        "@photogabble/eleventy-plugin-interlinker": "^1.1.0",
+        "@photogabble/eleventy-plugin-interlinker": "1.1.0",
         "@quasibit/eleventy-plugin-schema": "1.11.1",
         "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
         "@shikijs/markdown-it": "3.11.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-navigation": "^1.0.4",
     "@11ty/eleventy-plugin-rss": "^2.0.4",
-    "@photogabble/eleventy-plugin-interlinker": "^1.1.0",
+    "@photogabble/eleventy-plugin-interlinker": "1.1.0",
     "@quasibit/eleventy-plugin-schema": "1.11.1",
     "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
     "@shikijs/markdown-it": "3.11.0",


### PR DESCRIPTION
## Summary
- pin `@photogabble/eleventy-plugin-interlinker` to version 1.1.0 so patch applies consistently and Eleventy build avoids `document.match` errors

## Testing
- `npm test` *(fails: process hung in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4fc670508330ad359368e279bce0