### PR TITLE
fix: improve npm shim streaming

### DIFF
--- a/artifacts/patches/20250827T055116Z.patch
+++ b/artifacts/patches/20250827T055116Z.patch
@@ -1,0 +1,86 @@
+diff --git a/bin/node b/bin/node
+index c1a69da..941a1d4 100755
+--- a/bin/node
++++ b/bin/node
+@@ -1,7 +1,10 @@
+ #!/usr/bin/env bash
+-# This shim simply executes the 'node' command found in the shell's PATH.
+-# It relies on the environment being pre-configured with the correct Node.js version.
+-# The output streaming compatibility with llm_run is handled upstream by the npm shim.
+-set -e
+-
+-exec node "$@"
+\ No newline at end of file
++set -euo pipefail
++DIR="$(cd "$(dirname "$0")" && pwd)"
++PATH_WITHOUT_DIR=$(printf "%s" "$PATH" | sed "s|$DIR:||;s|:$DIR||;s|$DIR||")
++REAL_NODE="$(PATH="$PATH_WITHOUT_DIR" command -v node)"
++if [ -z "$REAL_NODE" ]; then
++  echo "node binary not found" >&2
++  exit 127
++fi
++exec "$REAL_NODE" "$@"
+diff --git a/bin/npm b/bin/npm
+index 3f05367..983e733 100755
+--- a/bin/npm
++++ b/bin/npm
+@@ -1,24 +1,44 @@
+-#!/bin/sh
++#!/usr/bin/env bash
+ # A smart shim for npm that handles output buffering for test commands.
+-set -e
++set -euo pipefail
+ 
+-# Get the absolute path of the directory containing this script.
++# Compute real npm binary, skipping this shim
+ DIR="$(cd "$(dirname "$0")" && pwd)"
+-NPM_CLI="$DIR/../node_modules/npm/bin/npm-cli.js"
++PATH_WITHOUT_DIR=$(printf "%s" "$PATH" | sed "s|$DIR:||;s|:$DIR||;s|$DIR||")
++NPM_BIN="$(PATH="$PATH_WITHOUT_DIR" command -v npm)"
++if [ -z "$NPM_BIN" ]; then
++  echo "npm binary not found" >&2
++  exit 127
++fi
++
++# Helper to run npm with a PTY so output streams in real time
++run_with_pty() {
++  if command -v script >/dev/null 2>&1; then
++    cmd="$NPM_BIN $(printf '%q ' "$@")"
++    script -q -e -c "$cmd" /dev/null
++    return $?
++  elif command -v unbuffer >/dev/null 2>&1; then
++    unbuffer "$NPM_BIN" "$@"
++    return $?
++  elif command -v expect >/dev/null 2>&1; then
++    expect -c "spawn -noecho $NPM_BIN $(printf '%q ' "$@"); interact"
++    return $?
++  elif command -v stdbuf >/dev/null 2>&1; then
++    stdbuf -oL -eL "$NPM_BIN" "$@"
++    return $?
++  else
++    "$NPM_BIN" "$@"
++    return $?
++  fi
++}
+ 
+ # Check if the command is 'test'. This is often the command that suffers
+ # from I/O buffering when run in non-interactive shells.
+ if [ "$1" = "test" ]; then
+-  # For 'npm test', we use a pseudo-terminal (PTY) to force line-buffering.
+-  # This tricks the Node.js test runner into streaming its output immediately.
+-  # The `script` command is a standard Linux utility for this purpose.
+-  # -q = quiet mode (no start/done messages)
+-  # -e = return the exit code of the child command (crucial for CI)
+-  # -c = the command to run, with all arguments passed through
+-  # The final /dev/null argument is for the typescript log file, which we don't need.
++  # For 'npm test', use PTY/line buffering strategies to ensure streaming.
+   echo "::notice:: NPM-SHIM: Using PTY wrapper for 'npm test' to ensure output streaming." >&2
+-  exec script -q -e -c "\"$DIR/node\" \"$NPM_CLI\" \"$@\"" /dev/null
++  run_with_pty "$@"
+ else
+   # For all other commands (install, run build, etc.), execute directly.
+-  exec "$DIR/node" "$NPM_CLI" "$@"
+-fi
+\ No newline at end of file
++  exec "$NPM_BIN" "$@"
++fi

