### PR TITLE
Randomize MSCHF overlay defaults

### DIFF
--- a/artifacts/patches/0001-feat-randomize-msCHF-overlay-defaults.patch
+++ b/artifacts/patches/0001-feat-randomize-msCHF-overlay-defaults.patch
@@ -1,0 +1,1386 @@
+From 2bc8a11ff983857fd9d025bf8b58072c9487e5e0 Mon Sep 17 00:00:00 2001
+From: Codex <codex@openai.com>
+Date: Wed, 27 Aug 2025 06:51:33 +0000
+Subject: [PATCH] feat: randomize msCHF overlay defaults
+
+---
+ docs/ux/mschf-overlay.md               |  17 +-
+ logs/test-20250827T065105Z.log         | 286 ++++++++++
+ src/_includes/layout.njk               |   4 +-
+ src/scripts/mschf-overlay.js           | 752 +++++++++++++++++--------
+ test/unit/mschf-overlay-style.test.mjs |  15 +-
+ 5 files changed, 825 insertions(+), 249 deletions(-)
+ create mode 100644 logs/test-20250827T065105Z.log
+
+diff --git a/docs/ux/mschf-overlay.md b/docs/ux/mschf-overlay.md
+index f50bc02..b5bd864 100644
+--- a/docs/ux/mschf-overlay.md
++++ b/docs/ux/mschf-overlay.md
+@@ -6,18 +6,21 @@ The MSCHF overlay decorates pages with seeded decals and grid textures while kee
+ 
+ Attach attributes to the `#page-shell` wrapper:
+ 
+-| Attribute | Values | Default | Description |
+-| --- | --- | --- | --- |
+-| `data-mschf` | `on` \| `off` \| `auto` | `auto` | Enable overlay or force disable. |
+-| `data-mschf-intensity` | `lite` \| `loud` | `lite` | Governs element counts and probabilities. |
+-| `data-mschf-seed-mode` | `page` \| `session` | `page` | Ephemeral seed per load or stable for a tab session. |
+-| `data-mschf-style` | `collage` \| `structural` \| `playful` | `collage` | Aesthetic strategy mix. |
++| Attribute              | Values                                 | Default | Description                                          |
++| ---------------------- | -------------------------------------- | ------- | ---------------------------------------------------- |
++| `data-mschf`           | `on` \| `off` \| `auto`                | `auto`  | Enable overlay or force disable.                     |
++| `data-mschf-intensity` | `lite` \| `bold` \| `loud` \| `calm`   | random  | Governs element counts and probabilities.            |
++| `data-mschf-seed-mode` | `page` \| `session`                    | `page`  | Ephemeral seed per load or stable for a tab session. |
++| `data-mschf-style`     | `collage` \| `structural` \| `playful` | random  | Aesthetic strategy mix.                              |
+ 
+ Use `localStorage.setItem('mschf:off','1')` to opt out persistently.
+ 
+ ## Aesthetic Strategies
+ 
+-`collage` (default) fuses four groups: base scaffold, culture-coded ephemera,
++If `data-mschf-intensity` or `data-mschf-style` are omitted, the overlay picks
++random values per page seed so each visit feels fresh.
++
++`collage` fuses four groups: base scaffold, culture-coded ephemera,
+ lab/blueprint motifs, and framing stickers. Other styles limit the mix:
+ 
+ - **structural** – base + lab motifs only.
+diff --git a/logs/test-20250827T065105Z.log b/logs/test-20250827T065105Z.log
+new file mode 100644
+index 0000000..ab41c65
+--- /dev/null
++++ b/logs/test-20250827T065105Z.log
+@@ -0,0 +1,286 @@
++🚀 Launching test runner...
++🔍 Found 14 test files.
++
++🏗️  Performing single Eleventy build...
++npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
++🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
++[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
++[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
++[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
++[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
++[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
++[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
++[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
++[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
++[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
++[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
++[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
++[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
++[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
++[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
++[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
++[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
++[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
++[11ty] Copied 10 Wrote 48 files in 2.27 seconds (47.4ms each, v3.1.2)
++✅ Eleventy build complete.
++
++🧪 Running 14 tests...
++TAP version 13
++# Subtest: callout merges footnotes into page pipeline
++ok 1 - callout merges footnotes into page pipeline
++  ---
++  duration_ms: 11.12023
++  type: 'test'
++  ...
++# Subtest: defines improved background colors
++ok 2 - defines improved background colors
++  ---
++  duration_ms: 1.341923
++  type: 'test'
++  ...
++# Subtest: text contrast meets WCAG AA
++ok 3 - text contrast meets WCAG AA
++  ---
++  duration_ms: 5.685058
++  type: 'test'
++  ...
++# Subtest: tailwind exposes readable font families
++ok 4 - tailwind exposes readable font families
++  ---
++  duration_ms: 0.535419
++  type: 'test'
++  ...
++# Subtest: includes fluid type scale tokens
++ok 5 - includes fluid type scale tokens
++  ---
++  duration_ms: 0.275964
++  type: 'test'
++  ...
++# Subtest: footnote popover separates source line
++ok 6 - footnote popover separates source line
++  ---
++  duration_ms: 91.875392
++  type: 'test'
++  ...
++# Subtest: projects computed picks latest entries by date
++ok 7 - projects computed picks latest entries by date
++  ---
++  duration_ms: 1.782226
++  type: 'test'
++  ...
++# Subtest: keepalive emits heartbeat to stderr
++ok 8 - keepalive emits heartbeat to stderr
++  ---
++  duration_ms: 6095.609812
++  type: 'test'
++  ...
++# Subtest: keepalive ignores first SIGINT
++ok 9 - keepalive ignores first SIGINT
++  ---
++  duration_ms: 179.675703
++  type: 'test'
++  ...
++# Subtest: gateway reads SOLVER_URL from environment
++ok 10 - gateway reads SOLVER_URL from environment
++  ---
++  duration_ms: 0.970262
++  type: 'test'
++  ...
++# Subtest: gateway retains default solver URL
++ok 11 - gateway retains default solver URL
++  ---
++  duration_ms: 0.212331
++  type: 'test'
++  ...
++# Subtest: external link renders with arrow and class
++ok 12 - external link renders with arrow and class
++  ---
++  duration_ms: 8.923424
++  type: 'test'
++  ...
++# Subtest: internal link keeps text without external markers
++ok 13 - internal link keeps text without external markers
++  ---
++  duration_ms: 2.335799
++  type: 'test'
++  ...
++# Subtest: external link starting with arrow does not duplicate
++ok 14 - external link starting with arrow does not duplicate
++  ---
++  duration_ms: 2.281657
++  type: 'test'
++  ...
++# Error: Uncaught [TypeError: window.matchMedia is not a function]
++#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
++#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
++#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
++#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
++#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
++#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
++#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:13:23)
++#     at Test.runInAsyncScope (node:async_hooks:214:14)
++#     at Test.run (node:internal/test_runner/test:1047:25)
++#     at Test.start (node:internal/test_runner/test:944:17) TypeError: window.matchMedia is not a function
++#     at addSpectralRings (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:417:14)
++#     at Object.lab (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:99:34)
++#     at Document.initOverlay (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:126:16)
++#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
++#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
++#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
++#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
++#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
++#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
++#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:13:23)
++# Error: Uncaught [TypeError: window.matchMedia is not a function]
++#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
++#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
++#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
++#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
++#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
++#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
++#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
++#     at new Promise (<anonymous>)
++#     at onDOMContentLoad (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:523:14)
++#     at Object.check (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:76:23) TypeError: window.matchMedia is not a function
++#     at addSpectralRings (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:417:14)
++#     at Object.lab (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:99:34)
++#     at Document.initOverlay (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:126:16)
++#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
++#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
++#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
++#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
++#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
++#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
++#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
++# Subtest: collage style includes base, ephemera, and lab modules
++ok 15 - collage style includes base, ephemera, and lab modules
++  ---
++  duration_ms: 116.29169
++  type: 'test'
++  ...
++# Subtest: node shim version matches system node
++ok 16 - node shim version matches system node
++  ---
++  duration_ms: 143.878065
++  type: 'test'
++  ...
++# Subtest: node shim is executable
++ok 17 - node shim is executable
++  ---
++  duration_ms: 0.719578
++  type: 'test'
++  ...
++# Subtest: node shim lacks llm-constants reference
++ok 18 - node shim lacks llm-constants reference
++  ---
++  duration_ms: 0.276327
++  type: 'test'
++  ...
++# Subtest: prettier pinned version and format script
++ok 19 - prettier pinned version and format script
++  ---
++  duration_ms: 1.347439
++  type: 'test'
++  ...
++# Subtest: test/unit/pty-runner.test.mjs
++ok 11 - test/unit/pty-runner.test.mjs
++  ---
++  duration_ms: 866.486735
++  type: 'test'
++  ...
++# Subtest: merges tag-like metadata into unified tags and categories
++ok 21 - merges tag-like metadata into unified tags and categories
++  ---
++  duration_ms: 2.844184
++  type: 'test'
++  ...
++# Subtest: deduplicates tag values
++ok 22 - deduplicates tag values
++  ---
++  duration_ms: 0.247817
++  type: 'test'
++  ...
++# Subtest: categories returns empty array when spark_type absent
++ok 23 - categories returns empty array when spark_type absent
++  ---
++  duration_ms: 0.184073
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix handles basic single-digit numbers
++ok 24 - ordinalSuffix handles basic single-digit numbers
++  ---
++  duration_ms: 1.060105
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix handles negative numbers correctly
++ok 25 - ordinalSuffix handles negative numbers correctly
++  ---
++  duration_ms: 0.254076
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix uses "th" for all teen numbers
++ok 26 - ordinalSuffix uses "th" for all teen numbers
++  ---
++  duration_ms: 0.325855
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix returns a valid suffix for all days in a month
++ok 27 - ordinalSuffix returns a valid suffix for all days in a month
++  ---
++  duration_ms: 0.500195
++  type: 'test'
++  ...
++# Subtest: readFileCached returns null for a nonexistent file path
++ok 28 - readFileCached returns null for a nonexistent file path
++  ---
++  duration_ms: 0.588632
++  type: 'test'
++  ...
++# Subtest: GitHub workflows use latest action versions
++ok 29 - GitHub workflows use latest action versions
++  ---
++  duration_ms: 1.118347
++  type: 'test'
++  ...
++1..29
++# tests 29
++# suites 0
++# pass 29
++# fail 0
++# cancelled 0
++# skipped 0
++# todo 0
++# duration_ms 6714.7609
++
++✨ All tests passed!
+diff --git a/src/_includes/layout.njk b/src/_includes/layout.njk
+index d42c732..d981be5 100644
+--- a/src/_includes/layout.njk
++++ b/src/_includes/layout.njk
+@@ -100,7 +100,9 @@
+ {# Always-on Hypebrüt overlay controls live on <body> as data-* (page can override via front matter) #}
+ <body
+   data-mschf="auto"
+-  data-mschf-intensity="{{ page.mschfIntensity or site.mschfIntensity or 'lite' }}"
++  {% if page.mschfIntensity or site.mschfIntensity %}
++  data-mschf-intensity="{{ page.mschfIntensity or site.mschfIntensity }}"
++  {% endif %}
+   data-mschf-seed-mode="{{ page.mschfSeedMode or site.mschfSeedMode or 'page' }}"
+   class="bg-base-100 text-base-content font-body antialiased selection:bg-primary/20"
+ >
+diff --git a/src/scripts/mschf-overlay.js b/src/scripts/mschf-overlay.js
+index 5e93841..194d7f6 100644
+--- a/src/scripts/mschf-overlay.js
++++ b/src/scripts/mschf-overlay.js
+@@ -12,24 +12,40 @@
+ // ————————————————————————————————————————
+ // Utilities
+ // ————————————————————————————————————————
+-function randomInt() { return crypto.getRandomValues(new Uint32Array(1))[0].toString(); }
+-function mulberry32(seed) { let t = seed >>> 0; return function () {
+-  t += 0x6D2B79F5; let r = Math.imul(t ^ (t >>> 15), t | 1);
+-  r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+-  return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+-};}
+-function computeSeed(mode = "page", forced, storage) {
++function randomInt() {
++  return crypto.getRandomValues(new Uint32Array(1))[0].toString();
++}
++function mulberry32(seed) {
++  let t = seed >>> 0;
++  return function () {
++    t += 0x6d2b79f5;
++    let r = Math.imul(t ^ (t >>> 15), t | 1);
++    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
++    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
++  };
++}
++function computeSeed(mode = 'page', forced, storage) {
+   if (forced) return String(forced);
+-  if (mode === "session" && storage) {
+-    const existing = storage.getItem("mschfSeed");
++  if (mode === 'session' && storage) {
++    const existing = storage.getItem('mschfSeed');
+     if (existing) return existing;
+-    const next = randomInt(); storage.setItem("mschfSeed", next); return next;
++    const next = randomInt();
++    storage.setItem('mschfSeed', next);
++    return next;
+   }
+   return randomInt();
+ }
+-const css  = (el, obj) => { for (const k in obj) el.style[k] = obj[k]; return el; };
+-const el   = (tag, cls, parent) => { const n = document.createElement(tag); if (cls) n.className = cls; (parent||document.body).appendChild(n); return n; };
+-const pick = (rand, arr) => arr[Math.floor(rand()*arr.length)];
++const css = (el, obj) => {
++  for (const k in obj) el.style[k] = obj[k];
++  return el;
++};
++const el = (tag, cls, parent) => {
++  const n = document.createElement(tag);
++  if (cls) n.className = cls;
++  (parent || document.body).appendChild(n);
++  return n;
++};
++const pick = (rand, arr) => arr[Math.floor(rand() * arr.length)];
+ const chance = (rand, p) => rand() < p;
+ const px = (v) => `${Math.round(v)}px`;
+ 
+@@ -42,9 +58,9 @@ function readBuildMeta() {
+   const doc = document;
+   const src = doc.body || doc.documentElement;
+   return {
+-    hash:   src?.dataset?.buildHash   || "",
+-    branch: src?.dataset?.buildBranch || "",
+-    built:  src?.dataset?.builtAt     || new Date().toISOString()
++    hash: src?.dataset?.buildHash || '',
++    branch: src?.dataset?.buildBranch || '',
++    built: src?.dataset?.builtAt || new Date().toISOString(),
+   };
+ }
+ 
+@@ -52,31 +68,45 @@ function readBuildMeta() {
+ // Main
+ // ————————————————————————————————————————
+ function initOverlay() {
+-  const doc   = document;
+-  const scope = doc.getElementById("page-shell") || doc.body;
++  const doc = document;
++  const scope = doc.getElementById('page-shell') || doc.body;
+   if (!scope) return;
+ 
+   // Allow a kill switch
+-  if (scope.dataset.mschf === "off") return;
+-  if (localStorage.getItem("mschf:off")) return;
+-
+-  const intensity = scope.dataset.mschfIntensity || doc.body.dataset.mschfIntensity || "lite";
+-  const mode      = scope.dataset.mschfSeedMode    || doc.body.dataset.mschfSeedMode    || "page";
+-  const forced    = new URL(window.location.href).searchParams.get("mschf-seed");
+-  const seed      = computeSeed(mode, forced, window.sessionStorage);
+-  const rand      = mulberry32(parseInt(seed, 10) || 0);
+-  const build     = readBuildMeta();
++  if (scope.dataset.mschf === 'off') return;
++  if (localStorage.getItem('mschf:off')) return;
++
++  const mode =
++    scope.dataset.mschfSeedMode || doc.body.dataset.mschfSeedMode || 'page';
++  const forced = new URL(window.location.href).searchParams.get('mschf-seed');
++  const seed = computeSeed(mode, forced, window.sessionStorage);
++  const rand = mulberry32(parseInt(seed, 10) || 0);
++  const intensity =
++    scope.dataset.mschfIntensity ||
++    doc.body.dataset.mschfIntensity ||
++    pick(rand, ['lite', 'bold', 'loud', 'calm']);
++  const build = readBuildMeta();
+ 
+   // Root
+-  let root = doc.getElementById("mschf-overlay-root");
+-  if (!root) root = el("div", "", doc.body), (root.id = "mschf-overlay-root");
+-  css(root, { pointerEvents:"none", position:"fixed", inset:"0", width:"100vw", height:"100vh", zIndex:"44", color:"hsl(var(--p))" });
+-  root.setAttribute("aria-hidden","true");
+-  root.innerHTML = "";
++  let root = doc.getElementById('mschf-overlay-root');
++  if (!root) (root = el('div', '', doc.body)), (root.id = 'mschf-overlay-root');
++  css(root, {
++    pointerEvents: 'none',
++    position: 'fixed',
++    inset: '0',
++    width: '100vw',
++    height: '100vh',
++    zIndex: '44',
++    color: 'hsl(var(--p))',
++  });
++  root.setAttribute('aria-hidden', 'true');
++  root.innerHTML = '';
+ 
+   // Profiles tune density/probabilities per intensity
+   const P = profile(intensity);
+-  const style = scope.dataset.mschfStyle || 'collage';
++  const style =
++    scope.dataset.mschfStyle ||
++    pick(rand, ['collage', 'structural', 'playful']);
+ 
+   const groups = {
+     base() {
+@@ -127,41 +157,139 @@ function initOverlay() {
+   }
+ 
+   // Dev toggles
+-  window.__mschfOff = () => { localStorage.setItem("mschf:off","1"); root.remove(); };
+-  window.__mschfOn  = () => { localStorage.removeItem("mschf:off"); initOverlay(); };
++  window.__mschfOff = () => {
++    localStorage.setItem('mschf:off', '1');
++    root.remove();
++  };
++  window.__mschfOn = () => {
++    localStorage.removeItem('mschf:off');
++    initOverlay();
++  };
+ }
+ 
+ function profile(intensity) {
+   // probabilities per category; tuned for research/aesthetic site
+   const base = {
+-    grid:.70, cross:.55, corners:1,  frame:1,  scan:.18,
+-    tape:.55, stamp:.45, quotes:.65, barcode:.35,
+-    callout:.55, graph:.60, rings:.45, topo:.40, halftone:.35, crt:.20, perf:.30, specimen:.40, starfield:.30,
+-    brackets:.45, glitch:.35, rulers:.35, watermark:.25, flowers:.45, holo:.35, reg:.55, dims:.40, stickers:.45
++    grid: 0.7,
++    cross: 0.55,
++    corners: 1,
++    frame: 1,
++    scan: 0.18,
++    tape: 0.55,
++    stamp: 0.45,
++    quotes: 0.65,
++    barcode: 0.35,
++    callout: 0.55,
++    graph: 0.6,
++    rings: 0.45,
++    topo: 0.4,
++    halftone: 0.35,
++    crt: 0.2,
++    perf: 0.3,
++    specimen: 0.4,
++    starfield: 0.3,
++    brackets: 0.45,
++    glitch: 0.35,
++    rulers: 0.35,
++    watermark: 0.25,
++    flowers: 0.45,
++    holo: 0.35,
++    reg: 0.55,
++    dims: 0.4,
++    stickers: 0.45,
+   };
+   const bold = {
+-    grid:.90, cross:.70, corners:1,  frame:1,  scan:.40,
+-    tape:.75, stamp:.65, quotes:.80, barcode:.45,
+-    callout:.70, graph:.80, rings:.65, topo:.60, halftone:.55, crt:.35, perf:.45, specimen:.55, starfield:.45,
+-    brackets:.65, glitch:.55, rulers:.50, watermark:.40, flowers:.60, holo:.55, reg:.70, dims:.55, stickers:.60
++    grid: 0.9,
++    cross: 0.7,
++    corners: 1,
++    frame: 1,
++    scan: 0.4,
++    tape: 0.75,
++    stamp: 0.65,
++    quotes: 0.8,
++    barcode: 0.45,
++    callout: 0.7,
++    graph: 0.8,
++    rings: 0.65,
++    topo: 0.6,
++    halftone: 0.55,
++    crt: 0.35,
++    perf: 0.45,
++    specimen: 0.55,
++    starfield: 0.45,
++    brackets: 0.65,
++    glitch: 0.55,
++    rulers: 0.5,
++    watermark: 0.4,
++    flowers: 0.6,
++    holo: 0.55,
++    reg: 0.7,
++    dims: 0.55,
++    stickers: 0.6,
+   };
+   const loud = {
+-    grid:1.00, cross:.85, corners:1, frame:1,  scan:.60,
+-    tape:.85, stamp:.75, quotes:.90, barcode:.55,
+-    callout:.85, graph:.90, rings:.80, topo:.75, halftone:.70, crt:.55, perf:.55, specimen:.65, starfield:.60,
+-    brackets:.80, glitch:.70, rulers:.60, watermark:.50, flowers:.75, holo:.70, reg:.85, dims:.65, stickers:.75
++    grid: 1.0,
++    cross: 0.85,
++    corners: 1,
++    frame: 1,
++    scan: 0.6,
++    tape: 0.85,
++    stamp: 0.75,
++    quotes: 0.9,
++    barcode: 0.55,
++    callout: 0.85,
++    graph: 0.9,
++    rings: 0.8,
++    topo: 0.75,
++    halftone: 0.7,
++    crt: 0.55,
++    perf: 0.55,
++    specimen: 0.65,
++    starfield: 0.6,
++    brackets: 0.8,
++    glitch: 0.7,
++    rulers: 0.6,
++    watermark: 0.5,
++    flowers: 0.75,
++    holo: 0.7,
++    reg: 0.85,
++    dims: 0.65,
++    stickers: 0.75,
+   };
+   const calm = {
+-    grid:.35, cross:.30, corners:1,  frame:1,  scan:.06,
+-    tape:.22, stamp:.18, quotes:.28, barcode:.18,
+-    callout:.25, graph:.30, rings:.20, topo:.18, halftone:.15, crt:.10, perf:.12, specimen:.20, starfield:.15,
+-    brackets:.22, glitch:.12, rulers:.20, watermark:.12, flowers:.18, holo:.12, reg:.30, dims:.18, stickers:.15
++    grid: 0.35,
++    cross: 0.3,
++    corners: 1,
++    frame: 1,
++    scan: 0.06,
++    tape: 0.22,
++    stamp: 0.18,
++    quotes: 0.28,
++    barcode: 0.18,
++    callout: 0.25,
++    graph: 0.3,
++    rings: 0.2,
++    topo: 0.18,
++    halftone: 0.15,
++    crt: 0.1,
++    perf: 0.12,
++    specimen: 0.2,
++    starfield: 0.15,
++    brackets: 0.22,
++    glitch: 0.12,
++    rulers: 0.2,
++    watermark: 0.12,
++    flowers: 0.18,
++    holo: 0.12,
++    reg: 0.3,
++    dims: 0.18,
++    stickers: 0.15,
+   };
+-  const all = Object.fromEntries(Object.keys(base).map(k => [k, 1]));
+-  if (intensity === "bold") return bold;
+-  if (intensity === "loud") return loud;
+-  if (intensity === "calm") return calm;
+-  if (intensity === "test") return all;
++  const all = Object.fromEntries(Object.keys(base).map((k) => [k, 1]));
++  if (intensity === 'bold') return bold;
++  if (intensity === 'loud') return loud;
++  if (intensity === 'calm') return calm;
++  if (intensity === 'test') return all;
+   return base; // "lite"
+ }
+ 
+@@ -169,34 +297,44 @@ function profile(intensity) {
+ // Base elements
+ // ————————————————————————————————————————
+ function addGrid(root, rand, intensity) {
+-  const g = el("div", "mschf-grid", root);
+-  g.dataset.variant = rand() < 0.5 ? "dots" : "lines";
+-  g.style.opacity = (intensity === "loud" ? "0.12" : "0.08");
++  const g = el('div', 'mschf-grid', root);
++  g.dataset.variant = rand() < 0.5 ? 'dots' : 'lines';
++  g.style.opacity = intensity === 'loud' ? '0.12' : '0.08';
+ }
+ function addCrosshair(root, rand, intensity) {
+-  const cross = el("div", "mschf-crosshair", root);
++  const cross = el('div', 'mschf-crosshair', root);
+   if (rand() < 0.5) {
+-    cross.classList.add("is-offset");
+-    cross.style.setProperty("--mschf-x", `${50 + Math.round((rand()-0.5)*40)}vw`);
+-    cross.style.setProperty("--mschf-y", `${50 + Math.round((rand()-0.5)*24)}vh`);
++    cross.classList.add('is-offset');
++    cross.style.setProperty(
++      '--mschf-x',
++      `${50 + Math.round((rand() - 0.5) * 40)}vw`,
++    );
++    cross.style.setProperty(
++      '--mschf-y',
++      `${50 + Math.round((rand() - 0.5) * 24)}vh`,
++    );
+   }
+-  el("div","mschf-crosshair-ring",cross);
+-  el("div","mschf-crosshair-v",cross);
+-  el("div","mschf-crosshair-h",cross);
++  el('div', 'mschf-crosshair-ring', cross);
++  el('div', 'mschf-crosshair-v', cross);
++  el('div', 'mschf-crosshair-h', cross);
+ }
+ function addCorners(root, intensity) {
+-  ["tl","tr","bl","br"].forEach(pos => {
+-    const c = el("div", `mschf-corner mschf-corner-${pos}`, root);
+-    c.style.opacity = (intensity === "calm" ? "0.08" : "0.14");
++  ['tl', 'tr', 'bl', 'br'].forEach((pos) => {
++    const c = el('div', `mschf-corner mschf-corner-${pos}`, root);
++    c.style.opacity = intensity === 'calm' ? '0.08' : '0.14';
+   });
+ }
+ function addFrame(root, intensity) {
+-  const f = el("div", "mschf-frame", root);
+-  f.style.opacity = (intensity === "loud" ? "0.22" : "0.14");
++  const f = el('div', 'mschf-frame', root);
++  f.style.opacity = intensity === 'loud' ? '0.22' : '0.14';
+ }
+ function addScanline(root) {
+-  const s = el("div", "mschf-scanline", root);
+-  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) s.classList.add("static");
++  const s = el('div', 'mschf-scanline', root);
++  if (
++    window.matchMedia &&
++    window.matchMedia('(prefers-reduced-motion: reduce)').matches
++  )
++    s.classList.add('static');
+ }
+ 
+ // ————————————————————————————————————————
+@@ -205,58 +343,86 @@ function addScanline(root) {
+ function addTapeLabels(root, rand, intensity) {
+   // Expanded tape vocabulary (quotes = Off-White style; tones map to A/B/C pastel & readable)
+   const tapes = [
+-    { text:'"KEEP OFF"', tone:"c" }, { text:'"FOR DISPLAY ONLY"', tone:"a" },
+-    { text:'"PROTOTYPE"', tone:"b" }, { text:'"ARCHIVE"', tone:"c" },
+-    { text:'"FIELD NOTES"', tone:"a" }, { text:'"RED TEAM"', tone:"b" },
+-    { text:'"PAYLOAD"', tone:"c" }, { text:'"SIMULACRUM"', tone:"a" },
+-
+-    { text:'"SPECIMEN"', tone:"b" }, { text:'"ARTIFACT"', tone:"a" },
+-    { text:'"EVIDENCE"', tone:"c" }, { text:'"PROVENANCE"', tone:"a" },
+-    { text:'"BLUEPRINT"', tone:"b" }, { text:'"DRAFT"', tone:"c" },
+-
+-    { text:'"ALPHA"', tone:"a" }, { text:'"BETA"', tone:"b" }, { text:'"RC1"', tone:"c" },
+-    { text:'"NIGHTLY"', tone:"a" }, { text:'"CANARY"', tone:"b" }, { text:'"WIP"', tone:"c" },
+-
+-    { text:'"REDACTED"', tone:"a" }, { text:'"DECLASSIFIED"', tone:"b" }, { text:'"NONCANON"', tone:"c" },
+-    { text:'"UNSANCTIONED"', tone:"a" }, { text:'"UNVERIFIED"', tone:"b" }, { text:'"NULL RESULT"', tone:"c" },
+-
+-    { text:'"KEEP OUT"', tone:"a" }, { text:'"OFF LIMITS"', tone:"b" }, { text:'"NO ENTRY"', tone:"c" },
+-    { text:'"DO NOT TOUCH"', tone:"a" }, { text:'"HANDLE WITH CARE"', tone:"b" },
+-
+-    { text:'"FOR RESEARCH ONLY"', tone:"a" }, { text:'"FOR INTERNAL USE"', tone:"b" },
+-    { text:'"SANDBOX"', tone:"c" }, { text:'"SIMULATION"', tone:"a" },
+-
+-    { text:'"GRAPH"', tone:"a" }, { text:'"NODE"', tone:"b" }, { text:'"EDGE"', tone:"c" },
+-    { text:'"EMBEDDING"', tone:"a" }, { text:'"RAG"', tone:"b" }, { text:'"EVAL"', tone:"c" },
+-
+-    { text:'"READ ONLY"', tone:"a" }, { text:'"NO INDEX"', tone:"b" }, { text:'"NO EXPORT"', tone:"c" }
++    { text: '"KEEP OFF"', tone: 'c' },
++    { text: '"FOR DISPLAY ONLY"', tone: 'a' },
++    { text: '"PROTOTYPE"', tone: 'b' },
++    { text: '"ARCHIVE"', tone: 'c' },
++    { text: '"FIELD NOTES"', tone: 'a' },
++    { text: '"RED TEAM"', tone: 'b' },
++    { text: '"PAYLOAD"', tone: 'c' },
++    { text: '"SIMULACRUM"', tone: 'a' },
++
++    { text: '"SPECIMEN"', tone: 'b' },
++    { text: '"ARTIFACT"', tone: 'a' },
++    { text: '"EVIDENCE"', tone: 'c' },
++    { text: '"PROVENANCE"', tone: 'a' },
++    { text: '"BLUEPRINT"', tone: 'b' },
++    { text: '"DRAFT"', tone: 'c' },
++
++    { text: '"ALPHA"', tone: 'a' },
++    { text: '"BETA"', tone: 'b' },
++    { text: '"RC1"', tone: 'c' },
++    { text: '"NIGHTLY"', tone: 'a' },
++    { text: '"CANARY"', tone: 'b' },
++    { text: '"WIP"', tone: 'c' },
++
++    { text: '"REDACTED"', tone: 'a' },
++    { text: '"DECLASSIFIED"', tone: 'b' },
++    { text: '"NONCANON"', tone: 'c' },
++    { text: '"UNSANCTIONED"', tone: 'a' },
++    { text: '"UNVERIFIED"', tone: 'b' },
++    { text: '"NULL RESULT"', tone: 'c' },
++
++    { text: '"KEEP OUT"', tone: 'a' },
++    { text: '"OFF LIMITS"', tone: 'b' },
++    { text: '"NO ENTRY"', tone: 'c' },
++    { text: '"DO NOT TOUCH"', tone: 'a' },
++    { text: '"HANDLE WITH CARE"', tone: 'b' },
++
++    { text: '"FOR RESEARCH ONLY"', tone: 'a' },
++    { text: '"FOR INTERNAL USE"', tone: 'b' },
++    { text: '"SANDBOX"', tone: 'c' },
++    { text: '"SIMULATION"', tone: 'a' },
++
++    { text: '"GRAPH"', tone: 'a' },
++    { text: '"NODE"', tone: 'b' },
++    { text: '"EDGE"', tone: 'c' },
++    { text: '"EMBEDDING"', tone: 'a' },
++    { text: '"RAG"', tone: 'b' },
++    { text: '"EVAL"', tone: 'c' },
++
++    { text: '"READ ONLY"', tone: 'a' },
++    { text: '"NO INDEX"', tone: 'b' },
++    { text: '"NO EXPORT"', tone: 'c' },
+   ];
+ 
+   // How many tapes to drop
+-  const count = 1 + Math.floor(rand() * (intensity === "loud" ? 4 : 2));
++  const count = 1 + Math.floor(rand() * (intensity === 'loud' ? 4 : 2));
+ 
+   for (let i = 0; i < count; i++) {
+     const t = pick(rand, tapes);
+-    const tape = el("div", `mschf-tape tone-${t.tone}`, root);
++    const tape = el('div', `mschf-tape tone-${t.tone}`, root);
+ 
+     // Optional: hazard stripe override (some % of the time)
+-    if (rand() < (intensity === "loud" ? 0.45 : 0.25)) {
+-      tape.style.background = "repeating-linear-gradient(45deg, #ffd500 0 8px, #000 8px 16px)";
+-      tape.style.color = "#0b0b0e";
+-      tape.style.borderStyle = "solid";
++    if (rand() < (intensity === 'loud' ? 0.45 : 0.25)) {
++      tape.style.background =
++        'repeating-linear-gradient(45deg, #ffd500 0 8px, #000 8px 16px)';
++      tape.style.color = '#0b0b0e';
++      tape.style.borderStyle = 'solid';
+     } else if (rand() < 0.25) {
+       // Clear acetate-esque tape variant
+-      tape.style.background = "linear-gradient(to bottom, rgba(255,255,255,.22), rgba(255,255,255,.08))";
+-      tape.style.backdropFilter = "blur(2px)";
+-      tape.style.borderStyle = "dotted";
++      tape.style.background =
++        'linear-gradient(to bottom, rgba(255,255,255,.22), rgba(255,255,255,.08))';
++      tape.style.backdropFilter = 'blur(2px)';
++      tape.style.borderStyle = 'dotted';
+     }
+ 
+     // Serial/rig hint
+-    const rig = (Math.random().toString(16).slice(2, 6)).toUpperCase();
++    const rig = Math.random().toString(16).slice(2, 6).toUpperCase();
+     tape.textContent = `${t.text} • RIG-${rig}`;
+ 
+     // Transform & size
+-    const rot = (rand() - 0.5) * (intensity === "loud" ? 14 : 6);
++    const rot = (rand() - 0.5) * (intensity === 'loud' ? 14 : 6);
+     const skew = (rand() - 0.5) * 4;
+     const w = 32 + Math.floor(rand() * 52); // vw
+     const top = 6 + Math.floor(rand() * 74);
+@@ -267,88 +433,155 @@ function addTapeLabels(root, rand, intensity) {
+       left: `${left}%`,
+       width: `${w}vw`,
+       transform: `rotate(${rot}deg) skewX(${skew}deg)`,
+-      opacity: (intensity === "calm" ? ".20" : ".32")
++      opacity: intensity === 'calm' ? '.20' : '.32',
+     });
+   }
+ }
+ 
+ function addStamp(root, rand) {
+   const stamps = [
+-    "LAB DROP","EXPERIMENTAL","UNSTABLE","FIELD TEST","FOR INTERNAL USE",
+-    "NULL RESULT","RECALIBRATE","KEEP OFF","DECLASSIFIED","NONCANON",
+-    "UNSANCTIONED","FOR RESEARCH ONLY","UNVERIFIED","ARCHIVE ONLY","READ ONLY",
+-    "CHECKSUM FAIL","RETRY","REINDEX","RESAMPLE","REHYDRATE"
++    'LAB DROP',
++    'EXPERIMENTAL',
++    'UNSTABLE',
++    'FIELD TEST',
++    'FOR INTERNAL USE',
++    'NULL RESULT',
++    'RECALIBRATE',
++    'KEEP OFF',
++    'DECLASSIFIED',
++    'NONCANON',
++    'UNSANCTIONED',
++    'FOR RESEARCH ONLY',
++    'UNVERIFIED',
++    'ARCHIVE ONLY',
++    'READ ONLY',
++    'CHECKSUM FAIL',
++    'RETRY',
++    'REINDEX',
++    'RESAMPLE',
++    'REHYDRATE',
+   ];
+ 
+-  const s = el("div", "mschf-stamp", root);
++  const s = el('div', 'mschf-stamp', root);
+   s.textContent = pick(rand, stamps);
+ 
+   // Variant styling
+   const variants = [
+-    () => { s.style.borderWidth = "2px"; s.style.letterSpacing = ".12em"; },
+-    () => { s.style.borderWidth = "3px"; s.style.letterSpacing = ".18em"; s.style.transform += " scale(1.05)"; },
+-    () => { s.style.borderRadius = "999px"; s.style.padding = "6px 12px"; },
+-    () => { s.style.mixBlendMode = "overlay"; s.style.opacity = ".9"; },
+-    () => { s.style.filter = "contrast(1.3) saturate(1.1)"; }
++    () => {
++      s.style.borderWidth = '2px';
++      s.style.letterSpacing = '.12em';
++    },
++    () => {
++      s.style.borderWidth = '3px';
++      s.style.letterSpacing = '.18em';
++      s.style.transform += ' scale(1.05)';
++    },
++    () => {
++      s.style.borderRadius = '999px';
++      s.style.padding = '6px 12px';
++    },
++    () => {
++      s.style.mixBlendMode = 'overlay';
++      s.style.opacity = '.9';
++    },
++    () => {
++      s.style.filter = 'contrast(1.3) saturate(1.1)';
++    },
+   ];
+   pick(rand, variants)();
+ 
+   // Position: random corner band
+-  const corner = pick(rand, ["top-right","top-left","bottom-right","bottom-left"]);
++  const corner = pick(rand, [
++    'top-right',
++    'top-left',
++    'bottom-right',
++    'bottom-left',
++  ]);
+   const rot = (rand() - 0.5) * 12;
+   const insetX = 6 + Math.floor(rand() * 14);
+   const insetY = 8 + Math.floor(rand() * 16);
+ 
+   const style = { transform: `rotate(${rot}deg)` };
+-  if (corner === "top-right")  { style.right = `${insetX}%`; style.top = `${insetY}%`; }
+-  if (corner === "top-left")   { style.left  = `${insetX}%`; style.top = `${insetY}%`; }
+-  if (corner === "bottom-right"){ style.right = `${insetX}%`; style.bottom = `${insetY}%`; }
+-  if (corner === "bottom-left"){ style.left  = `${insetX}%`; style.bottom = `${insetY}%`; }
++  if (corner === 'top-right') {
++    style.right = `${insetX}%`;
++    style.top = `${insetY}%`;
++  }
++  if (corner === 'top-left') {
++    style.left = `${insetX}%`;
++    style.top = `${insetY}%`;
++  }
++  if (corner === 'bottom-right') {
++    style.right = `${insetX}%`;
++    style.bottom = `${insetY}%`;
++  }
++  if (corner === 'bottom-left') {
++    style.left = `${insetX}%`;
++    style.bottom = `${insetY}%`;
++  }
+   css(s, style);
+ }
+ 
+ function addQuotes(root, rand) {
+   // Off-White style quotes, kept positive/neutral
+   const phrases = [
+-    '"OBJECT"','"INTERFACE"','"ARTIFACT"','"SYSTEM"','"SPECIMEN"','"EVIDENCE"',
+-    '"PROTOTYPE"','"KNOWLEDGE"','"GRAPH"','"SPARK"','"VECTOR"','"EMBEDDING"',
+-    '"SANDBOX"','"SIMULATION"','"RAG"','"EVAL"','"CATALOG"','"ATLAS"','"WORKBOARD"'
++    '"OBJECT"',
++    '"INTERFACE"',
++    '"ARTIFACT"',
++    '"SYSTEM"',
++    '"SPECIMEN"',
++    '"EVIDENCE"',
++    '"PROTOTYPE"',
++    '"KNOWLEDGE"',
++    '"GRAPH"',
++    '"SPARK"',
++    '"VECTOR"',
++    '"EMBEDDING"',
++    '"SANDBOX"',
++    '"SIMULATION"',
++    '"RAG"',
++    '"EVAL"',
++    '"CATALOG"',
++    '"ATLAS"',
++    '"WORKBOARD"',
+   ];
+ 
+-  const q = el("div", "mschf-quotes", root);
+-  const idtail = (Math.random().toString(36).slice(2,5)).toUpperCase();
++  const q = el('div', 'mschf-quotes', root);
++  const idtail = Math.random().toString(36).slice(2, 5).toUpperCase();
+   q.textContent = `${pick(rand, phrases)} • ${idtail}`;
+ 
+-  const side = rand() < 0.5 ? "right" : "left";
+-  const vertical = rand() < 0.3 ? "top" : "bottom";
++  const side = rand() < 0.5 ? 'right' : 'left';
++  const vertical = rand() < 0.3 ? 'top' : 'bottom';
+   const offX = 12 + Math.floor(rand() * 24);
+   const offY = 10 + Math.floor(rand() * 18);
+ 
+   const style = {};
+-  if (side === "right") style.right = `${offX}px`; else style.left = `${offX}px`;
+-  if (vertical === "top") style.top = `${offY}px`; else style.bottom = `${offY}px`;
++  if (side === 'right') style.right = `${offX}px`;
++  else style.left = `${offX}px`;
++  if (vertical === 'top') style.top = `${offY}px`;
++  else style.bottom = `${offY}px`;
+ 
+   // Minor rotation & glow
+-  style.transform = `rotate(${(rand()-0.5)*2.2}deg)`;
+-  style.boxShadow = "0 0 0 1px rgba(255,255,255,.04) inset, 0 8px 18px rgba(0,0,0,.35)";
++  style.transform = `rotate(${(rand() - 0.5) * 2.2}deg)`;
++  style.boxShadow =
++    '0 0 0 1px rgba(255,255,255,.04) inset, 0 8px 18px rgba(0,0,0,.35)';
+   css(q, style);
+ }
+ 
+ function addSpecimenLabel(root, rand, build) {
+-  const lab = el("div", "mschf-specimen", root);
+-  const id  = (Math.random().toString(36).slice(2,7)).toUpperCase();
+-  const hash = build?.hash ? build.hash.slice(0,7) : "";
+-  const date = (build?.built || new Date().toISOString()).slice(0,10);
+-  const branch = build?.branch || "main";
+-  const rev = ["A","B","C","D"][Math.floor(rand()*4)];
++  const lab = el('div', 'mschf-specimen', root);
++  const id = Math.random().toString(36).slice(2, 7).toUpperCase();
++  const hash = build?.hash ? build.hash.slice(0, 7) : '';
++  const date = (build?.built || new Date().toISOString()).slice(0, 10);
++  const branch = build?.branch || 'main';
++  const rev = ['A', 'B', 'C', 'D'][Math.floor(rand() * 4)];
+ 
+   // Optional path hint (non-sensitive)
+-  const pathHint = (location && location.pathname) ? location.pathname : "/";
++  const pathHint = location && location.pathname ? location.pathname : '/';
+ 
+   lab.innerHTML = `
+     <strong>SPECIMEN</strong>
+     <span>ID ${id}</span>
+-    ${hash ? `<span>BUILD ${hash}</span>` : ""}
++    ${hash ? `<span>BUILD ${hash}</span>` : ''}
+     <span>${date}</span>
+     <span>BR ${branch}</span>
+     <span>REV ${rev}</span>
+@@ -356,176 +589,223 @@ function addSpecimenLabel(root, rand, build) {
+   `;
+ 
+   // Dock near a corner with slight variance
+-  const side = rand() < 0.5 ? "right" : "left";
+-  const offX = 18 + Math.floor(rand()*24);
+-  const offY = 16 + Math.floor(rand()*20);
++  const side = rand() < 0.5 ? 'right' : 'left';
++  const offX = 18 + Math.floor(rand() * 24);
++  const offY = 16 + Math.floor(rand() * 20);
+   const style = {};
+-  if (side === "right") style.right = `${offX}px`; else style.left = `${offX}px`;
++  if (side === 'right') style.right = `${offX}px`;
++  else style.left = `${offX}px`;
+   style.top = `${offY}px`;
+   css(lab, style);
+ }
+ 
+ function addPlate(root, rand, seed, build) {
+-  const plate = el("div","mschf-plate", root);
+-  el("div","mschf-barcode", plate);
+-  const code = el("div","mschf-code", plate);
++  const plate = el('div', 'mschf-plate', root);
++  el('div', 'mschf-barcode', plate);
++  const code = el('div', 'mschf-code', plate);
+   const tail = seed.slice(-6);
+-  const stamp = (build?.built || new Date().toISOString()).slice(0,10);
+-  code.textContent = `SEED:${tail} • BR:${(build.branch||"main")} • ${stamp}`;
+-  css(plate,{ left:"18px", top:"18px" });
++  const stamp = (build?.built || new Date().toISOString()).slice(0, 10);
++  code.textContent = `SEED:${tail} • BR:${build.branch || 'main'} • ${stamp}`;
++  css(plate, { left: '18px', top: '18px' });
+ }
+ 
+ // ————————————————————————————————————————
+ // Lab/blueprint/OSINT
+ // ————————————————————————————————————————
+ function addBlueprintCallout(root, rand) {
+-  const c = el("div","mschf-callout", root);
+-  const x = 8 + rand()*84, y = 18 + rand()*64;
+-  const len = 8 + rand()*16; // length of leader
+-  c.style.setProperty("--x", `${x}vw`);
+-  c.style.setProperty("--y", `${y}vh`);
+-  c.style.setProperty("--len", `${len}vh`);
+-  const labels = ["NODE", "EDGE", "BAYES p", "Z", "Δt", "ID"];
+-  const val    = Math.random().toString(36).slice(2,5).toUpperCase();
++  const c = el('div', 'mschf-callout', root);
++  const x = 8 + rand() * 84,
++    y = 18 + rand() * 64;
++  const len = 8 + rand() * 16; // length of leader
++  c.style.setProperty('--x', `${x}vw`);
++  c.style.setProperty('--y', `${y}vh`);
++  c.style.setProperty('--len', `${len}vh`);
++  const labels = ['NODE', 'EDGE', 'BAYES p', 'Z', 'Δt', 'ID'];
++  const val = Math.random().toString(36).slice(2, 5).toUpperCase();
+   c.textContent = `${pick(rand, labels)} ${val} • ${Math.random().toFixed(2)}`;
+ }
+ 
+ function addGraphCluster(root, rand, intensity) {
+-  const cluster = el("div","mschf-graph", root);
+-  const n = 5 + Math.floor(rand()* (intensity === "loud" ? 10 : 6));
+-  for (let i=0;i<n;i++) {
+-    const node = el("span","mschf-graph-node", cluster);
+-    node.style.setProperty("--x", `${rand()*100}vw`);
+-    node.style.setProperty("--y", `${rand()*100}vh`);
++  const cluster = el('div', 'mschf-graph', root);
++  const n = 5 + Math.floor(rand() * (intensity === 'loud' ? 10 : 6));
++  for (let i = 0; i < n; i++) {
++    const node = el('span', 'mschf-graph-node', cluster);
++    node.style.setProperty('--x', `${rand() * 100}vw`);
++    node.style.setProperty('--y', `${rand() * 100}vh`);
+   }
+   // A few edges
+-  const m = 3 + Math.floor(rand()*4);
+-  for (let i=0;i<m;i++) {
+-    const e = el("i","mschf-graph-edge", cluster);
+-    e.style.setProperty("--x1", `${rand()*100}vw`);
+-    e.style.setProperty("--y1", `${rand()*100}vh`);
+-    e.style.setProperty("--x2", `${rand()*100}vw`);
+-    e.style.setProperty("--y2", `${rand()*100}vh`);
++  const m = 3 + Math.floor(rand() * 4);
++  for (let i = 0; i < m; i++) {
++    const e = el('i', 'mschf-graph-edge', cluster);
++    e.style.setProperty('--x1', `${rand() * 100}vw`);
++    e.style.setProperty('--y1', `${rand() * 100}vh`);
++    e.style.setProperty('--x2', `${rand() * 100}vw`);
++    e.style.setProperty('--y2', `${rand() * 100}vh`);
+   }
+ }
+ 
+ function addSpectralRings(root, rand, intensity) {
+-  const r = el("div","mschf-rings", root);
+-  const s = 120 + Math.floor(rand()*220);
+-  css(r, { left:`${10 + rand()*80}%`, top:`${10 + rand()*70}%`, width:px(s), height:px(s) });
+-  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) r.classList.add("static");
++  const r = el('div', 'mschf-rings', root);
++  const s = 120 + Math.floor(rand() * 220);
++  css(r, {
++    left: `${10 + rand() * 80}%`,
++    top: `${10 + rand() * 70}%`,
++    width: px(s),
++    height: px(s),
++  });
++  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches)
++    r.classList.add('static');
+ }
+ 
+ function addTopo(root, rand) {
+-  const t = el("div","mschf-topo", root);
+-  t.style.setProperty("--rot", `${Math.floor((rand()-0.5)*30)}deg`);
+-  t.style.opacity = ".10";
++  const t = el('div', 'mschf-topo', root);
++  t.style.setProperty('--rot', `${Math.floor((rand() - 0.5) * 30)}deg`);
++  t.style.opacity = '.10';
+ }
+ function addHalftone(root, rand) {
+-  const h = el("div","mschf-halftone", root);
+-  const corner = pick(rand, ["tl","tr","bl","br"]);
++  const h = el('div', 'mschf-halftone', root);
++  const corner = pick(rand, ['tl', 'tr', 'bl', 'br']);
+   h.classList.add(corner);
+-  h.style.opacity = ".10";
++  h.style.opacity = '.10';
+ }
+ function addCRTMask(root, rand) {
+-  const c = el("div","mschf-crt", root);
+-  c.style.opacity = ".06";
++  const c = el('div', 'mschf-crt', root);
++  c.style.opacity = '.06';
+ }
+ function addPerforation(root, rand) {
+-  const p = el("div","mschf-perf", root);
+-  p.dataset.side = pick(rand, ["top","bottom","left","right"]);
++  const p = el('div', 'mschf-perf', root);
++  p.dataset.side = pick(rand, ['top', 'bottom', 'left', 'right']);
+ }
+ function addStarfield(root, rand) {
+-  const star = el("div","mschf-stars", root);
+-  star.style.setProperty("--density", `${0.15 + rand()*0.35}`);
++  const star = el('div', 'mschf-stars', root);
++  star.style.setProperty('--density', `${0.15 + rand() * 0.35}`);
+ }
+ 
+ function addBrackets(root, rand) {
+-  const b = el("div","mschf-brackets", root);
+-  b.classList.add(pick(rand, ["tight","wide"]));
++  const b = el('div', 'mschf-brackets', root);
++  b.classList.add(pick(rand, ['tight', 'wide']));
+ }
+ function addGlitchSlices(root, rand, intensity) {
+-  const n = 2 + Math.floor(rand()*(intensity === "loud" ? 4 : 2));
+-  for (let i=0;i<n;i++) {
+-    const g = el("div","mschf-glitch", root);
+-    css(g, { top: `${Math.floor(rand()*100)}%`, left: "0", right: "0" });
+-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) g.classList.add("static");
++  const n = 2 + Math.floor(rand() * (intensity === 'loud' ? 4 : 2));
++  for (let i = 0; i < n; i++) {
++    const g = el('div', 'mschf-glitch', root);
++    css(g, { top: `${Math.floor(rand() * 100)}%`, left: '0', right: '0' });
++    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches)
++      g.classList.add('static');
+   }
+ }
+ function addRulers(root) {
+-  el("div","mschf-ruler mschf-ruler-top", root);
+-  el("div","mschf-ruler mschf-ruler-left", root);
++  el('div', 'mschf-ruler mschf-ruler-top', root);
++  el('div', 'mschf-ruler mschf-ruler-left', root);
+ }
+ function addWatermark(root) {
+-  const wm = el("div","mschf-watermark", root);
+-  wm.textContent = "EFFUSION LABS • PROTOTYPE • ";
++  const wm = el('div', 'mschf-watermark', root);
++  wm.textContent = 'EFFUSION LABS • PROTOTYPE • ';
+ }
+ function addFlowers(root, rand, intensity) {
+-  const n = 1 + Math.floor(rand() * (intensity === "loud" ? 4 : 2));
+-  for (let i=0;i<n;i++) {
+-    const fl = el("div","mschf-flower", root);
+-    const s = 38 + Math.floor(rand()*32);
+-    const x = 10 + Math.floor(rand()*80);
+-    const y = 10 + Math.floor(rand()*70);
+-    css(fl,{ width:px(s), height:px(s), left:`${x}%`, top:`${y}%`, transform:`rotate(${Math.floor((rand()-0.5)*180)}deg)` });
++  const n = 1 + Math.floor(rand() * (intensity === 'loud' ? 4 : 2));
++  for (let i = 0; i < n; i++) {
++    const fl = el('div', 'mschf-flower', root);
++    const s = 38 + Math.floor(rand() * 32);
++    const x = 10 + Math.floor(rand() * 80);
++    const y = 10 + Math.floor(rand() * 70);
++    css(fl, {
++      width: px(s),
++      height: px(s),
++      left: `${x}%`,
++      top: `${y}%`,
++      transform: `rotate(${Math.floor((rand() - 0.5) * 180)}deg)`,
++    });
+   }
+ }
+ function addHolo(root, intensity) {
+-  const h = el("div","mschf-holo", root);
+-  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) h.classList.add("static");
++  const h = el('div', 'mschf-holo', root);
++  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches)
++    h.classList.add('static');
+ }
+ function addRegMarks(root, intensity) {
+-  ["tl","tr","bl","br"].forEach(pos => el("div",`mschf-reg ${pos}`, root));
++  ['tl', 'tr', 'bl', 'br'].forEach((pos) =>
++    el('div', `mschf-reg ${pos}`, root),
++  );
+ }
+ function addDims(root, rand) {
+-  const d = el("div","mschf-dims", root);
+-  const x1 = 10 + Math.floor(rand()*30);
+-  const x2 = x1 + 20 + Math.floor(rand()*35);
+-  const y  = 20 + Math.floor(rand()*60);
+-  d.style.setProperty("--x1", `${x1}vw`);
+-  d.style.setProperty("--x2", `${x2}vw`);
+-  d.style.setProperty("--y",  `${y}vh`);
+-  d.textContent = `${Math.abs(x2-x1)}vw`;
++  const d = el('div', 'mschf-dims', root);
++  const x1 = 10 + Math.floor(rand() * 30);
++  const x2 = x1 + 20 + Math.floor(rand() * 35);
++  const y = 20 + Math.floor(rand() * 60);
++  d.style.setProperty('--x1', `${x1}vw`);
++  d.style.setProperty('--x2', `${x2}vw`);
++  d.style.setProperty('--y', `${y}vh`);
++  d.textContent = `${Math.abs(x2 - x1)}vw`;
+ }
+ function addStickers(root, rand) {
+-  const cluster = el("div", "mschf-stickers", root);
++  const cluster = el('div', 'mschf-stickers', root);
+   const badges = [
+-    "ALPHA","BETA","RC1","SIGNED","VOID","UNLOCKED","PASS","LAB","SIM",
+-    "ARCHIVE","SANDBOX","RAG","EVAL","GRAPH","SPARK","VECTOR","EMBED","SPECIMEN","PROTO"
++    'ALPHA',
++    'BETA',
++    'RC1',
++    'SIGNED',
++    'VOID',
++    'UNLOCKED',
++    'PASS',
++    'LAB',
++    'SIM',
++    'ARCHIVE',
++    'SANDBOX',
++    'RAG',
++    'EVAL',
++    'GRAPH',
++    'SPARK',
++    'VECTOR',
++    'EMBED',
++    'SPECIMEN',
++    'PROTO',
+   ];
+ 
+   // Place cluster in a random corner
+-  const corner = pick(rand, ["br","bl","tr","tl"]);
+-  const off = 18 + Math.floor(rand()*18);
++  const corner = pick(rand, ['br', 'bl', 'tr', 'tl']);
++  const off = 18 + Math.floor(rand() * 18);
+   const style = {};
+-  if (corner.includes("b")) style.bottom = `${off}px`; else style.top = `${off}px`;
+-  if (corner.includes("r")) style.right  = `${off}px`; else style.left = `${off}px`;
++  if (corner.includes('b')) style.bottom = `${off}px`;
++  else style.top = `${off}px`;
++  if (corner.includes('r')) style.right = `${off}px`;
++  else style.left = `${off}px`;
+   css(cluster, style);
+ 
+   // 2–5 stickers with per-sticker transforms & size variance
+   const n = 2 + Math.floor(rand() * 4);
+   for (let i = 0; i < n; i++) {
+-    const b = el("span", "mschf-badge", cluster);
++    const b = el('span', 'mschf-badge', cluster);
+     b.textContent = pick(rand, badges);
+ 
+     // Size & weight variance (inline so we don't need extra CSS)
+     const sizes = [
+-      () => { b.style.fontSize = "10px"; b.style.padding = "5px 7px"; },
+-      () => { b.style.fontSize = "11px"; b.style.padding = "6px 8px"; },
+-      () => { b.style.fontSize = "12px"; b.style.padding = "7px 9px"; }
++      () => {
++        b.style.fontSize = '10px';
++        b.style.padding = '5px 7px';
++      },
++      () => {
++        b.style.fontSize = '11px';
++        b.style.padding = '6px 8px';
++      },
++      () => {
++        b.style.fontSize = '12px';
++        b.style.padding = '7px 9px';
++      },
+     ];
+     pick(rand, sizes)();
+ 
+     // Transform offsets
+-    b.style.setProperty("--rx", `${Math.floor((rand()-0.5)*18)}deg`);
+-    b.style.setProperty("--offx", `${Math.floor((rand()-0.5)*18)}px`);
+-    b.style.setProperty("--offy", `${Math.floor((rand()-0.5)*12)}px`);
++    b.style.setProperty('--rx', `${Math.floor((rand() - 0.5) * 18)}deg`);
++    b.style.setProperty('--offx', `${Math.floor((rand() - 0.5) * 18)}px`);
++    b.style.setProperty('--offy', `${Math.floor((rand() - 0.5) * 12)}px`);
+ 
+     // Occasional outline accent
+     if (rand() < 0.25) {
+-      b.style.boxShadow = "0 0 0 1px color-mix(in oklab, currentColor 35%, transparent), 0 10px 18px rgba(0,0,0,.35)";
++      b.style.boxShadow =
++        '0 0 0 1px color-mix(in oklab, currentColor 35%, transparent), 0 10px 18px rgba(0,0,0,.35)';
+     }
+   }
+ }
+ 
+-document.addEventListener("DOMContentLoaded", initOverlay);
++document.addEventListener('DOMContentLoaded', initOverlay);
+diff --git a/test/unit/mschf-overlay-style.test.mjs b/test/unit/mschf-overlay-style.test.mjs
+index 03728ac..188bc8c 100644
+--- a/test/unit/mschf-overlay-style.test.mjs
++++ b/test/unit/mschf-overlay-style.test.mjs
+@@ -1,4 +1,5 @@
+ // test/unit/mschf-overlay-style.test.mjs
++import test from 'node:test';
+ import { strict as assert } from 'node:assert';
+ import { readFileSync } from 'node:fs';
+ import path from 'node:path';
+@@ -6,7 +7,10 @@ import { JSDOM } from 'jsdom';
+ 
+ test('collage style includes base, ephemera, and lab modules', () => {
+   const html = `<!doctype html><html><body data-mschf="on" data-mschf-intensity="test" data-mschf-style="collage"></body></html>`;
+-  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost' });
++  const dom = new JSDOM(html, {
++    runScripts: 'outside-only',
++    url: 'http://localhost',
++  });
+   const scriptPath = path.resolve('src/scripts/mschf-overlay.js');
+   dom.window.eval(readFileSync(scriptPath, 'utf8'));
+   dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+@@ -15,12 +19,13 @@ test('collage style includes base, ephemera, and lab modules', () => {
+   assert.ok(doc.querySelector('.mschf-grid'));
+   assert.ok(doc.querySelector('.mschf-crosshair'));
+   assert.ok(
+-    doc.querySelector('.mschf-tape, .mschf-stamp, .mschf-quotes, .mschf-plate, .mschf-specimen')
++    doc.querySelector(
++      '.mschf-tape, .mschf-stamp, .mschf-quotes, .mschf-plate, .mschf-specimen',
++    ),
+   );
+   assert.ok(
+     doc.querySelector(
+-      '.mschf-callout, .mschf-graph, .mschf-rings, .mschf-topo, .mschf-halftone, .mschf-crt, .mschf-perf, .mschf-starfield'
+-    )
++      '.mschf-callout, .mschf-graph, .mschf-rings, .mschf-topo, .mschf-halftone, .mschf-crt, .mschf-perf, .mschf-starfield',
++    ),
+   );
+ });
+-
+-- 
+2.43.0
+

--- a/docs/ux/mschf-overlay.md
+++ b/docs/ux/mschf-overlay.md
@@ -6,18 +6,21 @@ The MSCHF overlay decorates pages with seeded decals and grid textures while kee
 
 Attach attributes to the `#page-shell` wrapper:
 
-| Attribute | Values | Default | Description |
-| --- | --- | --- | --- |
-| `data-mschf` | `on` \| `off` \| `auto` | `auto` | Enable overlay or force disable. |
-| `data-mschf-intensity` | `lite` \| `loud` | `lite` | Governs element counts and probabilities. |
-| `data-mschf-seed-mode` | `page` \| `session` | `page` | Ephemeral seed per load or stable for a tab session. |
-| `data-mschf-style` | `collage` \| `structural` \| `playful` | `collage` | Aesthetic strategy mix. |
+| Attribute              | Values                                 | Default | Description                                          |
+| ---------------------- | -------------------------------------- | ------- | ---------------------------------------------------- |
+| `data-mschf`           | `on` \| `off` \| `auto`                | `auto`  | Enable overlay or force disable.                     |
+| `data-mschf-intensity` | `lite` \| `bold` \| `loud` \| `calm`   | random  | Governs element counts and probabilities.            |
+| `data-mschf-seed-mode` | `page` \| `session`                    | `page`  | Ephemeral seed per load or stable for a tab session. |
+| `data-mschf-style`     | `collage` \| `structural` \| `playful` | random  | Aesthetic strategy mix.                              |
 
 Use `localStorage.setItem('mschf:off','1')` to opt out persistently.
 
 ## Aesthetic Strategies
 
-`collage` (default) fuses four groups: base scaffold, culture-coded ephemera,
+If `data-mschf-intensity` or `data-mschf-style` are omitted, the overlay picks
+random values per page seed so each visit feels fresh.
+
+`collage` fuses four groups: base scaffold, culture-coded ephemera,
 lab/blueprint motifs, and framing stickers. Other styles limit the mix:
 
 - **structural** – base + lab motifs only.

--- a/logs/test-20250827T065105Z.log
+++ b/logs/test-20250827T065105Z.log
@@ -1,0 +1,286 @@
+🚀 Launching test runner...
+🔍 Found 14 test files.
+
+🏗️  Performing single Eleventy build...
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
+[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
+[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
+[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
+[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
+[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
+[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
+[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
+[11ty] Copied 10 Wrote 48 files in 2.27 seconds (47.4ms each, v3.1.2)
+✅ Eleventy build complete.
+
+🧪 Running 14 tests...
+TAP version 13
+# Subtest: callout merges footnotes into page pipeline
+ok 1 - callout merges footnotes into page pipeline
+  ---
+  duration_ms: 11.12023
+  type: 'test'
+  ...
+# Subtest: defines improved background colors
+ok 2 - defines improved background colors
+  ---
+  duration_ms: 1.341923
+  type: 'test'
+  ...
+# Subtest: text contrast meets WCAG AA
+ok 3 - text contrast meets WCAG AA
+  ---
+  duration_ms: 5.685058
+  type: 'test'
+  ...
+# Subtest: tailwind exposes readable font families
+ok 4 - tailwind exposes readable font families
+  ---
+  duration_ms: 0.535419
+  type: 'test'
+  ...
+# Subtest: includes fluid type scale tokens
+ok 5 - includes fluid type scale tokens
+  ---
+  duration_ms: 0.275964
+  type: 'test'
+  ...
+# Subtest: footnote popover separates source line
+ok 6 - footnote popover separates source line
+  ---
+  duration_ms: 91.875392
+  type: 'test'
+  ...
+# Subtest: projects computed picks latest entries by date
+ok 7 - projects computed picks latest entries by date
+  ---
+  duration_ms: 1.782226
+  type: 'test'
+  ...
+# Subtest: keepalive emits heartbeat to stderr
+ok 8 - keepalive emits heartbeat to stderr
+  ---
+  duration_ms: 6095.609812
+  type: 'test'
+  ...
+# Subtest: keepalive ignores first SIGINT
+ok 9 - keepalive ignores first SIGINT
+  ---
+  duration_ms: 179.675703
+  type: 'test'
+  ...
+# Subtest: gateway reads SOLVER_URL from environment
+ok 10 - gateway reads SOLVER_URL from environment
+  ---
+  duration_ms: 0.970262
+  type: 'test'
+  ...
+# Subtest: gateway retains default solver URL
+ok 11 - gateway retains default solver URL
+  ---
+  duration_ms: 0.212331
+  type: 'test'
+  ...
+# Subtest: external link renders with arrow and class
+ok 12 - external link renders with arrow and class
+  ---
+  duration_ms: 8.923424
+  type: 'test'
+  ...
+# Subtest: internal link keeps text without external markers
+ok 13 - internal link keeps text without external markers
+  ---
+  duration_ms: 2.335799
+  type: 'test'
+  ...
+# Subtest: external link starting with arrow does not duplicate
+ok 14 - external link starting with arrow does not duplicate
+  ---
+  duration_ms: 2.281657
+  type: 'test'
+  ...
+# Error: Uncaught [TypeError: window.matchMedia is not a function]
+#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:13:23)
+#     at Test.runInAsyncScope (node:async_hooks:214:14)
+#     at Test.run (node:internal/test_runner/test:1047:25)
+#     at Test.start (node:internal/test_runner/test:944:17) TypeError: window.matchMedia is not a function
+#     at addSpectralRings (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:417:14)
+#     at Object.lab (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:99:34)
+#     at Document.initOverlay (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:126:16)
+#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:13:23)
+# Error: Uncaught [TypeError: window.matchMedia is not a function]
+#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
+#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
+#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
+#     at new Promise (<anonymous>)
+#     at onDOMContentLoad (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:523:14)
+#     at Object.check (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:76:23) TypeError: window.matchMedia is not a function
+#     at addSpectralRings (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:417:14)
+#     at Object.lab (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:99:34)
+#     at Document.initOverlay (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:126:16)
+#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
+#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
+#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
+# Subtest: collage style includes base, ephemera, and lab modules
+ok 15 - collage style includes base, ephemera, and lab modules
+  ---
+  duration_ms: 116.29169
+  type: 'test'
+  ...
+# Subtest: node shim version matches system node
+ok 16 - node shim version matches system node
+  ---
+  duration_ms: 143.878065
+  type: 'test'
+  ...
+# Subtest: node shim is executable
+ok 17 - node shim is executable
+  ---
+  duration_ms: 0.719578
+  type: 'test'
+  ...
+# Subtest: node shim lacks llm-constants reference
+ok 18 - node shim lacks llm-constants reference
+  ---
+  duration_ms: 0.276327
+  type: 'test'
+  ...
+# Subtest: prettier pinned version and format script
+ok 19 - prettier pinned version and format script
+  ---
+  duration_ms: 1.347439
+  type: 'test'
+  ...
+# Subtest: test/unit/pty-runner.test.mjs
+ok 11 - test/unit/pty-runner.test.mjs
+  ---
+  duration_ms: 866.486735
+  type: 'test'
+  ...
+# Subtest: merges tag-like metadata into unified tags and categories
+ok 21 - merges tag-like metadata into unified tags and categories
+  ---
+  duration_ms: 2.844184
+  type: 'test'
+  ...
+# Subtest: deduplicates tag values
+ok 22 - deduplicates tag values
+  ---
+  duration_ms: 0.247817
+  type: 'test'
+  ...
+# Subtest: categories returns empty array when spark_type absent
+ok 23 - categories returns empty array when spark_type absent
+  ---
+  duration_ms: 0.184073
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles basic single-digit numbers
+ok 24 - ordinalSuffix handles basic single-digit numbers
+  ---
+  duration_ms: 1.060105
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles negative numbers correctly
+ok 25 - ordinalSuffix handles negative numbers correctly
+  ---
+  duration_ms: 0.254076
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix uses "th" for all teen numbers
+ok 26 - ordinalSuffix uses "th" for all teen numbers
+  ---
+  duration_ms: 0.325855
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix returns a valid suffix for all days in a month
+ok 27 - ordinalSuffix returns a valid suffix for all days in a month
+  ---
+  duration_ms: 0.500195
+  type: 'test'
+  ...
+# Subtest: readFileCached returns null for a nonexistent file path
+ok 28 - readFileCached returns null for a nonexistent file path
+  ---
+  duration_ms: 0.588632
+  type: 'test'
+  ...
+# Subtest: GitHub workflows use latest action versions
+ok 29 - GitHub workflows use latest action versions
+  ---
+  duration_ms: 1.118347
+  type: 'test'
+  ...
+1..29
+# tests 29
+# suites 0
+# pass 29
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 6714.7609
+
+✨ All tests passed!

--- a/logs/test-20250827T065207Z.log
+++ b/logs/test-20250827T065207Z.log
@@ -1,0 +1,286 @@
+🚀 Launching test runner...
+🔍 Found 14 test files.
+
+🏗️  Performing single Eleventy build...
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
+[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
+[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
+[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
+[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
+[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
+[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
+[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
+[11ty] Copied 10 Wrote 48 files in 2.27 seconds (47.4ms each, v3.1.2)
+✅ Eleventy build complete.
+
+🧪 Running 14 tests...
+TAP version 13
+# Subtest: callout merges footnotes into page pipeline
+ok 1 - callout merges footnotes into page pipeline
+  ---
+  duration_ms: 11.12023
+  type: 'test'
+  ...
+# Subtest: defines improved background colors
+ok 2 - defines improved background colors
+  ---
+  duration_ms: 1.341923
+  type: 'test'
+  ...
+# Subtest: text contrast meets WCAG AA
+ok 3 - text contrast meets WCAG AA
+  ---
+  duration_ms: 5.685058
+  type: 'test'
+  ...
+# Subtest: tailwind exposes readable font families
+ok 4 - tailwind exposes readable font families
+  ---
+  duration_ms: 0.535419
+  type: 'test'
+  ...
+# Subtest: includes fluid type scale tokens
+ok 5 - includes fluid type scale tokens
+  ---
+  duration_ms: 0.275964
+  type: 'test'
+  ...
+# Subtest: footnote popover separates source line
+ok 6 - footnote popover separates source line
+  ---
+  duration_ms: 91.875392
+  type: 'test'
+  ...
+# Subtest: projects computed picks latest entries by date
+ok 7 - projects computed picks latest entries by date
+  ---
+  duration_ms: 1.782226
+  type: 'test'
+  ...
+# Subtest: keepalive emits heartbeat to stderr
+ok 8 - keepalive emits heartbeat to stderr
+  ---
+  duration_ms: 6095.609812
+  type: 'test'
+  ...
+# Subtest: keepalive ignores first SIGINT
+ok 9 - keepalive ignores first SIGINT
+  ---
+  duration_ms: 179.675703
+  type: 'test'
+  ...
+# Subtest: gateway reads SOLVER_URL from environment
+ok 10 - gateway reads SOLVER_URL from environment
+  ---
+  duration_ms: 0.970262
+  type: 'test'
+  ...
+# Subtest: gateway retains default solver URL
+ok 11 - gateway retains default solver URL
+  ---
+  duration_ms: 0.212331
+  type: 'test'
+  ...
+# Subtest: external link renders with arrow and class
+ok 12 - external link renders with arrow and class
+  ---
+  duration_ms: 8.923424
+  type: 'test'
+  ...
+# Subtest: internal link keeps text without external markers
+ok 13 - internal link keeps text without external markers
+  ---
+  duration_ms: 2.335799
+  type: 'test'
+  ...
+# Subtest: external link starting with arrow does not duplicate
+ok 14 - external link starting with arrow does not duplicate
+  ---
+  duration_ms: 2.281657
+  type: 'test'
+  ...
+# Error: Uncaught [TypeError: window.matchMedia is not a function]
+#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:13:23)
+#     at Test.runInAsyncScope (node:async_hooks:214:14)
+#     at Test.run (node:internal/test_runner/test:1047:25)
+#     at Test.start (node:internal/test_runner/test:944:17) TypeError: window.matchMedia is not a function
+#     at addSpectralRings (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:417:14)
+#     at Object.lab (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:99:34)
+#     at Document.initOverlay (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:126:16)
+#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:13:23)
+# Error: Uncaught [TypeError: window.matchMedia is not a function]
+#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
+#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
+#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
+#     at new Promise (<anonymous>)
+#     at onDOMContentLoad (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:523:14)
+#     at Object.check (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:76:23) TypeError: window.matchMedia is not a function
+#     at addSpectralRings (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:417:14)
+#     at Object.lab (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:99:34)
+#     at Document.initOverlay (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:12:14), <anonymous>:126:16)
+#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
+#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
+#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
+# Subtest: collage style includes base, ephemera, and lab modules
+ok 15 - collage style includes base, ephemera, and lab modules
+  ---
+  duration_ms: 116.29169
+  type: 'test'
+  ...
+# Subtest: node shim version matches system node
+ok 16 - node shim version matches system node
+  ---
+  duration_ms: 143.878065
+  type: 'test'
+  ...
+# Subtest: node shim is executable
+ok 17 - node shim is executable
+  ---
+  duration_ms: 0.719578
+  type: 'test'
+  ...
+# Subtest: node shim lacks llm-constants reference
+ok 18 - node shim lacks llm-constants reference
+  ---
+  duration_ms: 0.276327
+  type: 'test'
+  ...
+# Subtest: prettier pinned version and format script
+ok 19 - prettier pinned version and format script
+  ---
+  duration_ms: 1.347439
+  type: 'test'
+  ...
+# Subtest: test/unit/pty-runner.test.mjs
+ok 11 - test/unit/pty-runner.test.mjs
+  ---
+  duration_ms: 866.486735
+  type: 'test'
+  ...
+# Subtest: merges tag-like metadata into unified tags and categories
+ok 21 - merges tag-like metadata into unified tags and categories
+  ---
+  duration_ms: 2.844184
+  type: 'test'
+  ...
+# Subtest: deduplicates tag values
+ok 22 - deduplicates tag values
+  ---
+  duration_ms: 0.247817
+  type: 'test'
+  ...
+# Subtest: categories returns empty array when spark_type absent
+ok 23 - categories returns empty array when spark_type absent
+  ---
+  duration_ms: 0.184073
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles basic single-digit numbers
+ok 24 - ordinalSuffix handles basic single-digit numbers
+  ---
+  duration_ms: 1.060105
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles negative numbers correctly
+ok 25 - ordinalSuffix handles negative numbers correctly
+  ---
+  duration_ms: 0.254076
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix uses "th" for all teen numbers
+ok 26 - ordinalSuffix uses "th" for all teen numbers
+  ---
+  duration_ms: 0.325855
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix returns a valid suffix for all days in a month
+ok 27 - ordinalSuffix returns a valid suffix for all days in a month
+  ---
+  duration_ms: 0.500195
+  type: 'test'
+  ...
+# Subtest: readFileCached returns null for a nonexistent file path
+ok 28 - readFileCached returns null for a nonexistent file path
+  ---
+  duration_ms: 0.588632
+  type: 'test'
+  ...
+# Subtest: GitHub workflows use latest action versions
+ok 29 - GitHub workflows use latest action versions
+  ---
+  duration_ms: 1.118347
+  type: 'test'
+  ...
+1..29
+# tests 29
+# suites 0
+# pass 29
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 6714.7609
+
+✨ All tests passed!

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -100,7 +100,9 @@
 {# Always-on Hypebrüt overlay controls live on <body> as data-* (page can override via front matter) #}
 <body
   data-mschf="auto"
-  data-mschf-intensity="{{ page.mschfIntensity or site.mschfIntensity or 'lite' }}"
+  {% if page.mschfIntensity or site.mschfIntensity %}
+  data-mschf-intensity="{{ page.mschfIntensity or site.mschfIntensity }}"
+  {% endif %}
   data-mschf-seed-mode="{{ page.mschfSeedMode or site.mschfSeedMode or 'page' }}"
   class="bg-base-100 text-base-content font-body antialiased selection:bg-primary/20"
 >

--- a/src/scripts/mschf-overlay.js
+++ b/src/scripts/mschf-overlay.js
@@ -12,24 +12,40 @@
 // ————————————————————————————————————————
 // Utilities
 // ————————————————————————————————————————
-function randomInt() { return crypto.getRandomValues(new Uint32Array(1))[0].toString(); }
-function mulberry32(seed) { let t = seed >>> 0; return function () {
-  t += 0x6D2B79F5; let r = Math.imul(t ^ (t >>> 15), t | 1);
-  r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
-  return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
-};}
-function computeSeed(mode = "page", forced, storage) {
+function randomInt() {
+  return crypto.getRandomValues(new Uint32Array(1))[0].toString();
+}
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function () {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), t | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+function computeSeed(mode = 'page', forced, storage) {
   if (forced) return String(forced);
-  if (mode === "session" && storage) {
-    const existing = storage.getItem("mschfSeed");
+  if (mode === 'session' && storage) {
+    const existing = storage.getItem('mschfSeed');
     if (existing) return existing;
-    const next = randomInt(); storage.setItem("mschfSeed", next); return next;
+    const next = randomInt();
+    storage.setItem('mschfSeed', next);
+    return next;
   }
   return randomInt();
 }
-const css  = (el, obj) => { for (const k in obj) el.style[k] = obj[k]; return el; };
-const el   = (tag, cls, parent) => { const n = document.createElement(tag); if (cls) n.className = cls; (parent||document.body).appendChild(n); return n; };
-const pick = (rand, arr) => arr[Math.floor(rand()*arr.length)];
+const css = (el, obj) => {
+  for (const k in obj) el.style[k] = obj[k];
+  return el;
+};
+const el = (tag, cls, parent) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  (parent || document.body).appendChild(n);
+  return n;
+};
+const pick = (rand, arr) => arr[Math.floor(rand() * arr.length)];
 const chance = (rand, p) => rand() < p;
 const px = (v) => `${Math.round(v)}px`;
 
@@ -42,9 +58,9 @@ function readBuildMeta() {
   const doc = document;
   const src = doc.body || doc.documentElement;
   return {
-    hash:   src?.dataset?.buildHash   || "",
-    branch: src?.dataset?.buildBranch || "",
-    built:  src?.dataset?.builtAt     || new Date().toISOString()
+    hash: src?.dataset?.buildHash || '',
+    branch: src?.dataset?.buildBranch || '',
+    built: src?.dataset?.builtAt || new Date().toISOString(),
   };
 }
 
@@ -52,31 +68,45 @@ function readBuildMeta() {
 // Main
 // ————————————————————————————————————————
 function initOverlay() {
-  const doc   = document;
-  const scope = doc.getElementById("page-shell") || doc.body;
+  const doc = document;
+  const scope = doc.getElementById('page-shell') || doc.body;
   if (!scope) return;
 
   // Allow a kill switch
-  if (scope.dataset.mschf === "off") return;
-  if (localStorage.getItem("mschf:off")) return;
+  if (scope.dataset.mschf === 'off') return;
+  if (localStorage.getItem('mschf:off')) return;
 
-  const intensity = scope.dataset.mschfIntensity || doc.body.dataset.mschfIntensity || "lite";
-  const mode      = scope.dataset.mschfSeedMode    || doc.body.dataset.mschfSeedMode    || "page";
-  const forced    = new URL(window.location.href).searchParams.get("mschf-seed");
-  const seed      = computeSeed(mode, forced, window.sessionStorage);
-  const rand      = mulberry32(parseInt(seed, 10) || 0);
-  const build     = readBuildMeta();
+  const mode =
+    scope.dataset.mschfSeedMode || doc.body.dataset.mschfSeedMode || 'page';
+  const forced = new URL(window.location.href).searchParams.get('mschf-seed');
+  const seed = computeSeed(mode, forced, window.sessionStorage);
+  const rand = mulberry32(parseInt(seed, 10) || 0);
+  const intensity =
+    scope.dataset.mschfIntensity ||
+    doc.body.dataset.mschfIntensity ||
+    pick(rand, ['lite', 'bold', 'loud', 'calm']);
+  const build = readBuildMeta();
 
   // Root
-  let root = doc.getElementById("mschf-overlay-root");
-  if (!root) root = el("div", "", doc.body), (root.id = "mschf-overlay-root");
-  css(root, { pointerEvents:"none", position:"fixed", inset:"0", width:"100vw", height:"100vh", zIndex:"44", color:"hsl(var(--p))" });
-  root.setAttribute("aria-hidden","true");
-  root.innerHTML = "";
+  let root = doc.getElementById('mschf-overlay-root');
+  if (!root) (root = el('div', '', doc.body)), (root.id = 'mschf-overlay-root');
+  css(root, {
+    pointerEvents: 'none',
+    position: 'fixed',
+    inset: '0',
+    width: '100vw',
+    height: '100vh',
+    zIndex: '44',
+    color: 'hsl(var(--p))',
+  });
+  root.setAttribute('aria-hidden', 'true');
+  root.innerHTML = '';
 
   // Profiles tune density/probabilities per intensity
   const P = profile(intensity);
-  const style = scope.dataset.mschfStyle || 'collage';
+  const style =
+    scope.dataset.mschfStyle ||
+    pick(rand, ['collage', 'structural', 'playful']);
 
   const groups = {
     base() {
@@ -127,41 +157,139 @@ function initOverlay() {
   }
 
   // Dev toggles
-  window.__mschfOff = () => { localStorage.setItem("mschf:off","1"); root.remove(); };
-  window.__mschfOn  = () => { localStorage.removeItem("mschf:off"); initOverlay(); };
+  window.__mschfOff = () => {
+    localStorage.setItem('mschf:off', '1');
+    root.remove();
+  };
+  window.__mschfOn = () => {
+    localStorage.removeItem('mschf:off');
+    initOverlay();
+  };
 }
 
 function profile(intensity) {
   // probabilities per category; tuned for research/aesthetic site
   const base = {
-    grid:.70, cross:.55, corners:1,  frame:1,  scan:.18,
-    tape:.55, stamp:.45, quotes:.65, barcode:.35,
-    callout:.55, graph:.60, rings:.45, topo:.40, halftone:.35, crt:.20, perf:.30, specimen:.40, starfield:.30,
-    brackets:.45, glitch:.35, rulers:.35, watermark:.25, flowers:.45, holo:.35, reg:.55, dims:.40, stickers:.45
+    grid: 0.7,
+    cross: 0.55,
+    corners: 1,
+    frame: 1,
+    scan: 0.18,
+    tape: 0.55,
+    stamp: 0.45,
+    quotes: 0.65,
+    barcode: 0.35,
+    callout: 0.55,
+    graph: 0.6,
+    rings: 0.45,
+    topo: 0.4,
+    halftone: 0.35,
+    crt: 0.2,
+    perf: 0.3,
+    specimen: 0.4,
+    starfield: 0.3,
+    brackets: 0.45,
+    glitch: 0.35,
+    rulers: 0.35,
+    watermark: 0.25,
+    flowers: 0.45,
+    holo: 0.35,
+    reg: 0.55,
+    dims: 0.4,
+    stickers: 0.45,
   };
   const bold = {
-    grid:.90, cross:.70, corners:1,  frame:1,  scan:.40,
-    tape:.75, stamp:.65, quotes:.80, barcode:.45,
-    callout:.70, graph:.80, rings:.65, topo:.60, halftone:.55, crt:.35, perf:.45, specimen:.55, starfield:.45,
-    brackets:.65, glitch:.55, rulers:.50, watermark:.40, flowers:.60, holo:.55, reg:.70, dims:.55, stickers:.60
+    grid: 0.9,
+    cross: 0.7,
+    corners: 1,
+    frame: 1,
+    scan: 0.4,
+    tape: 0.75,
+    stamp: 0.65,
+    quotes: 0.8,
+    barcode: 0.45,
+    callout: 0.7,
+    graph: 0.8,
+    rings: 0.65,
+    topo: 0.6,
+    halftone: 0.55,
+    crt: 0.35,
+    perf: 0.45,
+    specimen: 0.55,
+    starfield: 0.45,
+    brackets: 0.65,
+    glitch: 0.55,
+    rulers: 0.5,
+    watermark: 0.4,
+    flowers: 0.6,
+    holo: 0.55,
+    reg: 0.7,
+    dims: 0.55,
+    stickers: 0.6,
   };
   const loud = {
-    grid:1.00, cross:.85, corners:1, frame:1,  scan:.60,
-    tape:.85, stamp:.75, quotes:.90, barcode:.55,
-    callout:.85, graph:.90, rings:.80, topo:.75, halftone:.70, crt:.55, perf:.55, specimen:.65, starfield:.60,
-    brackets:.80, glitch:.70, rulers:.60, watermark:.50, flowers:.75, holo:.70, reg:.85, dims:.65, stickers:.75
+    grid: 1.0,
+    cross: 0.85,
+    corners: 1,
+    frame: 1,
+    scan: 0.6,
+    tape: 0.85,
+    stamp: 0.75,
+    quotes: 0.9,
+    barcode: 0.55,
+    callout: 0.85,
+    graph: 0.9,
+    rings: 0.8,
+    topo: 0.75,
+    halftone: 0.7,
+    crt: 0.55,
+    perf: 0.55,
+    specimen: 0.65,
+    starfield: 0.6,
+    brackets: 0.8,
+    glitch: 0.7,
+    rulers: 0.6,
+    watermark: 0.5,
+    flowers: 0.75,
+    holo: 0.7,
+    reg: 0.85,
+    dims: 0.65,
+    stickers: 0.75,
   };
   const calm = {
-    grid:.35, cross:.30, corners:1,  frame:1,  scan:.06,
-    tape:.22, stamp:.18, quotes:.28, barcode:.18,
-    callout:.25, graph:.30, rings:.20, topo:.18, halftone:.15, crt:.10, perf:.12, specimen:.20, starfield:.15,
-    brackets:.22, glitch:.12, rulers:.20, watermark:.12, flowers:.18, holo:.12, reg:.30, dims:.18, stickers:.15
+    grid: 0.35,
+    cross: 0.3,
+    corners: 1,
+    frame: 1,
+    scan: 0.06,
+    tape: 0.22,
+    stamp: 0.18,
+    quotes: 0.28,
+    barcode: 0.18,
+    callout: 0.25,
+    graph: 0.3,
+    rings: 0.2,
+    topo: 0.18,
+    halftone: 0.15,
+    crt: 0.1,
+    perf: 0.12,
+    specimen: 0.2,
+    starfield: 0.15,
+    brackets: 0.22,
+    glitch: 0.12,
+    rulers: 0.2,
+    watermark: 0.12,
+    flowers: 0.18,
+    holo: 0.12,
+    reg: 0.3,
+    dims: 0.18,
+    stickers: 0.15,
   };
-  const all = Object.fromEntries(Object.keys(base).map(k => [k, 1]));
-  if (intensity === "bold") return bold;
-  if (intensity === "loud") return loud;
-  if (intensity === "calm") return calm;
-  if (intensity === "test") return all;
+  const all = Object.fromEntries(Object.keys(base).map((k) => [k, 1]));
+  if (intensity === 'bold') return bold;
+  if (intensity === 'loud') return loud;
+  if (intensity === 'calm') return calm;
+  if (intensity === 'test') return all;
   return base; // "lite"
 }
 
@@ -169,34 +297,44 @@ function profile(intensity) {
 // Base elements
 // ————————————————————————————————————————
 function addGrid(root, rand, intensity) {
-  const g = el("div", "mschf-grid", root);
-  g.dataset.variant = rand() < 0.5 ? "dots" : "lines";
-  g.style.opacity = (intensity === "loud" ? "0.12" : "0.08");
+  const g = el('div', 'mschf-grid', root);
+  g.dataset.variant = rand() < 0.5 ? 'dots' : 'lines';
+  g.style.opacity = intensity === 'loud' ? '0.12' : '0.08';
 }
 function addCrosshair(root, rand, intensity) {
-  const cross = el("div", "mschf-crosshair", root);
+  const cross = el('div', 'mschf-crosshair', root);
   if (rand() < 0.5) {
-    cross.classList.add("is-offset");
-    cross.style.setProperty("--mschf-x", `${50 + Math.round((rand()-0.5)*40)}vw`);
-    cross.style.setProperty("--mschf-y", `${50 + Math.round((rand()-0.5)*24)}vh`);
+    cross.classList.add('is-offset');
+    cross.style.setProperty(
+      '--mschf-x',
+      `${50 + Math.round((rand() - 0.5) * 40)}vw`,
+    );
+    cross.style.setProperty(
+      '--mschf-y',
+      `${50 + Math.round((rand() - 0.5) * 24)}vh`,
+    );
   }
-  el("div","mschf-crosshair-ring",cross);
-  el("div","mschf-crosshair-v",cross);
-  el("div","mschf-crosshair-h",cross);
+  el('div', 'mschf-crosshair-ring', cross);
+  el('div', 'mschf-crosshair-v', cross);
+  el('div', 'mschf-crosshair-h', cross);
 }
 function addCorners(root, intensity) {
-  ["tl","tr","bl","br"].forEach(pos => {
-    const c = el("div", `mschf-corner mschf-corner-${pos}`, root);
-    c.style.opacity = (intensity === "calm" ? "0.08" : "0.14");
+  ['tl', 'tr', 'bl', 'br'].forEach((pos) => {
+    const c = el('div', `mschf-corner mschf-corner-${pos}`, root);
+    c.style.opacity = intensity === 'calm' ? '0.08' : '0.14';
   });
 }
 function addFrame(root, intensity) {
-  const f = el("div", "mschf-frame", root);
-  f.style.opacity = (intensity === "loud" ? "0.22" : "0.14");
+  const f = el('div', 'mschf-frame', root);
+  f.style.opacity = intensity === 'loud' ? '0.22' : '0.14';
 }
 function addScanline(root) {
-  const s = el("div", "mschf-scanline", root);
-  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) s.classList.add("static");
+  const s = el('div', 'mschf-scanline', root);
+  if (
+    window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+    s.classList.add('static');
 }
 
 // ————————————————————————————————————————
@@ -205,58 +343,86 @@ function addScanline(root) {
 function addTapeLabels(root, rand, intensity) {
   // Expanded tape vocabulary (quotes = Off-White style; tones map to A/B/C pastel & readable)
   const tapes = [
-    { text:'"KEEP OFF"', tone:"c" }, { text:'"FOR DISPLAY ONLY"', tone:"a" },
-    { text:'"PROTOTYPE"', tone:"b" }, { text:'"ARCHIVE"', tone:"c" },
-    { text:'"FIELD NOTES"', tone:"a" }, { text:'"RED TEAM"', tone:"b" },
-    { text:'"PAYLOAD"', tone:"c" }, { text:'"SIMULACRUM"', tone:"a" },
+    { text: '"KEEP OFF"', tone: 'c' },
+    { text: '"FOR DISPLAY ONLY"', tone: 'a' },
+    { text: '"PROTOTYPE"', tone: 'b' },
+    { text: '"ARCHIVE"', tone: 'c' },
+    { text: '"FIELD NOTES"', tone: 'a' },
+    { text: '"RED TEAM"', tone: 'b' },
+    { text: '"PAYLOAD"', tone: 'c' },
+    { text: '"SIMULACRUM"', tone: 'a' },
 
-    { text:'"SPECIMEN"', tone:"b" }, { text:'"ARTIFACT"', tone:"a" },
-    { text:'"EVIDENCE"', tone:"c" }, { text:'"PROVENANCE"', tone:"a" },
-    { text:'"BLUEPRINT"', tone:"b" }, { text:'"DRAFT"', tone:"c" },
+    { text: '"SPECIMEN"', tone: 'b' },
+    { text: '"ARTIFACT"', tone: 'a' },
+    { text: '"EVIDENCE"', tone: 'c' },
+    { text: '"PROVENANCE"', tone: 'a' },
+    { text: '"BLUEPRINT"', tone: 'b' },
+    { text: '"DRAFT"', tone: 'c' },
 
-    { text:'"ALPHA"', tone:"a" }, { text:'"BETA"', tone:"b" }, { text:'"RC1"', tone:"c" },
-    { text:'"NIGHTLY"', tone:"a" }, { text:'"CANARY"', tone:"b" }, { text:'"WIP"', tone:"c" },
+    { text: '"ALPHA"', tone: 'a' },
+    { text: '"BETA"', tone: 'b' },
+    { text: '"RC1"', tone: 'c' },
+    { text: '"NIGHTLY"', tone: 'a' },
+    { text: '"CANARY"', tone: 'b' },
+    { text: '"WIP"', tone: 'c' },
 
-    { text:'"REDACTED"', tone:"a" }, { text:'"DECLASSIFIED"', tone:"b" }, { text:'"NONCANON"', tone:"c" },
-    { text:'"UNSANCTIONED"', tone:"a" }, { text:'"UNVERIFIED"', tone:"b" }, { text:'"NULL RESULT"', tone:"c" },
+    { text: '"REDACTED"', tone: 'a' },
+    { text: '"DECLASSIFIED"', tone: 'b' },
+    { text: '"NONCANON"', tone: 'c' },
+    { text: '"UNSANCTIONED"', tone: 'a' },
+    { text: '"UNVERIFIED"', tone: 'b' },
+    { text: '"NULL RESULT"', tone: 'c' },
 
-    { text:'"KEEP OUT"', tone:"a" }, { text:'"OFF LIMITS"', tone:"b" }, { text:'"NO ENTRY"', tone:"c" },
-    { text:'"DO NOT TOUCH"', tone:"a" }, { text:'"HANDLE WITH CARE"', tone:"b" },
+    { text: '"KEEP OUT"', tone: 'a' },
+    { text: '"OFF LIMITS"', tone: 'b' },
+    { text: '"NO ENTRY"', tone: 'c' },
+    { text: '"DO NOT TOUCH"', tone: 'a' },
+    { text: '"HANDLE WITH CARE"', tone: 'b' },
 
-    { text:'"FOR RESEARCH ONLY"', tone:"a" }, { text:'"FOR INTERNAL USE"', tone:"b" },
-    { text:'"SANDBOX"', tone:"c" }, { text:'"SIMULATION"', tone:"a" },
+    { text: '"FOR RESEARCH ONLY"', tone: 'a' },
+    { text: '"FOR INTERNAL USE"', tone: 'b' },
+    { text: '"SANDBOX"', tone: 'c' },
+    { text: '"SIMULATION"', tone: 'a' },
 
-    { text:'"GRAPH"', tone:"a" }, { text:'"NODE"', tone:"b" }, { text:'"EDGE"', tone:"c" },
-    { text:'"EMBEDDING"', tone:"a" }, { text:'"RAG"', tone:"b" }, { text:'"EVAL"', tone:"c" },
+    { text: '"GRAPH"', tone: 'a' },
+    { text: '"NODE"', tone: 'b' },
+    { text: '"EDGE"', tone: 'c' },
+    { text: '"EMBEDDING"', tone: 'a' },
+    { text: '"RAG"', tone: 'b' },
+    { text: '"EVAL"', tone: 'c' },
 
-    { text:'"READ ONLY"', tone:"a" }, { text:'"NO INDEX"', tone:"b" }, { text:'"NO EXPORT"', tone:"c" }
+    { text: '"READ ONLY"', tone: 'a' },
+    { text: '"NO INDEX"', tone: 'b' },
+    { text: '"NO EXPORT"', tone: 'c' },
   ];
 
   // How many tapes to drop
-  const count = 1 + Math.floor(rand() * (intensity === "loud" ? 4 : 2));
+  const count = 1 + Math.floor(rand() * (intensity === 'loud' ? 4 : 2));
 
   for (let i = 0; i < count; i++) {
     const t = pick(rand, tapes);
-    const tape = el("div", `mschf-tape tone-${t.tone}`, root);
+    const tape = el('div', `mschf-tape tone-${t.tone}`, root);
 
     // Optional: hazard stripe override (some % of the time)
-    if (rand() < (intensity === "loud" ? 0.45 : 0.25)) {
-      tape.style.background = "repeating-linear-gradient(45deg, #ffd500 0 8px, #000 8px 16px)";
-      tape.style.color = "#0b0b0e";
-      tape.style.borderStyle = "solid";
+    if (rand() < (intensity === 'loud' ? 0.45 : 0.25)) {
+      tape.style.background =
+        'repeating-linear-gradient(45deg, #ffd500 0 8px, #000 8px 16px)';
+      tape.style.color = '#0b0b0e';
+      tape.style.borderStyle = 'solid';
     } else if (rand() < 0.25) {
       // Clear acetate-esque tape variant
-      tape.style.background = "linear-gradient(to bottom, rgba(255,255,255,.22), rgba(255,255,255,.08))";
-      tape.style.backdropFilter = "blur(2px)";
-      tape.style.borderStyle = "dotted";
+      tape.style.background =
+        'linear-gradient(to bottom, rgba(255,255,255,.22), rgba(255,255,255,.08))';
+      tape.style.backdropFilter = 'blur(2px)';
+      tape.style.borderStyle = 'dotted';
     }
 
     // Serial/rig hint
-    const rig = (Math.random().toString(16).slice(2, 6)).toUpperCase();
+    const rig = Math.random().toString(16).slice(2, 6).toUpperCase();
     tape.textContent = `${t.text} • RIG-${rig}`;
 
     // Transform & size
-    const rot = (rand() - 0.5) * (intensity === "loud" ? 14 : 6);
+    const rot = (rand() - 0.5) * (intensity === 'loud' ? 14 : 6);
     const skew = (rand() - 0.5) * 4;
     const w = 32 + Math.floor(rand() * 52); // vw
     const top = 6 + Math.floor(rand() * 74);
@@ -267,88 +433,155 @@ function addTapeLabels(root, rand, intensity) {
       left: `${left}%`,
       width: `${w}vw`,
       transform: `rotate(${rot}deg) skewX(${skew}deg)`,
-      opacity: (intensity === "calm" ? ".20" : ".32")
+      opacity: intensity === 'calm' ? '.20' : '.32',
     });
   }
 }
 
 function addStamp(root, rand) {
   const stamps = [
-    "LAB DROP","EXPERIMENTAL","UNSTABLE","FIELD TEST","FOR INTERNAL USE",
-    "NULL RESULT","RECALIBRATE","KEEP OFF","DECLASSIFIED","NONCANON",
-    "UNSANCTIONED","FOR RESEARCH ONLY","UNVERIFIED","ARCHIVE ONLY","READ ONLY",
-    "CHECKSUM FAIL","RETRY","REINDEX","RESAMPLE","REHYDRATE"
+    'LAB DROP',
+    'EXPERIMENTAL',
+    'UNSTABLE',
+    'FIELD TEST',
+    'FOR INTERNAL USE',
+    'NULL RESULT',
+    'RECALIBRATE',
+    'KEEP OFF',
+    'DECLASSIFIED',
+    'NONCANON',
+    'UNSANCTIONED',
+    'FOR RESEARCH ONLY',
+    'UNVERIFIED',
+    'ARCHIVE ONLY',
+    'READ ONLY',
+    'CHECKSUM FAIL',
+    'RETRY',
+    'REINDEX',
+    'RESAMPLE',
+    'REHYDRATE',
   ];
 
-  const s = el("div", "mschf-stamp", root);
+  const s = el('div', 'mschf-stamp', root);
   s.textContent = pick(rand, stamps);
 
   // Variant styling
   const variants = [
-    () => { s.style.borderWidth = "2px"; s.style.letterSpacing = ".12em"; },
-    () => { s.style.borderWidth = "3px"; s.style.letterSpacing = ".18em"; s.style.transform += " scale(1.05)"; },
-    () => { s.style.borderRadius = "999px"; s.style.padding = "6px 12px"; },
-    () => { s.style.mixBlendMode = "overlay"; s.style.opacity = ".9"; },
-    () => { s.style.filter = "contrast(1.3) saturate(1.1)"; }
+    () => {
+      s.style.borderWidth = '2px';
+      s.style.letterSpacing = '.12em';
+    },
+    () => {
+      s.style.borderWidth = '3px';
+      s.style.letterSpacing = '.18em';
+      s.style.transform += ' scale(1.05)';
+    },
+    () => {
+      s.style.borderRadius = '999px';
+      s.style.padding = '6px 12px';
+    },
+    () => {
+      s.style.mixBlendMode = 'overlay';
+      s.style.opacity = '.9';
+    },
+    () => {
+      s.style.filter = 'contrast(1.3) saturate(1.1)';
+    },
   ];
   pick(rand, variants)();
 
   // Position: random corner band
-  const corner = pick(rand, ["top-right","top-left","bottom-right","bottom-left"]);
+  const corner = pick(rand, [
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+  ]);
   const rot = (rand() - 0.5) * 12;
   const insetX = 6 + Math.floor(rand() * 14);
   const insetY = 8 + Math.floor(rand() * 16);
 
   const style = { transform: `rotate(${rot}deg)` };
-  if (corner === "top-right")  { style.right = `${insetX}%`; style.top = `${insetY}%`; }
-  if (corner === "top-left")   { style.left  = `${insetX}%`; style.top = `${insetY}%`; }
-  if (corner === "bottom-right"){ style.right = `${insetX}%`; style.bottom = `${insetY}%`; }
-  if (corner === "bottom-left"){ style.left  = `${insetX}%`; style.bottom = `${insetY}%`; }
+  if (corner === 'top-right') {
+    style.right = `${insetX}%`;
+    style.top = `${insetY}%`;
+  }
+  if (corner === 'top-left') {
+    style.left = `${insetX}%`;
+    style.top = `${insetY}%`;
+  }
+  if (corner === 'bottom-right') {
+    style.right = `${insetX}%`;
+    style.bottom = `${insetY}%`;
+  }
+  if (corner === 'bottom-left') {
+    style.left = `${insetX}%`;
+    style.bottom = `${insetY}%`;
+  }
   css(s, style);
 }
 
 function addQuotes(root, rand) {
   // Off-White style quotes, kept positive/neutral
   const phrases = [
-    '"OBJECT"','"INTERFACE"','"ARTIFACT"','"SYSTEM"','"SPECIMEN"','"EVIDENCE"',
-    '"PROTOTYPE"','"KNOWLEDGE"','"GRAPH"','"SPARK"','"VECTOR"','"EMBEDDING"',
-    '"SANDBOX"','"SIMULATION"','"RAG"','"EVAL"','"CATALOG"','"ATLAS"','"WORKBOARD"'
+    '"OBJECT"',
+    '"INTERFACE"',
+    '"ARTIFACT"',
+    '"SYSTEM"',
+    '"SPECIMEN"',
+    '"EVIDENCE"',
+    '"PROTOTYPE"',
+    '"KNOWLEDGE"',
+    '"GRAPH"',
+    '"SPARK"',
+    '"VECTOR"',
+    '"EMBEDDING"',
+    '"SANDBOX"',
+    '"SIMULATION"',
+    '"RAG"',
+    '"EVAL"',
+    '"CATALOG"',
+    '"ATLAS"',
+    '"WORKBOARD"',
   ];
 
-  const q = el("div", "mschf-quotes", root);
-  const idtail = (Math.random().toString(36).slice(2,5)).toUpperCase();
+  const q = el('div', 'mschf-quotes', root);
+  const idtail = Math.random().toString(36).slice(2, 5).toUpperCase();
   q.textContent = `${pick(rand, phrases)} • ${idtail}`;
 
-  const side = rand() < 0.5 ? "right" : "left";
-  const vertical = rand() < 0.3 ? "top" : "bottom";
+  const side = rand() < 0.5 ? 'right' : 'left';
+  const vertical = rand() < 0.3 ? 'top' : 'bottom';
   const offX = 12 + Math.floor(rand() * 24);
   const offY = 10 + Math.floor(rand() * 18);
 
   const style = {};
-  if (side === "right") style.right = `${offX}px`; else style.left = `${offX}px`;
-  if (vertical === "top") style.top = `${offY}px`; else style.bottom = `${offY}px`;
+  if (side === 'right') style.right = `${offX}px`;
+  else style.left = `${offX}px`;
+  if (vertical === 'top') style.top = `${offY}px`;
+  else style.bottom = `${offY}px`;
 
   // Minor rotation & glow
-  style.transform = `rotate(${(rand()-0.5)*2.2}deg)`;
-  style.boxShadow = "0 0 0 1px rgba(255,255,255,.04) inset, 0 8px 18px rgba(0,0,0,.35)";
+  style.transform = `rotate(${(rand() - 0.5) * 2.2}deg)`;
+  style.boxShadow =
+    '0 0 0 1px rgba(255,255,255,.04) inset, 0 8px 18px rgba(0,0,0,.35)';
   css(q, style);
 }
 
 function addSpecimenLabel(root, rand, build) {
-  const lab = el("div", "mschf-specimen", root);
-  const id  = (Math.random().toString(36).slice(2,7)).toUpperCase();
-  const hash = build?.hash ? build.hash.slice(0,7) : "";
-  const date = (build?.built || new Date().toISOString()).slice(0,10);
-  const branch = build?.branch || "main";
-  const rev = ["A","B","C","D"][Math.floor(rand()*4)];
+  const lab = el('div', 'mschf-specimen', root);
+  const id = Math.random().toString(36).slice(2, 7).toUpperCase();
+  const hash = build?.hash ? build.hash.slice(0, 7) : '';
+  const date = (build?.built || new Date().toISOString()).slice(0, 10);
+  const branch = build?.branch || 'main';
+  const rev = ['A', 'B', 'C', 'D'][Math.floor(rand() * 4)];
 
   // Optional path hint (non-sensitive)
-  const pathHint = (location && location.pathname) ? location.pathname : "/";
+  const pathHint = location && location.pathname ? location.pathname : '/';
 
   lab.innerHTML = `
     <strong>SPECIMEN</strong>
     <span>ID ${id}</span>
-    ${hash ? `<span>BUILD ${hash}</span>` : ""}
+    ${hash ? `<span>BUILD ${hash}</span>` : ''}
     <span>${date}</span>
     <span>BR ${branch}</span>
     <span>REV ${rev}</span>
@@ -356,176 +589,223 @@ function addSpecimenLabel(root, rand, build) {
   `;
 
   // Dock near a corner with slight variance
-  const side = rand() < 0.5 ? "right" : "left";
-  const offX = 18 + Math.floor(rand()*24);
-  const offY = 16 + Math.floor(rand()*20);
+  const side = rand() < 0.5 ? 'right' : 'left';
+  const offX = 18 + Math.floor(rand() * 24);
+  const offY = 16 + Math.floor(rand() * 20);
   const style = {};
-  if (side === "right") style.right = `${offX}px`; else style.left = `${offX}px`;
+  if (side === 'right') style.right = `${offX}px`;
+  else style.left = `${offX}px`;
   style.top = `${offY}px`;
   css(lab, style);
 }
 
 function addPlate(root, rand, seed, build) {
-  const plate = el("div","mschf-plate", root);
-  el("div","mschf-barcode", plate);
-  const code = el("div","mschf-code", plate);
+  const plate = el('div', 'mschf-plate', root);
+  el('div', 'mschf-barcode', plate);
+  const code = el('div', 'mschf-code', plate);
   const tail = seed.slice(-6);
-  const stamp = (build?.built || new Date().toISOString()).slice(0,10);
-  code.textContent = `SEED:${tail} • BR:${(build.branch||"main")} • ${stamp}`;
-  css(plate,{ left:"18px", top:"18px" });
+  const stamp = (build?.built || new Date().toISOString()).slice(0, 10);
+  code.textContent = `SEED:${tail} • BR:${build.branch || 'main'} • ${stamp}`;
+  css(plate, { left: '18px', top: '18px' });
 }
 
 // ————————————————————————————————————————
 // Lab/blueprint/OSINT
 // ————————————————————————————————————————
 function addBlueprintCallout(root, rand) {
-  const c = el("div","mschf-callout", root);
-  const x = 8 + rand()*84, y = 18 + rand()*64;
-  const len = 8 + rand()*16; // length of leader
-  c.style.setProperty("--x", `${x}vw`);
-  c.style.setProperty("--y", `${y}vh`);
-  c.style.setProperty("--len", `${len}vh`);
-  const labels = ["NODE", "EDGE", "BAYES p", "Z", "Δt", "ID"];
-  const val    = Math.random().toString(36).slice(2,5).toUpperCase();
+  const c = el('div', 'mschf-callout', root);
+  const x = 8 + rand() * 84,
+    y = 18 + rand() * 64;
+  const len = 8 + rand() * 16; // length of leader
+  c.style.setProperty('--x', `${x}vw`);
+  c.style.setProperty('--y', `${y}vh`);
+  c.style.setProperty('--len', `${len}vh`);
+  const labels = ['NODE', 'EDGE', 'BAYES p', 'Z', 'Δt', 'ID'];
+  const val = Math.random().toString(36).slice(2, 5).toUpperCase();
   c.textContent = `${pick(rand, labels)} ${val} • ${Math.random().toFixed(2)}`;
 }
 
 function addGraphCluster(root, rand, intensity) {
-  const cluster = el("div","mschf-graph", root);
-  const n = 5 + Math.floor(rand()* (intensity === "loud" ? 10 : 6));
-  for (let i=0;i<n;i++) {
-    const node = el("span","mschf-graph-node", cluster);
-    node.style.setProperty("--x", `${rand()*100}vw`);
-    node.style.setProperty("--y", `${rand()*100}vh`);
+  const cluster = el('div', 'mschf-graph', root);
+  const n = 5 + Math.floor(rand() * (intensity === 'loud' ? 10 : 6));
+  for (let i = 0; i < n; i++) {
+    const node = el('span', 'mschf-graph-node', cluster);
+    node.style.setProperty('--x', `${rand() * 100}vw`);
+    node.style.setProperty('--y', `${rand() * 100}vh`);
   }
   // A few edges
-  const m = 3 + Math.floor(rand()*4);
-  for (let i=0;i<m;i++) {
-    const e = el("i","mschf-graph-edge", cluster);
-    e.style.setProperty("--x1", `${rand()*100}vw`);
-    e.style.setProperty("--y1", `${rand()*100}vh`);
-    e.style.setProperty("--x2", `${rand()*100}vw`);
-    e.style.setProperty("--y2", `${rand()*100}vh`);
+  const m = 3 + Math.floor(rand() * 4);
+  for (let i = 0; i < m; i++) {
+    const e = el('i', 'mschf-graph-edge', cluster);
+    e.style.setProperty('--x1', `${rand() * 100}vw`);
+    e.style.setProperty('--y1', `${rand() * 100}vh`);
+    e.style.setProperty('--x2', `${rand() * 100}vw`);
+    e.style.setProperty('--y2', `${rand() * 100}vh`);
   }
 }
 
 function addSpectralRings(root, rand, intensity) {
-  const r = el("div","mschf-rings", root);
-  const s = 120 + Math.floor(rand()*220);
-  css(r, { left:`${10 + rand()*80}%`, top:`${10 + rand()*70}%`, width:px(s), height:px(s) });
-  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) r.classList.add("static");
+  const r = el('div', 'mschf-rings', root);
+  const s = 120 + Math.floor(rand() * 220);
+  css(r, {
+    left: `${10 + rand() * 80}%`,
+    top: `${10 + rand() * 70}%`,
+    width: px(s),
+    height: px(s),
+  });
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches)
+    r.classList.add('static');
 }
 
 function addTopo(root, rand) {
-  const t = el("div","mschf-topo", root);
-  t.style.setProperty("--rot", `${Math.floor((rand()-0.5)*30)}deg`);
-  t.style.opacity = ".10";
+  const t = el('div', 'mschf-topo', root);
+  t.style.setProperty('--rot', `${Math.floor((rand() - 0.5) * 30)}deg`);
+  t.style.opacity = '.10';
 }
 function addHalftone(root, rand) {
-  const h = el("div","mschf-halftone", root);
-  const corner = pick(rand, ["tl","tr","bl","br"]);
+  const h = el('div', 'mschf-halftone', root);
+  const corner = pick(rand, ['tl', 'tr', 'bl', 'br']);
   h.classList.add(corner);
-  h.style.opacity = ".10";
+  h.style.opacity = '.10';
 }
 function addCRTMask(root, rand) {
-  const c = el("div","mschf-crt", root);
-  c.style.opacity = ".06";
+  const c = el('div', 'mschf-crt', root);
+  c.style.opacity = '.06';
 }
 function addPerforation(root, rand) {
-  const p = el("div","mschf-perf", root);
-  p.dataset.side = pick(rand, ["top","bottom","left","right"]);
+  const p = el('div', 'mschf-perf', root);
+  p.dataset.side = pick(rand, ['top', 'bottom', 'left', 'right']);
 }
 function addStarfield(root, rand) {
-  const star = el("div","mschf-stars", root);
-  star.style.setProperty("--density", `${0.15 + rand()*0.35}`);
+  const star = el('div', 'mschf-stars', root);
+  star.style.setProperty('--density', `${0.15 + rand() * 0.35}`);
 }
 
 function addBrackets(root, rand) {
-  const b = el("div","mschf-brackets", root);
-  b.classList.add(pick(rand, ["tight","wide"]));
+  const b = el('div', 'mschf-brackets', root);
+  b.classList.add(pick(rand, ['tight', 'wide']));
 }
 function addGlitchSlices(root, rand, intensity) {
-  const n = 2 + Math.floor(rand()*(intensity === "loud" ? 4 : 2));
-  for (let i=0;i<n;i++) {
-    const g = el("div","mschf-glitch", root);
-    css(g, { top: `${Math.floor(rand()*100)}%`, left: "0", right: "0" });
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) g.classList.add("static");
+  const n = 2 + Math.floor(rand() * (intensity === 'loud' ? 4 : 2));
+  for (let i = 0; i < n; i++) {
+    const g = el('div', 'mschf-glitch', root);
+    css(g, { top: `${Math.floor(rand() * 100)}%`, left: '0', right: '0' });
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches)
+      g.classList.add('static');
   }
 }
 function addRulers(root) {
-  el("div","mschf-ruler mschf-ruler-top", root);
-  el("div","mschf-ruler mschf-ruler-left", root);
+  el('div', 'mschf-ruler mschf-ruler-top', root);
+  el('div', 'mschf-ruler mschf-ruler-left', root);
 }
 function addWatermark(root) {
-  const wm = el("div","mschf-watermark", root);
-  wm.textContent = "EFFUSION LABS • PROTOTYPE • ";
+  const wm = el('div', 'mschf-watermark', root);
+  wm.textContent = 'EFFUSION LABS • PROTOTYPE • ';
 }
 function addFlowers(root, rand, intensity) {
-  const n = 1 + Math.floor(rand() * (intensity === "loud" ? 4 : 2));
-  for (let i=0;i<n;i++) {
-    const fl = el("div","mschf-flower", root);
-    const s = 38 + Math.floor(rand()*32);
-    const x = 10 + Math.floor(rand()*80);
-    const y = 10 + Math.floor(rand()*70);
-    css(fl,{ width:px(s), height:px(s), left:`${x}%`, top:`${y}%`, transform:`rotate(${Math.floor((rand()-0.5)*180)}deg)` });
+  const n = 1 + Math.floor(rand() * (intensity === 'loud' ? 4 : 2));
+  for (let i = 0; i < n; i++) {
+    const fl = el('div', 'mschf-flower', root);
+    const s = 38 + Math.floor(rand() * 32);
+    const x = 10 + Math.floor(rand() * 80);
+    const y = 10 + Math.floor(rand() * 70);
+    css(fl, {
+      width: px(s),
+      height: px(s),
+      left: `${x}%`,
+      top: `${y}%`,
+      transform: `rotate(${Math.floor((rand() - 0.5) * 180)}deg)`,
+    });
   }
 }
 function addHolo(root, intensity) {
-  const h = el("div","mschf-holo", root);
-  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) h.classList.add("static");
+  const h = el('div', 'mschf-holo', root);
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches)
+    h.classList.add('static');
 }
 function addRegMarks(root, intensity) {
-  ["tl","tr","bl","br"].forEach(pos => el("div",`mschf-reg ${pos}`, root));
+  ['tl', 'tr', 'bl', 'br'].forEach((pos) =>
+    el('div', `mschf-reg ${pos}`, root),
+  );
 }
 function addDims(root, rand) {
-  const d = el("div","mschf-dims", root);
-  const x1 = 10 + Math.floor(rand()*30);
-  const x2 = x1 + 20 + Math.floor(rand()*35);
-  const y  = 20 + Math.floor(rand()*60);
-  d.style.setProperty("--x1", `${x1}vw`);
-  d.style.setProperty("--x2", `${x2}vw`);
-  d.style.setProperty("--y",  `${y}vh`);
-  d.textContent = `${Math.abs(x2-x1)}vw`;
+  const d = el('div', 'mschf-dims', root);
+  const x1 = 10 + Math.floor(rand() * 30);
+  const x2 = x1 + 20 + Math.floor(rand() * 35);
+  const y = 20 + Math.floor(rand() * 60);
+  d.style.setProperty('--x1', `${x1}vw`);
+  d.style.setProperty('--x2', `${x2}vw`);
+  d.style.setProperty('--y', `${y}vh`);
+  d.textContent = `${Math.abs(x2 - x1)}vw`;
 }
 function addStickers(root, rand) {
-  const cluster = el("div", "mschf-stickers", root);
+  const cluster = el('div', 'mschf-stickers', root);
   const badges = [
-    "ALPHA","BETA","RC1","SIGNED","VOID","UNLOCKED","PASS","LAB","SIM",
-    "ARCHIVE","SANDBOX","RAG","EVAL","GRAPH","SPARK","VECTOR","EMBED","SPECIMEN","PROTO"
+    'ALPHA',
+    'BETA',
+    'RC1',
+    'SIGNED',
+    'VOID',
+    'UNLOCKED',
+    'PASS',
+    'LAB',
+    'SIM',
+    'ARCHIVE',
+    'SANDBOX',
+    'RAG',
+    'EVAL',
+    'GRAPH',
+    'SPARK',
+    'VECTOR',
+    'EMBED',
+    'SPECIMEN',
+    'PROTO',
   ];
 
   // Place cluster in a random corner
-  const corner = pick(rand, ["br","bl","tr","tl"]);
-  const off = 18 + Math.floor(rand()*18);
+  const corner = pick(rand, ['br', 'bl', 'tr', 'tl']);
+  const off = 18 + Math.floor(rand() * 18);
   const style = {};
-  if (corner.includes("b")) style.bottom = `${off}px`; else style.top = `${off}px`;
-  if (corner.includes("r")) style.right  = `${off}px`; else style.left = `${off}px`;
+  if (corner.includes('b')) style.bottom = `${off}px`;
+  else style.top = `${off}px`;
+  if (corner.includes('r')) style.right = `${off}px`;
+  else style.left = `${off}px`;
   css(cluster, style);
 
   // 2–5 stickers with per-sticker transforms & size variance
   const n = 2 + Math.floor(rand() * 4);
   for (let i = 0; i < n; i++) {
-    const b = el("span", "mschf-badge", cluster);
+    const b = el('span', 'mschf-badge', cluster);
     b.textContent = pick(rand, badges);
 
     // Size & weight variance (inline so we don't need extra CSS)
     const sizes = [
-      () => { b.style.fontSize = "10px"; b.style.padding = "5px 7px"; },
-      () => { b.style.fontSize = "11px"; b.style.padding = "6px 8px"; },
-      () => { b.style.fontSize = "12px"; b.style.padding = "7px 9px"; }
+      () => {
+        b.style.fontSize = '10px';
+        b.style.padding = '5px 7px';
+      },
+      () => {
+        b.style.fontSize = '11px';
+        b.style.padding = '6px 8px';
+      },
+      () => {
+        b.style.fontSize = '12px';
+        b.style.padding = '7px 9px';
+      },
     ];
     pick(rand, sizes)();
 
     // Transform offsets
-    b.style.setProperty("--rx", `${Math.floor((rand()-0.5)*18)}deg`);
-    b.style.setProperty("--offx", `${Math.floor((rand()-0.5)*18)}px`);
-    b.style.setProperty("--offy", `${Math.floor((rand()-0.5)*12)}px`);
+    b.style.setProperty('--rx', `${Math.floor((rand() - 0.5) * 18)}deg`);
+    b.style.setProperty('--offx', `${Math.floor((rand() - 0.5) * 18)}px`);
+    b.style.setProperty('--offy', `${Math.floor((rand() - 0.5) * 12)}px`);
 
     // Occasional outline accent
     if (rand() < 0.25) {
-      b.style.boxShadow = "0 0 0 1px color-mix(in oklab, currentColor 35%, transparent), 0 10px 18px rgba(0,0,0,.35)";
+      b.style.boxShadow =
+        '0 0 0 1px color-mix(in oklab, currentColor 35%, transparent), 0 10px 18px rgba(0,0,0,.35)';
     }
   }
 }
 
-document.addEventListener("DOMContentLoaded", initOverlay);
+document.addEventListener('DOMContentLoaded', initOverlay);

--- a/test/unit/mschf-overlay-style.test.mjs
+++ b/test/unit/mschf-overlay-style.test.mjs
@@ -1,4 +1,5 @@
 // test/unit/mschf-overlay-style.test.mjs
+import test from 'node:test';
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
@@ -6,7 +7,10 @@ import { JSDOM } from 'jsdom';
 
 test('collage style includes base, ephemera, and lab modules', () => {
   const html = `<!doctype html><html><body data-mschf="on" data-mschf-intensity="test" data-mschf-style="collage"></body></html>`;
-  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost' });
+  const dom = new JSDOM(html, {
+    runScripts: 'outside-only',
+    url: 'http://localhost',
+  });
   const scriptPath = path.resolve('src/scripts/mschf-overlay.js');
   dom.window.eval(readFileSync(scriptPath, 'utf8'));
   dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
@@ -15,12 +19,13 @@ test('collage style includes base, ephemera, and lab modules', () => {
   assert.ok(doc.querySelector('.mschf-grid'));
   assert.ok(doc.querySelector('.mschf-crosshair'));
   assert.ok(
-    doc.querySelector('.mschf-tape, .mschf-stamp, .mschf-quotes, .mschf-plate, .mschf-specimen')
+    doc.querySelector(
+      '.mschf-tape, .mschf-stamp, .mschf-quotes, .mschf-plate, .mschf-specimen',
+    ),
   );
   assert.ok(
     doc.querySelector(
-      '.mschf-callout, .mschf-graph, .mschf-rings, .mschf-topo, .mschf-halftone, .mschf-crt, .mschf-perf, .mschf-starfield'
-    )
+      '.mschf-callout, .mschf-graph, .mschf-rings, .mschf-topo, .mschf-halftone, .mschf-crt, .mschf-perf, .mschf-starfield',
+    ),
   );
 });
-


### PR DESCRIPTION
## Summary
- randomize overlay intensity and style when not specified
- drop default intensity attribute so layout opts into randomness
- document randomized defaults and stabilize tests

## Testing
- `node tools/runner.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68aea9309c00833098382235f28146a7