### PR TITLE
feat: add PTY fallback runner

### DIFF
--- a/artifacts/patches/20250827T055722Z.patch
+++ b/artifacts/patches/20250827T055722Z.patch
@@ -1,0 +1,90 @@
+commit 5d2147e59d5ac436113fa962bd60df05ab2845b6
+Author: Codex <codex@openai.com>
+Date:   Wed Aug 27 05:57:18 2025 +0000
+
+    feat: add PTY fallback runner
+
+diff --git a/logs/test-20250827T055704Z.log b/logs/test-20250827T055704Z.log
+new file mode 100644
+index 0000000..e69de29
+diff --git a/test/unit/pty-runner.test.mjs b/test/unit/pty-runner.test.mjs
+new file mode 100644
+index 0000000..58c4193
+--- /dev/null
++++ b/test/unit/pty-runner.test.mjs
+@@ -0,0 +1,14 @@
++import { strict as assert } from 'node:assert';
++import { spawnSync } from 'node:child_process';
++import path from 'node:path';
++import { fileURLToPath } from 'node:url';
++
++const __dirname = path.dirname(fileURLToPath(import.meta.url));
++const runner = path.resolve(__dirname, '../tools/pty-runner.mjs');
++
++const res = spawnSync(process.execPath, [runner, '--', 'node', '-e', "console.log('ok')"], {
++  encoding: 'utf8',
++});
++
++assert.equal(res.status, 0);
++assert.match(res.stdout, /ok/);
+diff --git a/tools/pty-runner.mjs b/tools/pty-runner.mjs
+new file mode 100644
+index 0000000..108c9f7
+--- /dev/null
++++ b/tools/pty-runner.mjs
+@@ -0,0 +1,55 @@
++import cp from 'node:child_process';
++import path from 'node:path';
++import process from 'node:process';
++import { fileURLToPath } from 'node:url';
++
++const strategies = [
++  {
++    name: 'llm_run',
++    spawn: (cmd, args, opts) =>
++      cp.spawn('llm_run', ['--', cmd, ...args], { ...opts, stdio: 'inherit' }),
++  },
++  {
++    name: 'npm_exec',
++    spawn: (cmd, args, opts) =>
++      cp.spawn(path.resolve('./bin/npm'), ['exec', '--', cmd, ...args], {
++        ...opts,
++        stdio: 'inherit',
++      }),
++  },
++  {
++    name: 'direct',
++    spawn: (cmd, args, opts) => cp.spawn(cmd, args, { ...opts, stdio: 'inherit' }),
++  },
++];
++
++export async function run(cmd, args = [], opts = {}) {
++  for (const strat of strategies) {
++    console.log(`// trying ${strat.name}`);
++    try {
++      const code = await new Promise((resolve) => {
++        const child = strat.spawn(cmd, args, opts);
++        child.on('close', (c) => resolve(c));
++        child.on('error', () => resolve(null));
++      });
++      if (code === 0) {
++        console.log(`// ${strat.name} succeeded`);
++        return 0;
++      }
++      console.warn(`// ${strat.name} failed with code ${code}`);
++    } catch (err) {
++      console.warn(`// ${strat.name} error: ${err.message}`);
++    }
++  }
++  console.error('// all strategies failed');
++  return 1;
++}
++
++if (process.argv[1] === fileURLToPath(import.meta.url)) {
++  const [, , cmd, ...rest] = process.argv;
++  if (!cmd) {
++    console.error('usage: node tools/pty-runner.mjs <cmd> [args...]');
++    process.exit(1);
++  }
++  run(cmd, rest).then((code) => process.exit(code));
++}

--- a/test/unit/pty-runner.test.mjs
+++ b/test/unit/pty-runner.test.mjs
@@ -1,0 +1,14 @@
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const runner = path.resolve(__dirname, '../tools/pty-runner.mjs');
+
+const res = spawnSync(process.execPath, [runner, '--', 'node', '-e', "console.log('ok')"], {
+  encoding: 'utf8',
+});
+
+assert.equal(res.status, 0);
+assert.match(res.stdout, /ok/);

--- a/tools/pty-runner.mjs
+++ b/tools/pty-runner.mjs
@@ -1,0 +1,55 @@
+import cp from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const strategies = [
+  {
+    name: 'llm_run',
+    spawn: (cmd, args, opts) =>
+      cp.spawn('llm_run', ['--', cmd, ...args], { ...opts, stdio: 'inherit' }),
+  },
+  {
+    name: 'npm_exec',
+    spawn: (cmd, args, opts) =>
+      cp.spawn(path.resolve('./bin/npm'), ['exec', '--', cmd, ...args], {
+        ...opts,
+        stdio: 'inherit',
+      }),
+  },
+  {
+    name: 'direct',
+    spawn: (cmd, args, opts) => cp.spawn(cmd, args, { ...opts, stdio: 'inherit' }),
+  },
+];
+
+export async function run(cmd, args = [], opts = {}) {
+  for (const strat of strategies) {
+    console.log(`// trying ${strat.name}`);
+    try {
+      const code = await new Promise((resolve) => {
+        const child = strat.spawn(cmd, args, opts);
+        child.on('close', (c) => resolve(c));
+        child.on('error', () => resolve(null));
+      });
+      if (code === 0) {
+        console.log(`// ${strat.name} succeeded`);
+        return 0;
+      }
+      console.warn(`// ${strat.name} failed with code ${code}`);
+    } catch (err) {
+      console.warn(`// ${strat.name} error: ${err.message}`);
+    }
+  }
+  console.error('// all strategies failed');
+  return 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [, , cmd, ...rest] = process.argv;
+  if (!cmd) {
+    console.error('usage: node tools/pty-runner.mjs <cmd> [args...]');
+    process.exit(1);
+  }
+  run(cmd, rest).then((code) => process.exit(code));
+}


### PR DESCRIPTION
## Summary
- add `pty-runner` tool that sequentially tries `llm_run`, npm exec shim, and direct spawn to keep command output streaming when PTY is restricted
- cover runner with unit test and store patch artifact

## Testing
- `llm_run --out /tmp/test.log -- npm test` *(fails: status 150, empty log)*
- `npm test` *(hangs; terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9d51f5b8833083b38ecd1d24c971