--- a/bin/node
+++ b/bin/node
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# This shim simply executes the 'node' command found in the shell's PATH.
-# It relies on the environment being pre-configured with the correct Node.js version.
-# The output streaming compatibility with llm_run is handled upstream by the npm shim.
-set -e
-
-exec node "$@"
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PATH_WITHOUT_DIR=$(printf "%s" "$PATH" | sed "s|$DIR:||;s|:$DIR||;s|$DIR||")
+REAL_NODE="$(PATH="$PATH_WITHOUT_DIR" command -v node)"
+if [ -z "$REAL_NODE" ]; then
+  echo "node binary not found" >&2
+  exit 127
+fi
+exec "$REAL_NODE" "$@"

--- a/bin/npm
+++ b/bin/npm
@@ -1,24 +1,44 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # A smart shim for npm that handles output buffering for test commands.
-set -e
+set -euo pipefail
 
-# Get the absolute path of the directory containing this script.
+# Compute real npm binary, skipping this shim
 DIR="$(cd "$(dirname "$0")" && pwd)"
-NPM_CLI="$DIR/../node_modules/npm/bin/npm-cli.js"
+PATH_WITHOUT_DIR=$(printf "%s" "$PATH" | sed "s|$DIR:||;s|:$DIR||;s|$DIR||")
+NPM_BIN="$(PATH="$PATH_WITHOUT_DIR" command -v npm)"
+if [ -z "$NPM_BIN" ]; then
+  echo "npm binary not found" >&2
+  exit 127
+fi
+
+# Helper to run npm with a PTY so output streams in real time
+run_with_pty() {
+  if command -v script >/dev/null 2>&1; then
+    cmd="$NPM_BIN $(printf '%q ' "$@")"
+    script -q -e -c "$cmd" /dev/null
+    return $?
+  elif command -v unbuffer >/dev/null 2>&1; then
+    unbuffer "$NPM_BIN" "$@"
+    return $?
+  elif command -v expect >/dev/null 2>&1; then
+    expect -c "spawn -noecho $NPM_BIN $(printf '%q ' "$@"); interact"
+    return $?
+  elif command -v stdbuf >/dev/null 2>&1; then
+    stdbuf -oL -eL "$NPM_BIN" "$@"
+    return $?
+  else
+    "$NPM_BIN" "$@"
+    return $?
+  fi
+}
 
 # Check if the command is 'test'. This is often the command that suffers
 # from I/O buffering when run in non-interactive shells.
 if [ "$1" = "test" ]; then
-  # For 'npm test', we use a pseudo-terminal (PTY) to force line-buffering.
-  # This tricks the Node.js test runner into streaming its output immediately.
-  # The `script` command is a standard Linux utility for this purpose.
-  # -q = quiet mode (no start/done messages)
-  # -e = return the exit code of the child command (crucial for CI)
-  # -c = the command to run, with all arguments passed through
-  # The final /dev/null argument is for the typescript log file, which we don't need.
+  # For 'npm test', use PTY/line buffering strategies to ensure streaming.
   echo "::notice:: NPM-SHIM: Using PTY wrapper for 'npm test' to ensure output streaming." >&2
-  exec script -q -e -c "\"$DIR/node\" \"$NPM_CLI\" \"$@\"" /dev/null
+  run_with_pty "$@"
 else
   # For all other commands (install, run build, etc.), execute directly.
-  exec "$DIR/node" "$NPM_CLI" "$@"
+  exec "$NPM_BIN" "$@"
 fi

