### PR TITLE
fix: adapt Pixi blend modes for v8

### DIFF
--- a/artifacts/patches/20250827T210413Z.patch
+++ b/artifacts/patches/20250827T210413Z.patch
@@ -1,0 +1,31 @@
+diff --git a/src/scripts/mschf-overlay.js b/src/scripts/mschf-overlay.js
+index 0eb5658..f0baf7a 100644
+--- a/src/scripts/mschf-overlay.js
++++ b/src/scripts/mschf-overlay.js
+@@ -247,7 +247,7 @@
+       function draw(cx, cy, baseR, color) {
+         g.clear();
+         g.alpha = .15;
+-        g.blendMode = PIXI.BLEND_MODES.ADD;
++        g.blendMode = PIXI.BLEND_MODES?.ADD ?? 'add';
+         g.lineStyle(1, color, 1);
+         for (let i=0;i<3;i++) g.drawCircle(cx, cy, baseR + i*baseR*.33);
+         g.endFill();
+@@ -271,7 +271,7 @@
+       const g = new PIXI.Graphics(); container.addChild(g);
+ 
+       function draw(){
+-        g.clear(); g.blendMode = PIXI.BLEND_MODES.SCREEN;
++        g.clear(); g.blendMode = PIXI.BLEND_MODES?.SCREEN ?? 'screen';
+         const w = innerWidth, h = innerHeight;
+         const lines = 18;
+         for (let i=0;i<lines;i++){
+@@ -295,7 +295,7 @@
+ 
+     makeStars(PIXI) {
+       const container = new PIXI.Container(); container.alpha = .12;
+-      container.blendMode = PIXI.BLEND_MODES.SCREEN;
++      container.blendMode = PIXI.BLEND_MODES?.SCREEN ?? 'screen';
+       const starTex = PIXI.Texture.WHITE;
+       const sprites = [];
+ 

--- a/logs/test-20250827T210413Z.log
+++ b/logs/test-20250827T210413Z.log
@@ -1,0 +1,54 @@
+🚀 Launching test runner...
+🔍 Found 14 test files.
+
+🏗️  Performing single Eleventy build...
+🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
+[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
+[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
+[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
+[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
+[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
+[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
+[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
+[11ty] Copied 10 Wrote 48 files in 3.00 seconds (62.5ms each, v3.1.2)

--- a/src/scripts/mschf-overlay.js
+++ b/src/scripts/mschf-overlay.js
@@ -247,7 +247,7 @@
       function draw(cx, cy, baseR, color) {
         g.clear();
         g.alpha = .15;
-        g.blendMode = PIXI.BLEND_MODES.ADD;
+        g.blendMode = PIXI.BLEND_MODES?.ADD ?? 'add';
         g.lineStyle(1, color, 1);
         for (let i=0;i<3;i++) g.drawCircle(cx, cy, baseR + i*baseR*.33);
         g.endFill();
@@ -271,7 +271,7 @@
       const g = new PIXI.Graphics(); container.addChild(g);
 
       function draw(){
-        g.clear(); g.blendMode = PIXI.BLEND_MODES.SCREEN;
+        g.clear(); g.blendMode = PIXI.BLEND_MODES?.SCREEN ?? 'screen';
         const w = innerWidth, h = innerHeight;
         const lines = 18;
         for (let i=0;i<lines;i++){
@@ -295,7 +295,7 @@
 
     makeStars(PIXI) {
       const container = new PIXI.Container(); container.alpha = .12;
-      container.blendMode = PIXI.BLEND_MODES.SCREEN;
+      container.blendMode = PIXI.BLEND_MODES?.SCREEN ?? 'screen';
       const starTex = PIXI.Texture.WHITE;
       const sprites = [];
 


### PR DESCRIPTION
## Summary
- handle PixiJS v8 by falling back to string-based blend modes
- record test run

## Testing
- `node tools/runner.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68af7194795c8330bedd776d7d9fe33c