### PR TITLE
feat: randomize mschf overlay style

### DIFF
--- a/artifacts/patches/20250827T065341Z.patch
+++ b/artifacts/patches/20250827T065341Z.patch
@@ -1,0 +1,406 @@
+diff --git a/docs/ux/mschf-overlay.md b/docs/ux/mschf-overlay.md
+index f50bc02..ef47f04 100644
+--- a/docs/ux/mschf-overlay.md
++++ b/docs/ux/mschf-overlay.md
+@@ -11,14 +11,13 @@ Attach attributes to the `#page-shell` wrapper:
+ | `data-mschf` | `on` \| `off` \| `auto` | `auto` | Enable overlay or force disable. |
+ | `data-mschf-intensity` | `lite` \| `loud` | `lite` | Governs element counts and probabilities. |
+ | `data-mschf-seed-mode` | `page` \| `session` | `page` | Ephemeral seed per load or stable for a tab session. |
+-| `data-mschf-style` | `collage` \| `structural` \| `playful` | `collage` | Aesthetic strategy mix. |
++| `data-mschf-style` | `collage` \| `structural` \| `playful` \| `auto` | `auto` | Aesthetic strategy mix; `auto` picks a style randomly each load. |
+ 
+ Use `localStorage.setItem('mschf:off','1')` to opt out persistently.
+ 
+ ## Aesthetic Strategies
+ 
+-`collage` (default) fuses four groups: base scaffold, culture-coded ephemera,
+-lab/blueprint motifs, and framing stickers. Other styles limit the mix:
++`auto` (default) randomly selects an aesthetic strategy. `collage` fuses four groups: base scaffold, culture-coded ephemera, lab/blueprint motifs, and framing stickers. Other styles limit the mix:
+ 
+ - **structural** – base + lab motifs only.
+ - **playful** – base + culture-coded ephemera.
+diff --git a/logs/build-20250827T065325Z.log b/logs/build-20250827T065325Z.log
+new file mode 100644
+index 0000000..a5ff177
+--- /dev/null
++++ b/logs/build-20250827T065325Z.log
+@@ -0,0 +1,61 @@
++npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
++
++> effusion_labs_final@1.0.0 build
++> eleventy
++
++🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
++🚀 Eleventy build starting with enhanced footnote system...
++/*! 🌼 daisyUI 5.0.50 */
++[PostCSS] Compiled src/styles/app.tailwind.css -> src/assets/css/app.css
++[11ty] Writing ./_site/concept-map.json from ./src/concept-map.json.njk
++[11ty] Writing ./_site/feed.xml from ./src/feed.njk
++[11ty/eleventy-img] Processing ./src/assets/static/logo.png (transform)
++[11ty] Writing ./_site/map/index.html from ./src/map.njk
++[11ty] Writing ./_site/404.html from ./src/404.njk
++[11ty] Writing ./_site/archives/index.html from ./src/archives/index.njk
++[11ty] Writing ./_site/work/1/index.html from ./src/work/index.njk
++[11ty] Writing ./_site/archives/collectables/index.html from ./src/archives/collectables/index.njk
++[11ty] Writing ./_site/meta/index.html from ./src/content/meta/index.njk
++[11ty] Writing ./_site/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
++[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
++[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
++[11ty] Writing ./_site/work/index.html from ./src/work.njk
++[11ty] Writing ./_site/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
++[11ty] Writing ./_site/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
++[11ty] Writing ./_site/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
++[11ty] Writing ./_site/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
++[11ty] Writing ./_site/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
++[11ty] Writing ./_site/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
++[11ty] Writing ./_site/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
++[11ty] Writing ./_site/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
++[11ty] Writing ./_site/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
++[11ty] Writing ./_site/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
++[11ty] Writing ./_site/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
++[11ty] Writing ./_site/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
++[11ty] Writing ./_site/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
++[11ty] Writing ./_site/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
++[11ty] Writing ./_site/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
++[11ty] Writing ./_site/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
++[11ty] Writing ./_site/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
++[11ty] Writing ./_site/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
++[11ty] Writing ./_site/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
++[11ty] Writing ./_site/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
++[11ty] Writing ./_site/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
++[11ty] Writing ./_site/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
++[11ty] Writing ./_site/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
++[11ty] Writing ./_site/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
++[11ty] Writing ./_site/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
++[11ty] Writing ./_site/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
++[11ty] Writing ./_site/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
++[11ty] Writing ./_site/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
++[11ty] Writing ./_site/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
++[11ty] Writing ./_site/work/drop/index.html from ./src/work/drop.11ty.js
++[11ty] Writing ./_site/work/latest/index.html from ./src/work/latest.11ty.js
++[11ty] Writing ./_site/concepts/index.html from ./src/content/concepts/index.njk
++[11ty] Writing ./_site/projects/index.html from ./src/content/projects/index.njk
++[11ty] Writing ./_site/sparks/index.html from ./src/content/sparks/index.njk
++[11ty] Writing ./_site/work/2/index.html from ./src/work/index.njk
++[11ty] Writing ./_site/index.html from ./src/index.njk
++✅ Eleventy build completed. Generated 48 files.
++[11ty/eleventy-img] 1 image optimized
++[11ty] Copied 11 Wrote 48 files in 18.19 seconds (379.0ms each, v3.1.2)
+diff --git a/logs/test-20250827T065259Z.log b/logs/test-20250827T065259Z.log
+new file mode 100644
+index 0000000..9b9cdb5
+--- /dev/null
++++ b/logs/test-20250827T065259Z.log
+@@ -0,0 +1,250 @@
++🚀 Launching test runner...
++🔍 Found 14 test files.
++
++🏗️  Performing single Eleventy build...
++npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
++🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
++[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
++[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
++[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
++[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
++[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
++[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
++[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
++[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
++[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
++[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
++[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
++[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
++[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
++[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
++[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
++[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
++[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
++[11ty] Copied 10 Wrote 48 files in 3.59 seconds (74.9ms each, v3.1.2)
++✅ Eleventy build complete.
++
++🧪 Running 14 tests...
++TAP version 13
++# Subtest: callout merges footnotes into page pipeline
++ok 1 - callout merges footnotes into page pipeline
++  ---
++  duration_ms: 17.335506
++  type: 'test'
++  ...
++# Subtest: defines improved background colors
++ok 2 - defines improved background colors
++  ---
++  duration_ms: 2.251341
++  type: 'test'
++  ...
++# Subtest: text contrast meets WCAG AA
++ok 3 - text contrast meets WCAG AA
++  ---
++  duration_ms: 7.591496
++  type: 'test'
++  ...
++# Subtest: tailwind exposes readable font families
++ok 4 - tailwind exposes readable font families
++  ---
++  duration_ms: 2.260901
++  type: 'test'
++  ...
++# Subtest: includes fluid type scale tokens
++ok 5 - includes fluid type scale tokens
++  ---
++  duration_ms: 0.369838
++  type: 'test'
++  ...
++# Subtest: footnote popover separates source line
++ok 6 - footnote popover separates source line
++  ---
++  duration_ms: 145.19098
++  type: 'test'
++  ...
++# Subtest: projects computed picks latest entries by date
++ok 7 - projects computed picks latest entries by date
++  ---
++  duration_ms: 3.8469
++  type: 'test'
++  ...
++# Subtest: keepalive emits heartbeat to stderr
++ok 8 - keepalive emits heartbeat to stderr
++  ---
++  duration_ms: 6139.496124
++  type: 'test'
++  ...
++# Subtest: keepalive ignores first SIGINT
++ok 9 - keepalive ignores first SIGINT
++  ---
++  duration_ms: 208.256593
++  type: 'test'
++  ...
++# Subtest: gateway reads SOLVER_URL from environment
++ok 10 - gateway reads SOLVER_URL from environment
++  ---
++  duration_ms: 1.525675
++  type: 'test'
++  ...
++# Subtest: gateway retains default solver URL
++ok 11 - gateway retains default solver URL
++  ---
++  duration_ms: 0.342719
++  type: 'test'
++  ...
++# Subtest: external link renders with arrow and class
++ok 12 - external link renders with arrow and class
++  ---
++  duration_ms: 15.347529
++  type: 'test'
++  ...
++# Subtest: internal link keeps text without external markers
++ok 13 - internal link keeps text without external markers
++  ---
++  duration_ms: 1.733699
++  type: 'test'
++  ...
++# Subtest: external link starting with arrow does not duplicate
++ok 14 - external link starting with arrow does not duplicate
++  ---
++  duration_ms: 2.367223
++  type: 'test'
++  ...
++# Subtest: collage style includes base, ephemera, and lab modules
++ok 15 - collage style includes base, ephemera, and lab modules
++  ---
++  duration_ms: 286.454032
++  type: 'test'
++  ...
++# Subtest: auto style selects deterministic variant based on seed
++ok 16 - auto style selects deterministic variant based on seed
++  ---
++  duration_ms: 39.814494
++  type: 'test'
++  ...
++# Subtest: node shim version matches system node
++ok 17 - node shim version matches system node
++  ---
++  duration_ms: 207.450959
++  type: 'test'
++  ...
++# Subtest: node shim is executable
++ok 18 - node shim is executable
++  ---
++  duration_ms: 1.961907
++  type: 'test'
++  ...
++# Subtest: node shim lacks llm-constants reference
++ok 19 - node shim lacks llm-constants reference
++  ---
++  duration_ms: 0.537954
++  type: 'test'
++  ...
++# Subtest: prettier pinned version and format script
++ok 20 - prettier pinned version and format script
++  ---
++  duration_ms: 2.024663
++  type: 'test'
++  ...
++# Subtest: test/unit/pty-runner.test.mjs
++ok 11 - test/unit/pty-runner.test.mjs
++  ---
++  duration_ms: 1314.012295
++  type: 'test'
++  ...
++# Subtest: merges tag-like metadata into unified tags and categories
++ok 22 - merges tag-like metadata into unified tags and categories
++  ---
++  duration_ms: 2.772732
++  type: 'test'
++  ...
++# Subtest: deduplicates tag values
++ok 23 - deduplicates tag values
++  ---
++  duration_ms: 0.991324
++  type: 'test'
++  ...
++# Subtest: categories returns empty array when spark_type absent
++ok 24 - categories returns empty array when spark_type absent
++  ---
++  duration_ms: 0.854618
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix handles basic single-digit numbers
++ok 25 - ordinalSuffix handles basic single-digit numbers
++  ---
++  duration_ms: 1.390642
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix handles negative numbers correctly
++ok 26 - ordinalSuffix handles negative numbers correctly
++  ---
++  duration_ms: 0.356111
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix uses "th" for all teen numbers
++ok 27 - ordinalSuffix uses "th" for all teen numbers
++  ---
++  duration_ms: 0.62235
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix returns a valid suffix for all days in a month
++ok 28 - ordinalSuffix returns a valid suffix for all days in a month
++  ---
++  duration_ms: 0.751584
++  type: 'test'
++  ...
++# Subtest: readFileCached returns null for a nonexistent file path
++ok 29 - readFileCached returns null for a nonexistent file path
++  ---
++  duration_ms: 0.767145
++  type: 'test'
++  ...
++# Subtest: GitHub workflows use latest action versions
++ok 30 - GitHub workflows use latest action versions
++  ---
++  duration_ms: 1.767839
++  type: 'test'
++  ...
++1..30
++# tests 30
++# suites 0
++# pass 30
++# fail 0
++# cancelled 0
++# skipped 0
++# todo 0
++# duration_ms 7054.864247
++
++✨ All tests passed!
+diff --git a/src/_includes/layout.njk b/src/_includes/layout.njk
+index d42c732..c321c53 100644
+--- a/src/_includes/layout.njk
++++ b/src/_includes/layout.njk
+@@ -102,6 +102,7 @@
+   data-mschf="auto"
+   data-mschf-intensity="{{ page.mschfIntensity or site.mschfIntensity or 'lite' }}"
+   data-mschf-seed-mode="{{ page.mschfSeedMode or site.mschfSeedMode or 'page' }}"
++  data-mschf-style="auto"
+   class="bg-base-100 text-base-content font-body antialiased selection:bg-primary/20"
+ >
+   <a href="#main" class="skip-link">Skip to main content</a>
+diff --git a/src/scripts/mschf-overlay.js b/src/scripts/mschf-overlay.js
+index 5e93841..9bbd655 100644
+--- a/src/scripts/mschf-overlay.js
++++ b/src/scripts/mschf-overlay.js
+@@ -76,7 +76,11 @@ function initOverlay() {
+ 
+   // Profiles tune density/probabilities per intensity
+   const P = profile(intensity);
+-  const style = scope.dataset.mschfStyle || 'collage';
++  const styleAttr = scope.dataset.mschfStyle;
++  const style = !styleAttr || styleAttr === 'auto'
++    ? pick(rand, ['collage', 'structural', 'playful'])
++    : styleAttr;
++  root.dataset.mschfStyle = style;
+ 
+   const groups = {
+     base() {
+diff --git a/test/unit/mschf-overlay-style.test.mjs b/test/unit/mschf-overlay-style.test.mjs
+index 03728ac..017f329 100644
+--- a/test/unit/mschf-overlay-style.test.mjs
++++ b/test/unit/mschf-overlay-style.test.mjs
+@@ -1,4 +1,5 @@
+ // test/unit/mschf-overlay-style.test.mjs
++import test from 'node:test';
+ import { strict as assert } from 'node:assert';
+ import { readFileSync } from 'node:fs';
+ import path from 'node:path';
+@@ -7,6 +8,7 @@ import { JSDOM } from 'jsdom';
+ test('collage style includes base, ephemera, and lab modules', () => {
+   const html = `<!doctype html><html><body data-mschf="on" data-mschf-intensity="test" data-mschf-style="collage"></body></html>`;
+   const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost' });
++  dom.window.matchMedia = dom.window.matchMedia || (() => ({ matches: false, addListener() {}, removeListener() {} }));
+   const scriptPath = path.resolve('src/scripts/mschf-overlay.js');
+   dom.window.eval(readFileSync(scriptPath, 'utf8'));
+   dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+@@ -24,3 +26,14 @@ test('collage style includes base, ephemera, and lab modules', () => {
+   );
+ });
+ 
++test('auto style selects deterministic variant based on seed', () => {
++  const html = `<!doctype html><html><body data-mschf="on" data-mschf-intensity="test" data-mschf-style="auto"></body></html>`;
++  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost/?mschf-seed=1' });
++  dom.window.matchMedia = dom.window.matchMedia || (() => ({ matches: false, addListener() {}, removeListener() {} }));
++  const scriptPath = path.resolve('src/scripts/mschf-overlay.js');
++  dom.window.eval(readFileSync(scriptPath, 'utf8'));
++  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
++  const root = dom.window.document.getElementById('mschf-overlay-root');
++  assert.equal(root.dataset.mschfStyle, 'structural');
++});
++

--- a/docs/ux/mschf-overlay.md
+++ b/docs/ux/mschf-overlay.md
@@ -11,14 +11,13 @@ Attach attributes to the `#page-shell` wrapper:
 | `data-mschf` | `on` \| `off` \| `auto` | `auto` | Enable overlay or force disable. |
 | `data-mschf-intensity` | `lite` \| `loud` | `lite` | Governs element counts and probabilities. |
 | `data-mschf-seed-mode` | `page` \| `session` | `page` | Ephemeral seed per load or stable for a tab session. |
-| `data-mschf-style` | `collage` \| `structural` \| `playful` | `collage` | Aesthetic strategy mix. |
+| `data-mschf-style` | `collage` \| `structural` \| `playful` \| `auto` | `auto` | Aesthetic strategy mix; `auto` picks a style randomly each load. |
 
 Use `localStorage.setItem('mschf:off','1')` to opt out persistently.
 
 ## Aesthetic Strategies
 
-`collage` (default) fuses four groups: base scaffold, culture-coded ephemera,
-lab/blueprint motifs, and framing stickers. Other styles limit the mix:
+`auto` (default) randomly selects an aesthetic strategy. `collage` fuses four groups: base scaffold, culture-coded ephemera, lab/blueprint motifs, and framing stickers. Other styles limit the mix:
 
 - **structural** – base + lab motifs only.
 - **playful** – base + culture-coded ephemera.

--- a/logs/build-20250827T065325Z.log
+++ b/logs/build-20250827T065325Z.log
@@ -1,0 +1,61 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 build
+> eleventy
+
+🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+🚀 Eleventy build starting with enhanced footnote system...
+/*! 🌼 daisyUI 5.0.50 */
+[PostCSS] Compiled src/styles/app.tailwind.css -> src/assets/css/app.css
+[11ty] Writing ./_site/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing ./_site/feed.xml from ./src/feed.njk
+[11ty/eleventy-img] Processing ./src/assets/static/logo.png (transform)
+[11ty] Writing ./_site/map/index.html from ./src/map.njk
+[11ty] Writing ./_site/404.html from ./src/404.njk
+[11ty] Writing ./_site/archives/index.html from ./src/archives/index.njk
+[11ty] Writing ./_site/work/1/index.html from ./src/work/index.njk
+[11ty] Writing ./_site/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing ./_site/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing ./_site/work/index.html from ./src/work.njk
+[11ty] Writing ./_site/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing ./_site/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing ./_site/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing ./_site/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing ./_site/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing ./_site/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing ./_site/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing ./_site/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing ./_site/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing ./_site/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing ./_site/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing ./_site/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
+[11ty] Writing ./_site/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing ./_site/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing ./_site/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
+[11ty] Writing ./_site/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing ./_site/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing ./_site/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing ./_site/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing ./_site/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing ./_site/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing ./_site/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing ./_site/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing ./_site/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing ./_site/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing ./_site/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing ./_site/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing ./_site/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing ./_site/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing ./_site/work/drop/index.html from ./src/work/drop.11ty.js
+[11ty] Writing ./_site/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing ./_site/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing ./_site/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing ./_site/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing ./_site/work/2/index.html from ./src/work/index.njk
+[11ty] Writing ./_site/index.html from ./src/index.njk
+✅ Eleventy build completed. Generated 48 files.
+[11ty/eleventy-img] 1 image optimized
+[11ty] Copied 11 Wrote 48 files in 18.19 seconds (379.0ms each, v3.1.2)

--- a/logs/test-20250827T065259Z.log
+++ b/logs/test-20250827T065259Z.log
@@ -1,0 +1,250 @@
+🚀 Launching test runner...
+🔍 Found 14 test files.
+
+🏗️  Performing single Eleventy build...
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
+[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
+[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
+[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
+[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
+[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
+[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
+[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
+[11ty] Copied 10 Wrote 48 files in 3.59 seconds (74.9ms each, v3.1.2)
+✅ Eleventy build complete.
+
+🧪 Running 14 tests...
+TAP version 13
+# Subtest: callout merges footnotes into page pipeline
+ok 1 - callout merges footnotes into page pipeline
+  ---
+  duration_ms: 17.335506
+  type: 'test'
+  ...
+# Subtest: defines improved background colors
+ok 2 - defines improved background colors
+  ---
+  duration_ms: 2.251341
+  type: 'test'
+  ...
+# Subtest: text contrast meets WCAG AA
+ok 3 - text contrast meets WCAG AA
+  ---
+  duration_ms: 7.591496
+  type: 'test'
+  ...
+# Subtest: tailwind exposes readable font families
+ok 4 - tailwind exposes readable font families
+  ---
+  duration_ms: 2.260901
+  type: 'test'
+  ...
+# Subtest: includes fluid type scale tokens
+ok 5 - includes fluid type scale tokens
+  ---
+  duration_ms: 0.369838
+  type: 'test'
+  ...
+# Subtest: footnote popover separates source line
+ok 6 - footnote popover separates source line
+  ---
+  duration_ms: 145.19098
+  type: 'test'
+  ...
+# Subtest: projects computed picks latest entries by date
+ok 7 - projects computed picks latest entries by date
+  ---
+  duration_ms: 3.8469
+  type: 'test'
+  ...
+# Subtest: keepalive emits heartbeat to stderr
+ok 8 - keepalive emits heartbeat to stderr
+  ---
+  duration_ms: 6139.496124
+  type: 'test'
+  ...
+# Subtest: keepalive ignores first SIGINT
+ok 9 - keepalive ignores first SIGINT
+  ---
+  duration_ms: 208.256593
+  type: 'test'
+  ...
+# Subtest: gateway reads SOLVER_URL from environment
+ok 10 - gateway reads SOLVER_URL from environment
+  ---
+  duration_ms: 1.525675
+  type: 'test'
+  ...
+# Subtest: gateway retains default solver URL
+ok 11 - gateway retains default solver URL
+  ---
+  duration_ms: 0.342719
+  type: 'test'
+  ...
+# Subtest: external link renders with arrow and class
+ok 12 - external link renders with arrow and class
+  ---
+  duration_ms: 15.347529
+  type: 'test'
+  ...
+# Subtest: internal link keeps text without external markers
+ok 13 - internal link keeps text without external markers
+  ---
+  duration_ms: 1.733699
+  type: 'test'
+  ...
+# Subtest: external link starting with arrow does not duplicate
+ok 14 - external link starting with arrow does not duplicate
+  ---
+  duration_ms: 2.367223
+  type: 'test'
+  ...
+# Subtest: collage style includes base, ephemera, and lab modules
+ok 15 - collage style includes base, ephemera, and lab modules
+  ---
+  duration_ms: 286.454032
+  type: 'test'
+  ...
+# Subtest: auto style selects deterministic variant based on seed
+ok 16 - auto style selects deterministic variant based on seed
+  ---
+  duration_ms: 39.814494
+  type: 'test'
+  ...
+# Subtest: node shim version matches system node
+ok 17 - node shim version matches system node
+  ---
+  duration_ms: 207.450959
+  type: 'test'
+  ...
+# Subtest: node shim is executable
+ok 18 - node shim is executable
+  ---
+  duration_ms: 1.961907
+  type: 'test'
+  ...
+# Subtest: node shim lacks llm-constants reference
+ok 19 - node shim lacks llm-constants reference
+  ---
+  duration_ms: 0.537954
+  type: 'test'
+  ...
+# Subtest: prettier pinned version and format script
+ok 20 - prettier pinned version and format script
+  ---
+  duration_ms: 2.024663
+  type: 'test'
+  ...
+# Subtest: test/unit/pty-runner.test.mjs
+ok 11 - test/unit/pty-runner.test.mjs
+  ---
+  duration_ms: 1314.012295
+  type: 'test'
+  ...
+# Subtest: merges tag-like metadata into unified tags and categories
+ok 22 - merges tag-like metadata into unified tags and categories
+  ---
+  duration_ms: 2.772732
+  type: 'test'
+  ...
+# Subtest: deduplicates tag values
+ok 23 - deduplicates tag values
+  ---
+  duration_ms: 0.991324
+  type: 'test'
+  ...
+# Subtest: categories returns empty array when spark_type absent
+ok 24 - categories returns empty array when spark_type absent
+  ---
+  duration_ms: 0.854618
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles basic single-digit numbers
+ok 25 - ordinalSuffix handles basic single-digit numbers
+  ---
+  duration_ms: 1.390642
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles negative numbers correctly
+ok 26 - ordinalSuffix handles negative numbers correctly
+  ---
+  duration_ms: 0.356111
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix uses "th" for all teen numbers
+ok 27 - ordinalSuffix uses "th" for all teen numbers
+  ---
+  duration_ms: 0.62235
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix returns a valid suffix for all days in a month
+ok 28 - ordinalSuffix returns a valid suffix for all days in a month
+  ---
+  duration_ms: 0.751584
+  type: 'test'
+  ...
+# Subtest: readFileCached returns null for a nonexistent file path
+ok 29 - readFileCached returns null for a nonexistent file path
+  ---
+  duration_ms: 0.767145
+  type: 'test'
+  ...
+# Subtest: GitHub workflows use latest action versions
+ok 30 - GitHub workflows use latest action versions
+  ---
+  duration_ms: 1.767839
+  type: 'test'
+  ...
+1..30
+# tests 30
+# suites 0
+# pass 30
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 7054.864247
+
+✨ All tests passed!

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -102,6 +102,7 @@
   data-mschf="auto"
   data-mschf-intensity="{{ page.mschfIntensity or site.mschfIntensity or 'lite' }}"
   data-mschf-seed-mode="{{ page.mschfSeedMode or site.mschfSeedMode or 'page' }}"
+  data-mschf-style="auto"
   class="bg-base-100 text-base-content font-body antialiased selection:bg-primary/20"
 >
   <a href="#main" class="skip-link">Skip to main content</a>

--- a/src/scripts/mschf-overlay.js
+++ b/src/scripts/mschf-overlay.js
@@ -76,7 +76,11 @@ function initOverlay() {
 
   // Profiles tune density/probabilities per intensity
   const P = profile(intensity);
-  const style = scope.dataset.mschfStyle || 'collage';
+  const styleAttr = scope.dataset.mschfStyle;
+  const style = !styleAttr || styleAttr === 'auto'
+    ? pick(rand, ['collage', 'structural', 'playful'])
+    : styleAttr;
+  root.dataset.mschfStyle = style;
 
   const groups = {
     base() {

--- a/test/unit/mschf-overlay-style.test.mjs
+++ b/test/unit/mschf-overlay-style.test.mjs
@@ -1,4 +1,5 @@
 // test/unit/mschf-overlay-style.test.mjs
+import test from 'node:test';
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
@@ -7,6 +8,7 @@ import { JSDOM } from 'jsdom';
 test('collage style includes base, ephemera, and lab modules', () => {
   const html = `<!doctype html><html><body data-mschf="on" data-mschf-intensity="test" data-mschf-style="collage"></body></html>`;
   const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost' });
+  dom.window.matchMedia = dom.window.matchMedia || (() => ({ matches: false, addListener() {}, removeListener() {} }));
   const scriptPath = path.resolve('src/scripts/mschf-overlay.js');
   dom.window.eval(readFileSync(scriptPath, 'utf8'));
   dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
@@ -22,5 +24,16 @@ test('collage style includes base, ephemera, and lab modules', () => {
       '.mschf-callout, .mschf-graph, .mschf-rings, .mschf-topo, .mschf-halftone, .mschf-crt, .mschf-perf, .mschf-starfield'
     )
   );
+});
+
+test('auto style selects deterministic variant based on seed', () => {
+  const html = `<!doctype html><html><body data-mschf="on" data-mschf-intensity="test" data-mschf-style="auto"></body></html>`;
+  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost/?mschf-seed=1' });
+  dom.window.matchMedia = dom.window.matchMedia || (() => ({ matches: false, addListener() {}, removeListener() {} }));
+  const scriptPath = path.resolve('src/scripts/mschf-overlay.js');
+  dom.window.eval(readFileSync(scriptPath, 'utf8'));
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  const root = dom.window.document.getElementById('mschf-overlay-root');
+  assert.equal(root.dataset.mschfStyle, 'structural');
 });
 


### PR DESCRIPTION
## Summary
- randomize MSCHF overlay style when unspecified
- enable site-wide overlay style auto in base layout
- document and test overlay style auto

## Testing
- `node tools/runner.mjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aea9309c00833098382235f28146a7