--- a/logs/test-20250827T055113Z.log
+++ b/logs/test-20250827T055113Z.log
@@ -1,0 +1,174 @@
+[1mnpm[22m [33mwarn[39m [94mUnknown env config "http-proxy". This will stop working in the next major version of npm.[39m
+
+> effusion_labs_final@1.0.0 test
+> c8 node tools/runner.mjs
+
+[1G[0K🚀 Launching test runner...
+🔍 Found 13 test files.
+
+🏗️  Performing single Eleventy build...
+[1mnpm[22m [33mwarn[39m [94mUnknown env config "http-proxy". This will stop working in the next major version of npm.[39m
+[1G[0K⠙[1G[0K⠹[1G[0K🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+[90m[11ty][39m Writing /tmp/eleventy-build/concept-map.json [90mfrom ./src/concept-map.json.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/feed.xml [90mfrom ./src/feed.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/map/index.html [90mfrom ./src/map.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/404.html [90mfrom ./src/404.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/archives/index.html [90mfrom ./src/archives/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/work/1/index.html [90mfrom ./src/work/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/archives/collectables/index.html [90mfrom ./src/archives/collectables/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/meta/index.html [90mfrom ./src/content/meta/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html [90mfrom ./src/archives/collectables/designer-toys/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html [90mfrom ./src/archives/collectables/designer-toys/pop-mart/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html [90mfrom ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/index.html [90mfrom ./src/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/work/index.html [90mfrom ./src/work.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html [90mfrom ./src/content/concepts/aesthetic-inquiry.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html [90mfrom ./src/content/concepts/atlas-process.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html [90mfrom ./src/content/concepts/autocatalytic-system.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/work/block-ledger/index.html [90mfrom ./src/content/concepts/block-ledger.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html [90mfrom ./src/content/concepts/compliant-spire.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html [90mfrom ./src/content/concepts/ghost-byline.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html [90mfrom ./src/content/concepts/ghost-engine.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html [90mfrom ./src/content/concepts/parroting-mimicry.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html [90mfrom ./src/content/concepts/readers-journey.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html [90mfrom ./src/content/concepts/rhizomatic-protocol.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html [90mfrom ./src/content/concepts/three-studies-sensory.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html [90mfrom ./src/content/concepts/verification-is-an-ecology.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html [90mfrom ./src/content/concepts/workshop-weather.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html [90mfrom ./src/content/meta/a-b-curatorial-protocolist.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/meta/core-concept/index.html [90mfrom ./src/content/meta/core-concept.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html [90mfrom ./src/content/meta/curatorial-generativism.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/meta/methodology/index.html [90mfrom ./src/content/meta/methodology.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/meta/protocolist/index.html [90mfrom ./src/content/meta/protocolist.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/meta/style-guide/index.html [90mfrom ./src/content/meta/style-guide.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html [90mfrom ./src/content/meta/unified-referencing-syntax.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html [90mfrom ./src/content/projects/project-dandelion.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html [90mfrom ./src/content/sparks/academic-blindness.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html [90mfrom ./src/content/sparks/breakfast-eggs.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html [90mfrom ./src/content/sparks/george-eastman-obscure.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html [90mfrom ./src/content/sparks/illusion-japan-nicotine.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html [90mfrom ./src/content/sparks/murakami-market-analysis-2025.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html [90mfrom ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html [90mfrom ./src/content/sparks/smoker-sysadmin.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html [90mfrom ./src/content/sparks/vapor-linked-governance.md (njk)[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/work/drop/index.html [90mfrom ./src/work/drop.11ty.js[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/work/latest/index.html [90mfrom ./src/work/latest.11ty.js[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/concepts/index.html [90mfrom ./src/content/concepts/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/projects/index.html [90mfrom ./src/content/projects/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/sparks/index.html [90mfrom ./src/content/sparks/index.njk[39m
+[90m[11ty][39m Writing /tmp/eleventy-build/work/2/index.html [90mfrom ./src/work/index.njk[39m
+[32m[90m[11ty][39m[32m Copied [1m10[22m Wrote [1m48[22m files in [1m3.18[22m seconds (66.3ms each, v3.1.2)[39m
+[1G[0K⠙[1G[0K✅ Eleventy build complete.
+
+🧪 Running 13 tests...
+[32m✔ callout merges footnotes into page pipeline [90m(10.967028ms)[39m[39m
+[32m✔ defines improved background colors [90m(1.84767ms)[39m[39m
+[32m✔ text contrast meets WCAG AA [90m(0.83168ms)[39m[39m
+[32m✔ tailwind exposes readable font families [90m(0.40981ms)[39m[39m
+[32m✔ includes fluid type scale tokens [90m(0.229807ms)[39m[39m
+[32m✔ footnote popover separates source line [90m(127.931654ms)[39m[39m
+[32m✔ projects computed picks latest entries by date [90m(5.916035ms)[39m[39m
+node:internal/modules/esm/resolve:313
+  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
+         ^
+
+Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /workspace/effusion-labs/node_modules/@photogabble/eleventy-plugin-interlinker/package.json
+[90m    at exportsNotFound (node:internal/modules/esm/resolve:313:10)[39m
+[90m    at packageExportsResolve (node:internal/modules/esm/resolve:660:9)[39m
+[90m    at resolveExports (node:internal/modules/cjs/loader:646:36)[39m
+[90m    at Function._findPath (node:internal/modules/cjs/loader:713:31)[39m
+[90m    at Function._resolveFilename (node:internal/modules/cjs/loader:1351:27)[39m
+[90m    at Function.resolve (node:internal/modules/helpers:145:19)[39m
+    at [90mfile:///workspace/effusion-labs/[39mtest/unit/interlinker-guard.test.mjs:7:25
+[90m    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)[39m
+[90m    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)[39m
+[90m    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)[39m {
+  code: [32m'ERR_PACKAGE_PATH_NOT_EXPORTED'[39m
+}
+
+Node.js v22.18.0
+[31m✖ test/unit/interlinker-guard.test.mjs [90m(144.982952ms)[39m[39m
+[32m✔ keepalive emits heartbeat to stderr [90m(6119.617985ms)[39m[39m
+[32m✔ keepalive ignores first SIGINT [90m(180.494417ms)[39m[39m
+[32m✔ gateway reads SOLVER_URL from environment [90m(6.748393ms)[39m[39m
+[32m✔ gateway retains default solver URL [90m(0.24827ms)[39m[39m
+[32m✔ external link renders with arrow and class [90m(11.445948ms)[39m[39m
+[32m✔ internal link keeps text without external markers [90m(1.207377ms)[39m[39m
+[32m✔ external link starting with arrow does not duplicate [90m(1.608855ms)[39m[39m
+[32m✔ node shim version matches system node [90m(152.869145ms)[39m[39m
+[32m✔ node shim is executable [90m(0.558519ms)[39m[39m
+[32m✔ node shim lacks llm-constants reference [90m(0.284543ms)[39m[39m
+[32m✔ prettier pinned version and format script [90m(6.996472ms)[39m[39m
+[32m✔ merges tag-like metadata into unified tags and categories [90m(7.555283ms)[39m[39m
+[32m✔ deduplicates tag values [90m(0.585715ms)[39m[39m
+[32m✔ categories returns empty array when spark_type absent [90m(0.231469ms)[39m[39m
+[32m✔ ordinalSuffix handles basic single-digit numbers [90m(1.258179ms)[39m[39m
+[32m✔ ordinalSuffix handles negative numbers correctly [90m(0.270714ms)[39m[39m
+[32m✔ ordinalSuffix uses "th" for all teen numbers [90m(0.220947ms)[39m[39m
+[32m✔ ordinalSuffix returns a valid suffix for all days in a month [90m(4.863491ms)[39m[39m
+[32m✔ readFileCached returns null for a nonexistent file path [90m(0.336732ms)[39m[39m
+[32m✔ GitHub workflows use latest action versions [90m(6.062239ms)[39m[39m
+[34mℹ tests 28[39m
+[34mℹ suites 0[39m
+[34mℹ pass 27[39m
+[34mℹ fail 1[39m
+[34mℹ cancelled 0[39m
+[34mℹ skipped 0[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms 6948.415834[39m
+
+[31m✖ failing tests:[39m
+
+test at test/unit/interlinker-guard.test.mjs:1:1
+[31m✖ test/unit/interlinker-guard.test.mjs [90m(144.982952ms)[39m[39m
+  [32m'test failed'[39m
+
+🔥 Tests failed with exit code 1
+----------------------------|---------|----------|---------|---------|------------------------------
+File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s            
+----------------------------|---------|----------|---------|---------|------------------------------
+[32;1mAll files                  [0m | [32;1m  80.55[0m | [33;1m   77.99[0m | [33;1m  69.36[0m | [32;1m  80.55[0m | [31;1m                            [0m 
+[33;1m effusion-labs             [0m | [33;1m  71.52[0m | [33;1m   68.29[0m | [33;1m  57.14[0m | [33;1m  71.52[0m | [31;1m                            [0m 
+[32;1m  eleventy.config.mjs      [0m | [32;1m  87.69[0m | [33;1m   66.66[0m | [33;1m  66.66[0m | [32;1m  87.69[0m | [31;1m...1,153-157,160-162,184-185[0m 
+[32;1m  postcss.config.mjs       [0m | [32;1m    100[0m | [32;1m     100[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[31;1m  tailwind.config.mjs      [0m | [31;1m     38[0m | [32;1m     100[0m | [31;1m      0[0m | [31;1m     38[0m | [31;1m34-95                       [0m 
+[33;1m effusion-labs/lib         [0m | [33;1m  65.82[0m | [33;1m   67.12[0m | [31;1m  41.66[0m | [33;1m  65.82[0m | [31;1m                            [0m 
+[32;1m  archive-nav.js           [0m | [32;1m    100[0m | [32;1m     100[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[32;1m  build-info.js            [0m | [32;1m    100[0m | [31;1m   33.33[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m10-26                       [0m 
+[33;1m  concept-map.js           [0m | [33;1m  73.17[0m | [33;1m   66.66[0m | [33;1m     60[0m | [33;1m  73.17[0m | [31;1m10-12,21-29,56-65           [0m 
+[32;1m  config.js                [0m | [32;1m    100[0m | [32;1m     100[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[32;1m  constants.js             [0m | [32;1m    100[0m | [32;1m     100[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[33;1m  filters.js               [0m | [33;1m  68.51[0m | [33;1m   55.55[0m | [31;1m  41.17[0m | [33;1m  68.51[0m | [31;1m...0,113-119,126-142,158-159[0m 
+[31;1m  flareClient.js           [0m | [31;1m  23.21[0m | [32;1m     100[0m | [31;1m      0[0m | [31;1m  23.21[0m | [31;1m5-7,9,11-49                 [0m 
+[31;1m  outboundProxy.js         [0m | [31;1m     16[0m | [32;1m     100[0m | [31;1m      0[0m | [31;1m     16[0m | [31;1m1-3,6-23                    [0m 
+[32;1m  plugins.js               [0m | [32;1m    100[0m | [31;1m   42.85[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m20-21                       [0m 
+[31;1m  postcss.js               [0m | [31;1m     25[0m | [32;1m     100[0m | [31;1m      0[0m | [31;1m     25[0m | [31;1m15-56                       [0m 
+[31;1m  postcssPlugins.mjs       [0m | [31;1m     30[0m | [32;1m     100[0m | [31;1m      0[0m | [31;1m     30[0m | [31;1m4-10                        [0m 
+[31;1m  seeded.js                [0m | [31;1m  37.83[0m | [33;1m   66.66[0m | [31;1m     25[0m | [31;1m  37.83[0m | [31;1m10-17,19-25,28-35           [0m 
+[33;1m  shortcodes.js            [0m | [33;1m  59.25[0m | [32;1m     100[0m | [31;1m      0[0m | [33;1m  59.25[0m | [31;1m15-25                       [0m 
+[32;1m  utils.js                 [0m | [32;1m  95.65[0m | [32;1m   81.81[0m | [32;1m    100[0m | [32;1m  95.65[0m | [31;1m34-35                       [0m 
+[33;1m  webpageToMarkdown.js     [0m | [33;1m  61.36[0m | [31;1m   33.33[0m | [31;1m      0[0m | [33;1m  61.36[0m | [31;1m14-15,26-30,33-42           [0m 
+[32;1m effusion-labs/lib/eleventy[0m | [32;1m  91.91[0m | [32;1m   86.36[0m | [32;1m     80[0m | [32;1m  91.91[0m | [31;1m                            [0m 
+[32;1m  archives.mjs             [0m | [32;1m  98.71[0m | [32;1m   87.69[0m | [32;1m    100[0m | [32;1m  98.71[0m | [31;1m208-210                     [0m 
+[32;1m  register.mjs             [0m | [32;1m   82.2[0m | [32;1m    82.6[0m | [31;1m     40[0m | [32;1m   82.2[0m | [31;1m27-29,41,44,120-135,155-162 [0m 
+[32;1m effusion-labs/lib/markdown[0m | [32;1m  96.05[0m | [32;1m   86.48[0m | [32;1m    100[0m | [32;1m  96.05[0m | [31;1m                            [0m 
+[32;1m  footnotes.js             [0m | [32;1m  97.16[0m | [32;1m   87.93[0m | [32;1m    100[0m | [32;1m  97.16[0m | [31;1m89-90,103-104,116-118       [0m 
+[32;1m  index.js                 [0m | [32;1m  96.66[0m | [33;1m      75[0m | [32;1m    100[0m | [32;1m  96.66[0m | [31;1m31-32                       [0m 
+[32;1m  inlineMacros.js          [0m | [32;1m  81.48[0m | [32;1m      80[0m | [32;1m    100[0m | [32;1m  81.48[0m | [31;1m12-14,23-24                 [0m 
+[32;1m  links.js                 [0m | [32;1m    100[0m | [32;1m   85.71[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m8                           [0m 
+[32;1m effusion-labs/src         [0m | [32;1m    100[0m | [32;1m      84[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[32;1m  index.11tydata.js        [0m | [32;1m    100[0m | [32;1m    82.6[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m10,28,47,69                 [0m 
+[32;1m  work.11tydata.js         [0m | [32;1m    100[0m | [32;1m     100[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[32;1m effusion-labs/src/_data   [0m | [32;1m     95[0m | [32;1m   89.47[0m | [32;1m    100[0m | [32;1m     95[0m | [31;1m                            [0m 
+[32;1m  archivesNav.js           [0m | [32;1m    100[0m | [32;1m     100[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[32;1m  branding.js              [0m | [32;1m    100[0m | [32;1m     100[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[32;1m  eleventyComputed.js      [0m | [32;1m  89.47[0m | [32;1m   85.71[0m | [32;1m    100[0m | [32;1m  89.47[0m | [31;1m4,6                         [0m 
+[32;1m  nav.js                   [0m | [32;1m    100[0m | [32;1m     100[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[32;1m effusion-labs/src/work    [0m | [32;1m    100[0m | [33;1m      60[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m                            [0m 
+[32;1m  drop.11ty.js             [0m | [32;1m    100[0m | [33;1m   55.55[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m9-13,20                     [0m 
+[32;1m  latest.11ty.js           [0m | [32;1m    100[0m | [33;1m   63.63[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m8-9,16                      [0m 
+[32;1m effusion-labs/tools       [0m | [32;1m  87.21[0m | [33;1m   68.42[0m | [32;1m    100[0m | [32;1m  87.21[0m | [31;1m                            [0m 
+[32;1m  runner.mjs               [0m | [32;1m  81.11[0m | [33;1m   58.33[0m | [32;1m    100[0m | [32;1m  81.11[0m | [31;1m...3-65,71,77-78,83-84,88-89[0m 
+[32;1m  select.mjs               [0m | [32;1m    100[0m | [32;1m   85.71[0m | [32;1m    100[0m | [32;1m    100[0m | [33;1m11                          [0m 
+----------------------------|---------|----------|---------|---------|------------------------------
+[1G[0K⠙[1G[0K


### PR DESCRIPTION
## Summary
- resolve node shim recursion by finding real node binary
- enhance npm shim to stream test output with PTY/line-buffering fallbacks
- record test run log

## Testing
- `npm test` *(fails: ERR_PACKAGE_PATH_NOT_EXPORTED in interlinker-guard.test.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9ab61140833084698d27f746ed9b