### PR TITLE
feat: render HTML in hero tiles

### DIFF
--- a/artifacts/patches/20250827T075442Z.patch
+++ b/artifacts/patches/20250827T075442Z.patch
@@ -1,0 +1,20 @@
+diff --git a/logs/test-20250827T075442Z.log b/logs/test-20250827T075442Z.log
+new file mode 100644
+index 0000000..e69de29
+diff --git a/src/_includes/components/hero-tile.njk b/src/_includes/components/hero-tile.njk
+index c01c91c..e08a983 100644
+--- a/src/_includes/components/hero-tile.njk
++++ b/src/_includes/components/hero-tile.njk
+@@ -10,8 +10,8 @@
+          {% endif %}
+          hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus-visible:ring focus-visible:ring-primary/40 p-6 text-left"
+ >
+-  <span class="badge badge-ghost badge-xs uppercase tracking-wider">{{ type }}</span>
+-  <h3 class="mt-2 font-heading text-lg text-base-content group-hover:text-primary transition-colors">{{ title }}</h3>
+-  <p class="text-sm text-base-content/90">{{ description }}</p>
++  <span class="badge badge-ghost badge-xs uppercase tracking-wider">{{ type | safe }}</span>
++  <h3 class="mt-2 font-heading text-lg text-base-content group-hover:text-primary transition-colors">{{ title | safe }}</h3>
++  <p class="text-sm text-base-content/90">{{ description | safe }}</p>
+ </a>
+ {%- endmacro %}
+\ No newline at end of file

--- a/src/_includes/components/hero-tile.njk
+++ b/src/_includes/components/hero-tile.njk
@@ -10,8 +10,8 @@
          {% endif %}
          hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus-visible:ring focus-visible:ring-primary/40 p-6 text-left"
 >
-  <span class="badge badge-ghost badge-xs uppercase tracking-wider">{{ type }}</span>
-  <h3 class="mt-2 font-heading text-lg text-base-content group-hover:text-primary transition-colors">{{ title }}</h3>
-  <p class="text-sm text-base-content/90">{{ description }}</p>
+  <span class="badge badge-ghost badge-xs uppercase tracking-wider">{{ type | safe }}</span>
+  <h3 class="mt-2 font-heading text-lg text-base-content group-hover:text-primary transition-colors">{{ title | safe }}</h3>
+  <p class="text-sm text-base-content/90">{{ description | safe }}</p>
 </a>
 {%- endmacro %}


### PR DESCRIPTION
## Summary
- ensure hero tile content allows HTML so headings and descriptions render properly
- add patch artifact for traceability

## Testing
- `npm test` *(fails: guard stopped the command)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb98954d88330b60ca19b72c85a73