### PR TITLE
Ensure MSCHF overlay spans viewport

### DIFF
--- a/artifacts/patches/20250827T053438Z.patch
+++ b/artifacts/patches/20250827T053438Z.patch
@@ -1,0 +1,38 @@
+From d5574a30bdc8b6a43de66087230a747e3cba8461 Mon Sep 17 00:00:00 2001
+From: Codex <codex@openai.com>
+Date: Wed, 27 Aug 2025 05:34:17 +0000
+Subject: [PATCH] fix: expand overlay root to viewport
+
+---
+ src/scripts/mschf-overlay.js | 2 +-
+ src/styles/mschf-overlay.css | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/scripts/mschf-overlay.js b/src/scripts/mschf-overlay.js
+index 8b71aeb..273e2c1 100644
+--- a/src/scripts/mschf-overlay.js
++++ b/src/scripts/mschf-overlay.js
+@@ -70,7 +70,7 @@ function initOverlay() {
+   // Root
+   let root = doc.getElementById("mschf-overlay-root");
+   if (!root) root = el("div", "", doc.body), (root.id = "mschf-overlay-root");
+-  css(root, { pointerEvents:"none", position:"fixed", inset:"0", zIndex:"44", color:"hsl(var(--p))" });
++  css(root, { pointerEvents:"none", position:"fixed", inset:"0", width:"100vw", height:"100vh", zIndex:"44", color:"hsl(var(--p))" });
+   root.setAttribute("aria-hidden","true");
+   root.innerHTML = "";
+ 
+diff --git a/src/styles/mschf-overlay.css b/src/styles/mschf-overlay.css
+index 54d83e5..a0f48c7 100644
+--- a/src/styles/mschf-overlay.css
++++ b/src/styles/mschf-overlay.css
+@@ -1,6 +1,6 @@
+ /* assets/css/mschf-overlay.css */
+ /* Effusion Labs — Hypebrüt overlay styles. Theme-tinted (color = currentColor). */
+-#mschf-overlay-root { pointer-events:none; position:fixed; inset:0; z-index:44; color:hsl(var(--p)); }
++#mschf-overlay-root { pointer-events:none; position:fixed; inset:0; width:100vw; height:100vh; z-index:44; color:hsl(var(--p)); }
+ @media print { #mschf-overlay-root { display:none; } }
+ 
+ /* ————————————————— Base scaffold ————————————————— */
+-- 
+2.43.0
+

--- a/logs/test-20250827T053410Z.log
+++ b/logs/test-20250827T053410Z.log
@@ -1,0 +1,4 @@
+::notice:: NPM-SHIM: Using PTY wrapper for 'npm test' to ensure output streaming.
+::notice:: NPM-SHIM: Using PTY wrapper for 'npm test' to ensure output streaming.
+::notice:: NPM-SHIM: Using PTY wrapper for 'npm test' to ensure output streaming.
+::notice:: NPM-SHIM: Using PTY wrapper for 'npm test' to ensure output streaming.

--- a/src/scripts/mschf-overlay.js
+++ b/src/scripts/mschf-overlay.js
@@ -70,7 +70,7 @@ function initOverlay() {
   // Root
   let root = doc.getElementById("mschf-overlay-root");
   if (!root) root = el("div", "", doc.body), (root.id = "mschf-overlay-root");
-  css(root, { pointerEvents:"none", position:"fixed", inset:"0", zIndex:"44", color:"hsl(var(--p))" });
+  css(root, { pointerEvents:"none", position:"fixed", inset:"0", width:"100vw", height:"100vh", zIndex:"44", color:"hsl(var(--p))" });
   root.setAttribute("aria-hidden","true");
   root.innerHTML = "";
 

--- a/src/styles/mschf-overlay.css
+++ b/src/styles/mschf-overlay.css
@@ -1,6 +1,6 @@
 /* assets/css/mschf-overlay.css */
 /* Effusion Labs — Hypebrüt overlay styles. Theme-tinted (color = currentColor). */
-#mschf-overlay-root { pointer-events:none; position:fixed; inset:0; z-index:44; color:hsl(var(--p)); }
+#mschf-overlay-root { pointer-events:none; position:fixed; inset:0; width:100vw; height:100vh; z-index:44; color:hsl(var(--p)); }
 @media print { #mschf-overlay-root { display:none; } }
 
 /* ————————————————— Base scaffold ————————————————— */


### PR DESCRIPTION
## Summary
- ensure mschf overlay root fills entire viewport so randomized decorations position correctly
- record failing npm test attempt and patch artifact

## Testing
- `npm test` *(fails: NPM-SHIM PTY wrapper messages only)*

------
https://chatgpt.com/codex/tasks/task_e_68ae971f20a483309211ed751fe2de09