### PR TITLE
fix: remove ripgrep-bin to restore npm ci

### DIFF
--- a/artifacts/patches/20250827T072755Z.patch
+++ b/artifacts/patches/20250827T072755Z.patch
@@ -1,0 +1,462 @@
+diff --git a/bin/rg b/bin/rg
+index ed1cf40..2aef9c1 100755
+--- a/bin/rg
++++ b/bin/rg
+@@ -6,7 +6,7 @@ retry_exec "$@" -- \
+   "$REPO_ROOT/node_modules/.bin/rg" \
+   "$REPO_ROOT/node_modules/.bin/ripgrep" \
+   "$TOOLS_DIR/rg/rg" \
+-  rg
++  /usr/bin/rg
+ 
+-echo "❌ ripgrep (rg) not available; ensure devDeps installed or provide a system 'rg'." >&2
++echo "❌ ripgrep (rg) not available; install via package manager or provide a system 'rg'." >&2
+ exit 127
+diff --git a/docs/reports/ripgrep-fix-ledger.md b/docs/reports/ripgrep-fix-ledger.md
+index 28cb3f6..9b6cea9 100644
+--- a/docs/reports/ripgrep-fix-ledger.md
++++ b/docs/reports/ripgrep-fix-ledger.md
+@@ -5,13 +5,16 @@
+ 2. `prepare-docs` script no longer auto-installs ripgrep.
+ 3. README reflects manual ripgrep requirement.
+ 
++4. Remove `ripgrep-bin` dev dependency to avoid build tool requirement.
++
+ ## Proofs
+ - `test/unit/ripgrep.test.mjs` checks absence of `@vscode/ripgrep` and script content.
+ - `docs/knowledge/ripgrep/test-success.log` shows passing tests.
+ - `docs/knowledge/ripgrep/docs-validate.log` records successful docs validation.
++- package.json and package-lock.json omit `ripgrep-bin`.
+ 
+ ## Index
+-3/3 criteria satisfied.
++4/4 criteria satisfied.
+ 
+ ## Delta Queue
+ - none
+diff --git a/logs/build-20250827T072740Z.log b/logs/build-20250827T072740Z.log
+new file mode 100644
+index 0000000..ae0813d
+--- /dev/null
++++ b/logs/build-20250827T072740Z.log
+@@ -0,0 +1,61 @@
++npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
++
++> effusion_labs_final@1.0.0 build
++> eleventy
++
++🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
++🚀 Eleventy build starting with enhanced footnote system...
++/*! 🌼 daisyUI 5.0.50 */
++[PostCSS] Compiled src/styles/app.tailwind.css -> src/assets/css/app.css
++[11ty] Writing ./_site/concept-map.json from ./src/concept-map.json.njk
++[11ty] Writing ./_site/feed.xml from ./src/feed.njk
++[11ty/eleventy-img] Processing ./src/assets/static/logo.png (transform)
++[11ty] Writing ./_site/map/index.html from ./src/map.njk
++[11ty] Writing ./_site/404.html from ./src/404.njk
++[11ty] Writing ./_site/archives/index.html from ./src/archives/index.njk
++[11ty] Writing ./_site/work/1/index.html from ./src/work/index.njk
++[11ty] Writing ./_site/archives/collectables/index.html from ./src/archives/collectables/index.njk
++[11ty] Writing ./_site/meta/index.html from ./src/content/meta/index.njk
++[11ty] Writing ./_site/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
++[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
++[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
++[11ty] Writing ./_site/work/index.html from ./src/work.njk
++[11ty] Writing ./_site/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
++[11ty] Writing ./_site/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
++[11ty] Writing ./_site/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
++[11ty] Writing ./_site/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
++[11ty] Writing ./_site/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
++[11ty] Writing ./_site/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
++[11ty] Writing ./_site/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
++[11ty] Writing ./_site/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
++[11ty] Writing ./_site/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
++[11ty] Writing ./_site/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
++[11ty] Writing ./_site/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
++[11ty] Writing ./_site/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
++[11ty] Writing ./_site/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
++[11ty] Writing ./_site/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
++[11ty] Writing ./_site/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
++[11ty] Writing ./_site/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
++[11ty] Writing ./_site/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
++[11ty] Writing ./_site/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
++[11ty] Writing ./_site/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
++[11ty] Writing ./_site/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
++[11ty] Writing ./_site/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
++[11ty] Writing ./_site/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
++[11ty] Writing ./_site/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
++[11ty] Writing ./_site/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
++[11ty] Writing ./_site/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
++[11ty] Writing ./_site/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
++[11ty] Writing ./_site/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
++[11ty] Writing ./_site/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
++[11ty] Writing ./_site/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
++[11ty] Writing ./_site/work/drop/index.html from ./src/work/drop.11ty.js
++[11ty] Writing ./_site/work/latest/index.html from ./src/work/latest.11ty.js
++[11ty] Writing ./_site/concepts/index.html from ./src/content/concepts/index.njk
++[11ty] Writing ./_site/projects/index.html from ./src/content/projects/index.njk
++[11ty] Writing ./_site/sparks/index.html from ./src/content/sparks/index.njk
++[11ty] Writing ./_site/work/2/index.html from ./src/work/index.njk
++[11ty] Writing ./_site/index.html from ./src/index.njk
++✅ Eleventy build completed. Generated 48 files.
++[11ty/eleventy-img] 1 image optimized
++[11ty] Copied 11 Wrote 48 files in 11.17 seconds (232.6ms each, v3.1.2)
+diff --git a/logs/npm-install-20250827T072740Z.log b/logs/npm-install-20250827T072740Z.log
+new file mode 100644
+index 0000000..69ed553
+--- /dev/null
++++ b/logs/npm-install-20250827T072740Z.log
+@@ -0,0 +1,28 @@
++npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
++npm warn EBADENGINE Unsupported engine {
++npm warn EBADENGINE   package: 'effusion_labs_final@1.0.0',
++npm warn EBADENGINE   required: { node: '>=24' },
++npm warn EBADENGINE   current: { node: 'v22.18.0', npm: '11.4.2' }
++npm warn EBADENGINE }
++
++> effusion_labs_final@1.0.0 postinstall
++> patch-package
++
++patch-package 8.0.0
++Applying patches...
++@photogabble/eleventy-plugin-interlinker@1.1.0 ✔
++
++up to date, audited 928 packages in 2s
++
++203 packages are looking for funding
++  run `npm fund` for details
++
++15 vulnerabilities (4 low, 4 moderate, 3 high, 4 critical)
++
++To address issues that do not require attention, run:
++  npm audit fix
++
++Some issues need review, and may require choosing
++a different dependency.
++
++Run `npm audit` for details.
+diff --git a/logs/npm-prune-20250827T072740Z.log b/logs/npm-prune-20250827T072740Z.log
+new file mode 100644
+index 0000000..44cafb9
+--- /dev/null
++++ b/logs/npm-prune-20250827T072740Z.log
+@@ -0,0 +1,21 @@
++npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
++npm warn EBADENGINE Unsupported engine {
++npm warn EBADENGINE   package: 'effusion_labs_final@1.0.0',
++npm warn EBADENGINE   required: { node: '>=24' },
++npm warn EBADENGINE   current: { node: 'v22.18.0', npm: '11.4.2' }
++npm warn EBADENGINE }
++
++removed 1 package, and audited 928 packages in 1s
++
++203 packages are looking for funding
++  run `npm fund` for details
++
++15 vulnerabilities (4 low, 4 moderate, 3 high, 4 critical)
++
++To address issues that do not require attention, run:
++  npm audit fix
++
++Some issues need review, and may require choosing
++a different dependency.
++
++Run `npm audit` for details.
+diff --git a/logs/test-20250827T072740Z.log b/logs/test-20250827T072740Z.log
+new file mode 100644
+index 0000000..2aa969d
+--- /dev/null
++++ b/logs/test-20250827T072740Z.log
+@@ -0,0 +1,250 @@
++🚀 Launching test runner...
++🔍 Found 14 test files.
++
++🏗️  Performing single Eleventy build...
++npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
++🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
++[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
++[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
++[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
++[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
++[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
++[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
++[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
++[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
++[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
++[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
++[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
++[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
++[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
++[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
++[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
++[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
++[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
++[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
++[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
++[11ty] Copied 11 Wrote 48 files in 2.32 seconds (48.3ms each, v3.1.2)
++✅ Eleventy build complete.
++
++🧪 Running 14 tests...
++TAP version 13
++# Subtest: callout merges footnotes into page pipeline
++ok 1 - callout merges footnotes into page pipeline
++  ---
++  duration_ms: 10.236134
++  type: 'test'
++  ...
++# Subtest: defines improved background colors
++ok 2 - defines improved background colors
++  ---
++  duration_ms: 1.478306
++  type: 'test'
++  ...
++# Subtest: text contrast meets WCAG AA
++ok 3 - text contrast meets WCAG AA
++  ---
++  duration_ms: 6.73166
++  type: 'test'
++  ...
++# Subtest: tailwind exposes readable font families
++ok 4 - tailwind exposes readable font families
++  ---
++  duration_ms: 1.927301
++  type: 'test'
++  ...
++# Subtest: includes fluid type scale tokens
++ok 5 - includes fluid type scale tokens
++  ---
++  duration_ms: 0.230757
++  type: 'test'
++  ...
++# Subtest: footnote popover separates source line
++ok 6 - footnote popover separates source line
++  ---
++  duration_ms: 98.17799
++  type: 'test'
++  ...
++# Subtest: projects computed picks latest entries by date
++ok 7 - projects computed picks latest entries by date
++  ---
++  duration_ms: 1.686981
++  type: 'test'
++  ...
++# Subtest: keepalive emits heartbeat to stderr
++ok 8 - keepalive emits heartbeat to stderr
++  ---
++  duration_ms: 6138.832133
++  type: 'test'
++  ...
++# Subtest: keepalive ignores first SIGINT
++ok 9 - keepalive ignores first SIGINT
++  ---
++  duration_ms: 180.026829
++  type: 'test'
++  ...
++# Subtest: gateway reads SOLVER_URL from environment
++ok 10 - gateway reads SOLVER_URL from environment
++  ---
++  duration_ms: 1.726689
++  type: 'test'
++  ...
++# Subtest: gateway retains default solver URL
++ok 11 - gateway retains default solver URL
++  ---
++  duration_ms: 0.254983
++  type: 'test'
++  ...
++# Subtest: external link renders with arrow and class
++ok 12 - external link renders with arrow and class
++  ---
++  duration_ms: 12.566644
++  type: 'test'
++  ...
++# Subtest: internal link keeps text without external markers
++ok 13 - internal link keeps text without external markers
++  ---
++  duration_ms: 1.287253
++  type: 'test'
++  ...
++# Subtest: external link starting with arrow does not duplicate
++ok 14 - external link starting with arrow does not duplicate
++  ---
++  duration_ms: 1.683168
++  type: 'test'
++  ...
++# Subtest: collage style includes base, ephemera, and lab modules
++ok 15 - collage style includes base, ephemera, and lab modules
++  ---
++  duration_ms: 178.223911
++  type: 'test'
++  ...
++# Subtest: auto style selects deterministic variant based on seed
++ok 16 - auto style selects deterministic variant based on seed
++  ---
++  duration_ms: 28.086267
++  type: 'test'
++  ...
++# Subtest: node shim version matches system node
++ok 17 - node shim version matches system node
++  ---
++  duration_ms: 153.258235
++  type: 'test'
++  ...
++# Subtest: node shim is executable
++ok 18 - node shim is executable
++  ---
++  duration_ms: 0.725624
++  type: 'test'
++  ...
++# Subtest: node shim lacks llm-constants reference
++ok 19 - node shim lacks llm-constants reference
++  ---
++  duration_ms: 0.346976
++  type: 'test'
++  ...
++# Subtest: prettier pinned version and format script
++ok 20 - prettier pinned version and format script
++  ---
++  duration_ms: 1.157506
++  type: 'test'
++  ...
++# Subtest: test/unit/pty-runner.test.mjs
++ok 11 - test/unit/pty-runner.test.mjs
++  ---
++  duration_ms: 919.911174
++  type: 'test'
++  ...
++# Subtest: merges tag-like metadata into unified tags and categories
++ok 22 - merges tag-like metadata into unified tags and categories
++  ---
++  duration_ms: 2.294674
++  type: 'test'
++  ...
++# Subtest: deduplicates tag values
++ok 23 - deduplicates tag values
++  ---
++  duration_ms: 0.338654
++  type: 'test'
++  ...
++# Subtest: categories returns empty array when spark_type absent
++ok 24 - categories returns empty array when spark_type absent
++  ---
++  duration_ms: 0.218552
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix handles basic single-digit numbers
++ok 25 - ordinalSuffix handles basic single-digit numbers
++  ---
++  duration_ms: 1.542372
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix handles negative numbers correctly
++ok 26 - ordinalSuffix handles negative numbers correctly
++  ---
++  duration_ms: 0.256051
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix uses "th" for all teen numbers
++ok 27 - ordinalSuffix uses "th" for all teen numbers
++  ---
++  duration_ms: 0.481436
++  type: 'test'
++  ...
++# Subtest: ordinalSuffix returns a valid suffix for all days in a month
++ok 28 - ordinalSuffix returns a valid suffix for all days in a month
++  ---
++  duration_ms: 0.641807
++  type: 'test'
++  ...
++# Subtest: readFileCached returns null for a nonexistent file path
++ok 29 - readFileCached returns null for a nonexistent file path
++  ---
++  duration_ms: 0.695945
++  type: 'test'
++  ...
++# Subtest: GitHub workflows use latest action versions
++ok 30 - GitHub workflows use latest action versions
++  ---
++  duration_ms: 1.144997
++  type: 'test'
++  ...
++1..30
++# tests 30
++# suites 0
++# pass 30
++# fail 0
++# cancelled 0
++# skipped 0
++# todo 0
++# duration_ms 6845.182861
++
++✨ All tests passed!
+diff --git a/package-lock.json b/package-lock.json
+index e0dde6f..35dd22a 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -53,7 +53,6 @@
+         "postcss-cli": "11.0.1",
+         "prettier": "3.3.3",
+         "proxy-chain": "^2.5.0",
+-        "ripgrep-bin": "13.0.0",
+         "tailwindcss": "4.1.12",
+         "tree-cli": "0.6.7",
+         "yq": "0.0.1"
+@@ -9717,17 +9716,6 @@
+         "url": "https://github.com/sponsors/isaacs"
+       }
+     },
+-    "node_modules/ripgrep-bin": {
+-      "version": "13.0.0",
+-      "resolved": "https://registry.npmjs.org/ripgrep-bin/-/ripgrep-bin-13.0.0.tgz",
+-      "integrity": "sha512-lwFAmnB4ssW3H0RYApOHcViuIfuPiEp2S4vRvpdyKdidfGLrjfESvz8XuIGaFzS24KY+6c8NMmEXgoNdSm8uzw==",
+-      "dev": true,
+-      "hasInstallScript": true,
+-      "license": "MIT",
+-      "bin": {
+-        "ripgrep": "cli.js"
+-      }
+-    },
+     "node_modules/rrweb-cssom": {
+       "version": "0.8.0",
+       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+diff --git a/package.json b/package.json
+index f3f85d2..a9d4b2f 100644
+--- a/package.json
++++ b/package.json
+@@ -71,7 +71,6 @@
+     "postcss-cli": "11.0.1",
+     "prettier": "3.3.3",
+     "proxy-chain": "^2.5.0",
+-    "ripgrep-bin": "13.0.0",
+     "tailwindcss": "4.1.12",
+     "tree-cli": "0.6.7",
+     "yq": "0.0.1"

--- a/bin/rg
+++ b/bin/rg
@@ -6,7 +6,7 @@ retry_exec "$@" -- \
   "$REPO_ROOT/node_modules/.bin/rg" \
   "$REPO_ROOT/node_modules/.bin/ripgrep" \
   "$TOOLS_DIR/rg/rg" \
-  rg
+  /usr/bin/rg
 
-echo "❌ ripgrep (rg) not available; ensure devDeps installed or provide a system 'rg'." >&2
+echo "❌ ripgrep (rg) not available; install via package manager or provide a system 'rg'." >&2
 exit 127

--- a/docs/reports/ripgrep-fix-ledger.md
+++ b/docs/reports/ripgrep-fix-ledger.md
@@ -5,13 +5,16 @@
 2. `prepare-docs` script no longer auto-installs ripgrep.
 3. README reflects manual ripgrep requirement.
 
+4. Remove `ripgrep-bin` dev dependency to avoid build tool requirement.
+
 ## Proofs
 - `test/unit/ripgrep.test.mjs` checks absence of `@vscode/ripgrep` and script content.
 - `docs/knowledge/ripgrep/test-success.log` shows passing tests.
 - `docs/knowledge/ripgrep/docs-validate.log` records successful docs validation.
+- package.json and package-lock.json omit `ripgrep-bin`.
 
 ## Index
-3/3 criteria satisfied.
+4/4 criteria satisfied.
 
 ## Delta Queue
 - none

--- a/logs/build-20250827T072740Z.log
+++ b/logs/build-20250827T072740Z.log
@@ -1,0 +1,61 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> effusion_labs_final@1.0.0 build
+> eleventy
+
+🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+🚀 Eleventy build starting with enhanced footnote system...
+/*! 🌼 daisyUI 5.0.50 */
+[PostCSS] Compiled src/styles/app.tailwind.css -> src/assets/css/app.css
+[11ty] Writing ./_site/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing ./_site/feed.xml from ./src/feed.njk
+[11ty/eleventy-img] Processing ./src/assets/static/logo.png (transform)
+[11ty] Writing ./_site/map/index.html from ./src/map.njk
+[11ty] Writing ./_site/404.html from ./src/404.njk
+[11ty] Writing ./_site/archives/index.html from ./src/archives/index.njk
+[11ty] Writing ./_site/work/1/index.html from ./src/work/index.njk
+[11ty] Writing ./_site/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing ./_site/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing ./_site/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing ./_site/work/index.html from ./src/work.njk
+[11ty] Writing ./_site/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing ./_site/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing ./_site/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing ./_site/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing ./_site/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing ./_site/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing ./_site/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing ./_site/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing ./_site/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing ./_site/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing ./_site/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing ./_site/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
+[11ty] Writing ./_site/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing ./_site/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing ./_site/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
+[11ty] Writing ./_site/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing ./_site/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing ./_site/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing ./_site/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing ./_site/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing ./_site/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing ./_site/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing ./_site/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing ./_site/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing ./_site/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing ./_site/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing ./_site/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing ./_site/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing ./_site/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing ./_site/work/drop/index.html from ./src/work/drop.11ty.js
+[11ty] Writing ./_site/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing ./_site/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing ./_site/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing ./_site/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing ./_site/work/2/index.html from ./src/work/index.njk
+[11ty] Writing ./_site/index.html from ./src/index.njk
+✅ Eleventy build completed. Generated 48 files.
+[11ty/eleventy-img] 1 image optimized
+[11ty] Copied 11 Wrote 48 files in 11.17 seconds (232.6ms each, v3.1.2)

--- a/logs/ci-20250827T072740Z.log
+++ b/logs/ci-20250827T072740Z.log
@@ -1,0 +1,34 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn EBADENGINE Unsupported engine {
+npm warn EBADENGINE   package: 'effusion_labs_final@1.0.0',
+npm warn EBADENGINE   required: { node: '>=24' },
+npm warn EBADENGINE   current: { node: 'v22.18.0', npm: '11.4.2' }
+npm warn EBADENGINE }
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
+npm warn deprecated har-validator@5.1.5: this library is no longer supported
+npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+npm warn deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+npm warn deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
+
+> effusion_labs_final@1.0.0 postinstall
+> patch-package
+
+patch-package 8.0.0
+Applying patches...
+@photogabble/eleventy-plugin-interlinker@1.1.0 ✔
+
+added 927 packages, and audited 928 packages in 11s
+
+203 packages are looking for funding
+  run `npm fund` for details
+
+15 vulnerabilities (4 low, 4 moderate, 3 high, 4 critical)
+
+To address issues that do not require attention, run:
+  npm audit fix
+
+Some issues need review, and may require choosing
+a different dependency.
+
+Run `npm audit` for details.

--- a/logs/npm-install-20250827T072740Z.log
+++ b/logs/npm-install-20250827T072740Z.log
@@ -1,0 +1,28 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn EBADENGINE Unsupported engine {
+npm warn EBADENGINE   package: 'effusion_labs_final@1.0.0',
+npm warn EBADENGINE   required: { node: '>=24' },
+npm warn EBADENGINE   current: { node: 'v22.18.0', npm: '11.4.2' }
+npm warn EBADENGINE }
+
+> effusion_labs_final@1.0.0 postinstall
+> patch-package
+
+patch-package 8.0.0
+Applying patches...
+@photogabble/eleventy-plugin-interlinker@1.1.0 ✔
+
+up to date, audited 928 packages in 2s
+
+203 packages are looking for funding
+  run `npm fund` for details
+
+15 vulnerabilities (4 low, 4 moderate, 3 high, 4 critical)
+
+To address issues that do not require attention, run:
+  npm audit fix
+
+Some issues need review, and may require choosing
+a different dependency.
+
+Run `npm audit` for details.

--- a/logs/npm-prune-20250827T072740Z.log
+++ b/logs/npm-prune-20250827T072740Z.log
@@ -1,0 +1,21 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn EBADENGINE Unsupported engine {
+npm warn EBADENGINE   package: 'effusion_labs_final@1.0.0',
+npm warn EBADENGINE   required: { node: '>=24' },
+npm warn EBADENGINE   current: { node: 'v22.18.0', npm: '11.4.2' }
+npm warn EBADENGINE }
+
+removed 1 package, and audited 928 packages in 1s
+
+203 packages are looking for funding
+  run `npm fund` for details
+
+15 vulnerabilities (4 low, 4 moderate, 3 high, 4 critical)
+
+To address issues that do not require attention, run:
+  npm audit fix
+
+Some issues need review, and may require choosing
+a different dependency.
+
+Run `npm audit` for details.

--- a/logs/test-20250827T072740Z.log
+++ b/logs/test-20250827T072740Z.log
@@ -1,0 +1,250 @@
+🚀 Launching test runner...
+🔍 Found 14 test files.
+
+🏗️  Performing single Eleventy build...
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
+[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
+[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
+[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
+[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
+[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
+[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
+[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
+[11ty] Copied 11 Wrote 48 files in 2.32 seconds (48.3ms each, v3.1.2)
+✅ Eleventy build complete.
+
+🧪 Running 14 tests...
+TAP version 13
+# Subtest: callout merges footnotes into page pipeline
+ok 1 - callout merges footnotes into page pipeline
+  ---
+  duration_ms: 10.236134
+  type: 'test'
+  ...
+# Subtest: defines improved background colors
+ok 2 - defines improved background colors
+  ---
+  duration_ms: 1.478306
+  type: 'test'
+  ...
+# Subtest: text contrast meets WCAG AA
+ok 3 - text contrast meets WCAG AA
+  ---
+  duration_ms: 6.73166
+  type: 'test'
+  ...
+# Subtest: tailwind exposes readable font families
+ok 4 - tailwind exposes readable font families
+  ---
+  duration_ms: 1.927301
+  type: 'test'
+  ...
+# Subtest: includes fluid type scale tokens
+ok 5 - includes fluid type scale tokens
+  ---
+  duration_ms: 0.230757
+  type: 'test'
+  ...
+# Subtest: footnote popover separates source line
+ok 6 - footnote popover separates source line
+  ---
+  duration_ms: 98.17799
+  type: 'test'
+  ...
+# Subtest: projects computed picks latest entries by date
+ok 7 - projects computed picks latest entries by date
+  ---
+  duration_ms: 1.686981
+  type: 'test'
+  ...
+# Subtest: keepalive emits heartbeat to stderr
+ok 8 - keepalive emits heartbeat to stderr
+  ---
+  duration_ms: 6138.832133
+  type: 'test'
+  ...
+# Subtest: keepalive ignores first SIGINT
+ok 9 - keepalive ignores first SIGINT
+  ---
+  duration_ms: 180.026829
+  type: 'test'
+  ...
+# Subtest: gateway reads SOLVER_URL from environment
+ok 10 - gateway reads SOLVER_URL from environment
+  ---
+  duration_ms: 1.726689
+  type: 'test'
+  ...
+# Subtest: gateway retains default solver URL
+ok 11 - gateway retains default solver URL
+  ---
+  duration_ms: 0.254983
+  type: 'test'
+  ...
+# Subtest: external link renders with arrow and class
+ok 12 - external link renders with arrow and class
+  ---
+  duration_ms: 12.566644
+  type: 'test'
+  ...
+# Subtest: internal link keeps text without external markers
+ok 13 - internal link keeps text without external markers
+  ---
+  duration_ms: 1.287253
+  type: 'test'
+  ...
+# Subtest: external link starting with arrow does not duplicate
+ok 14 - external link starting with arrow does not duplicate
+  ---
+  duration_ms: 1.683168
+  type: 'test'
+  ...
+# Subtest: collage style includes base, ephemera, and lab modules
+ok 15 - collage style includes base, ephemera, and lab modules
+  ---
+  duration_ms: 178.223911
+  type: 'test'
+  ...
+# Subtest: auto style selects deterministic variant based on seed
+ok 16 - auto style selects deterministic variant based on seed
+  ---
+  duration_ms: 28.086267
+  type: 'test'
+  ...
+# Subtest: node shim version matches system node
+ok 17 - node shim version matches system node
+  ---
+  duration_ms: 153.258235
+  type: 'test'
+  ...
+# Subtest: node shim is executable
+ok 18 - node shim is executable
+  ---
+  duration_ms: 0.725624
+  type: 'test'
+  ...
+# Subtest: node shim lacks llm-constants reference
+ok 19 - node shim lacks llm-constants reference
+  ---
+  duration_ms: 0.346976
+  type: 'test'
+  ...
+# Subtest: prettier pinned version and format script
+ok 20 - prettier pinned version and format script
+  ---
+  duration_ms: 1.157506
+  type: 'test'
+  ...
+# Subtest: test/unit/pty-runner.test.mjs
+ok 11 - test/unit/pty-runner.test.mjs
+  ---
+  duration_ms: 919.911174
+  type: 'test'
+  ...
+# Subtest: merges tag-like metadata into unified tags and categories
+ok 22 - merges tag-like metadata into unified tags and categories
+  ---
+  duration_ms: 2.294674
+  type: 'test'
+  ...
+# Subtest: deduplicates tag values
+ok 23 - deduplicates tag values
+  ---
+  duration_ms: 0.338654
+  type: 'test'
+  ...
+# Subtest: categories returns empty array when spark_type absent
+ok 24 - categories returns empty array when spark_type absent
+  ---
+  duration_ms: 0.218552
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles basic single-digit numbers
+ok 25 - ordinalSuffix handles basic single-digit numbers
+  ---
+  duration_ms: 1.542372
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles negative numbers correctly
+ok 26 - ordinalSuffix handles negative numbers correctly
+  ---
+  duration_ms: 0.256051
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix uses "th" for all teen numbers
+ok 27 - ordinalSuffix uses "th" for all teen numbers
+  ---
+  duration_ms: 0.481436
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix returns a valid suffix for all days in a month
+ok 28 - ordinalSuffix returns a valid suffix for all days in a month
+  ---
+  duration_ms: 0.641807
+  type: 'test'
+  ...
+# Subtest: readFileCached returns null for a nonexistent file path
+ok 29 - readFileCached returns null for a nonexistent file path
+  ---
+  duration_ms: 0.695945
+  type: 'test'
+  ...
+# Subtest: GitHub workflows use latest action versions
+ok 30 - GitHub workflows use latest action versions
+  ---
+  duration_ms: 1.144997
+  type: 'test'
+  ...
+1..30
+# tests 30
+# suites 0
+# pass 30
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 6845.182861
+
+✨ All tests passed!

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "postcss-cli": "11.0.1",
         "prettier": "3.3.3",
         "proxy-chain": "^2.5.0",
-        "ripgrep-bin": "13.0.0",
         "tailwindcss": "4.1.12",
         "tree-cli": "0.6.7",
         "yq": "0.0.1"
@@ -9715,17 +9714,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ripgrep-bin": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/ripgrep-bin/-/ripgrep-bin-13.0.0.tgz",
-      "integrity": "sha512-lwFAmnB4ssW3H0RYApOHcViuIfuPiEp2S4vRvpdyKdidfGLrjfESvz8XuIGaFzS24KY+6c8NMmEXgoNdSm8uzw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "ripgrep": "cli.js"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "postcss-cli": "11.0.1",
     "prettier": "3.3.3",
     "proxy-chain": "^2.5.0",
-    "ripgrep-bin": "13.0.0",
     "tailwindcss": "4.1.12",
     "tree-cli": "0.6.7",
     "yq": "0.0.1"


### PR DESCRIPTION
## Summary
- remove `ripgrep-bin` dev dependency and adjust `bin/rg` to use system ripgrep
- update ripgrep ledger docs

## Testing
- `npm ci`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeb1cf08208330bdce4f1a72b1c173