### PR TITLE
fix: normalize Pixi blend modes

### DIFF
--- a/artifacts/patches/20250827T223938Z.patch
+++ b/artifacts/patches/20250827T223938Z.patch
@@ -1,0 +1,44 @@
+diff --git a/src/scripts/mschf-overlay.js b/src/scripts/mschf-overlay.js
+index 0eb5658..915218d 100644
+--- a/src/scripts/mschf-overlay.js
++++ b/src/scripts/mschf-overlay.js
+@@ -42,6 +42,12 @@
+     return null;
+   }
+ 
++  // Resolve blend modes across Pixi versions
++  function resolveBlend(PIXI, name) {
++    const map = PIXI?.BLEND_MODES;
++    return map && map[name] !== undefined ? map[name] : name.toLowerCase().replace(/_/g, '-');
++  }
++
+   // ————————————————————————————————————————
+   // Global State
+   // ————————————————————————————————————————
+@@ -247,7 +253,7 @@
+       function draw(cx, cy, baseR, color) {
+         g.clear();
+         g.alpha = .15;
+-        g.blendMode = PIXI.BLEND_MODES.ADD;
++        g.blendMode = resolveBlend(PIXI,'ADD');
+         g.lineStyle(1, color, 1);
+         for (let i=0;i<3;i++) g.drawCircle(cx, cy, baseR + i*baseR*.33);
+         g.endFill();
+@@ -271,7 +277,7 @@
+       const g = new PIXI.Graphics(); container.addChild(g);
+ 
+       function draw(){
+-        g.clear(); g.blendMode = PIXI.BLEND_MODES.SCREEN;
++        g.clear(); g.blendMode = resolveBlend(PIXI,'SCREEN');
+         const w = innerWidth, h = innerHeight;
+         const lines = 18;
+         for (let i=0;i<lines;i++){
+@@ -295,7 +301,7 @@
+ 
+     makeStars(PIXI) {
+       const container = new PIXI.Container(); container.alpha = .12;
+-      container.blendMode = PIXI.BLEND_MODES.SCREEN;
++      container.blendMode = resolveBlend(PIXI,'SCREEN');
+       const starTex = PIXI.Texture.WHITE;
+       const sprites = [];
+ 

--- a/artifacts/worklogs/20250827T223954Z.md
+++ b/artifacts/worklogs/20250827T223954Z.md
@@ -1,0 +1,4 @@
+- Added resolveBlend helper to map PixiJS blend mode constants to string fallbacks per v8 docs.
+- Updated ring, topo, and starfield rendering to use resolveBlend instead of PIXI.BLEND_MODES.*
+- Tests run via node tools/runner.mjs; two overlay style tests failing (mschf-grid missing and seed-based variant).
+- Patch snapshot and test log saved.

--- a/logs/test-20250827T223910Z.log
+++ b/logs/test-20250827T223910Z.log
@@ -1,0 +1,365 @@
+🚀 Launching test runner...
+🔍 Found 14 test files.
+
+🏗️  Performing single Eleventy build...
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+🗂  Archives loaded from "src/content/archives": 88 items (44 products, 4 characters, 40 series)
+[11ty] Writing /tmp/eleventy-build/concept-map.json from ./src/concept-map.json.njk
+[11ty] Writing /tmp/eleventy-build/feed.xml from ./src/feed.njk
+[11ty] Writing /tmp/eleventy-build/map/index.html from ./src/map.njk
+[11ty] Writing /tmp/eleventy-build/404.html from ./src/404.njk
+[11ty] Writing /tmp/eleventy-build/archives/index.html from ./src/archives/index.njk
+[11ty] Writing /tmp/eleventy-build/work/1/index.html from ./src/work/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/index.html from ./src/archives/collectables/index.njk
+[11ty] Writing /tmp/eleventy-build/meta/index.html from ./src/content/meta/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/index.html from ./src/archives/collectables/designer-toys/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/index.html from ./src/archives/collectables/designer-toys/pop-mart/index.njk
+[11ty] Writing /tmp/eleventy-build/archives/collectables/designer-toys/pop-mart/the-monsters/index.html from ./src/archives/collectables/designer-toys/pop-mart/the-monsters/index.njk
+[11ty] Writing /tmp/eleventy-build/index.html from ./src/index.njk
+[11ty] Writing /tmp/eleventy-build/work/index.html from ./src/work.njk
+[11ty] Writing /tmp/eleventy-build/content/concepts/aesthetic-inquiry/index.html from ./src/content/concepts/aesthetic-inquiry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/atlas-process/index.html from ./src/content/concepts/atlas-process.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/autocatalytic-system/index.html from ./src/content/concepts/autocatalytic-system.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/block-ledger/index.html from ./src/content/concepts/block-ledger.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/compliant-spire/index.html from ./src/content/concepts/compliant-spire.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-byline/index.html from ./src/content/concepts/ghost-byline.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/ghost-engine/index.html from ./src/content/concepts/ghost-engine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/parroting-mimicry/index.html from ./src/content/concepts/parroting-mimicry.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/readers-journey/index.html from ./src/content/concepts/readers-journey.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/rhizomatic-protocol/index.html from ./src/content/concepts/rhizomatic-protocol.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/three-studies-sensory/index.html from ./src/content/concepts/three-studies-sensory.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/verification-is-an-ecology/index.html from ./src/content/concepts/verification-is-an-ecology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/concepts/workshop-weather/index.html from ./src/content/concepts/workshop-weather.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/a-b-curatorial-protocolist/index.html from ./src/content/meta/a-b-curatorial-protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/core-concept/index.html from ./src/content/meta/core-concept.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/curatorial-generativism/index.html from ./src/content/meta/curatorial-generativism.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/methodology/index.html from ./src/content/meta/methodology.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/protocolist/index.html from ./src/content/meta/protocolist.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/style-guide/index.html from ./src/content/meta/style-guide.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/meta/unified-referencing-syntax/index.html from ./src/content/meta/unified-referencing-syntax.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/projects/project-dandelion/index.html from ./src/content/projects/project-dandelion.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/academic-blindness/index.html from ./src/content/sparks/academic-blindness.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/breakfast-eggs/index.html from ./src/content/sparks/breakfast-eggs.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/george-eastman-obscure/index.html from ./src/content/sparks/george-eastman-obscure.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/illusion-japan-nicotine/index.html from ./src/content/sparks/illusion-japan-nicotine.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/murakami-market-analysis-2025/index.html from ./src/content/sparks/murakami-market-analysis-2025.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/paulin-paulin-paulin-marketing/index.html from ./src/content/sparks/paulin-paulin-paulin-marketing.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/smoker-sysadmin/index.html from ./src/content/sparks/smoker-sysadmin.md (njk)
+[11ty] Writing /tmp/eleventy-build/content/sparks/vapor-linked-governance/index.html from ./src/content/sparks/vapor-linked-governance.md (njk)
+[11ty] Writing /tmp/eleventy-build/work/drop/index.html from ./src/work/drop.11ty.js
+[11ty] Writing /tmp/eleventy-build/work/latest/index.html from ./src/work/latest.11ty.js
+[11ty] Writing /tmp/eleventy-build/concepts/index.html from ./src/content/concepts/index.njk
+[11ty] Writing /tmp/eleventy-build/projects/index.html from ./src/content/projects/index.njk
+[11ty] Writing /tmp/eleventy-build/sparks/index.html from ./src/content/sparks/index.njk
+[11ty] Writing /tmp/eleventy-build/work/2/index.html from ./src/work/index.njk
+[11ty] Copied 10 Wrote 48 files in 2.29 seconds (47.7ms each, v3.1.2)
+✅ Eleventy build complete.
+
+🧪 Running 14 tests...
+TAP version 13
+# Subtest: callout merges footnotes into page pipeline
+ok 1 - callout merges footnotes into page pipeline
+  ---
+  duration_ms: 11.40444
+  type: 'test'
+  ...
+# Subtest: defines improved background colors
+ok 2 - defines improved background colors
+  ---
+  duration_ms: 1.85899
+  type: 'test'
+  ...
+# Subtest: text contrast meets WCAG AA
+ok 3 - text contrast meets WCAG AA
+  ---
+  duration_ms: 5.905627
+  type: 'test'
+  ...
+# Subtest: tailwind exposes readable font families
+ok 4 - tailwind exposes readable font families
+  ---
+  duration_ms: 0.719644
+  type: 'test'
+  ...
+# Subtest: includes fluid type scale tokens
+ok 5 - includes fluid type scale tokens
+  ---
+  duration_ms: 0.313661
+  type: 'test'
+  ...
+# Subtest: footnote popover separates source line
+ok 6 - footnote popover separates source line
+  ---
+  duration_ms: 100.397054
+  type: 'test'
+  ...
+# Subtest: projects computed picks latest entries by date
+ok 7 - projects computed picks latest entries by date
+  ---
+  duration_ms: 2.393395
+  type: 'test'
+  ...
+# Subtest: keepalive emits heartbeat to stderr
+ok 8 - keepalive emits heartbeat to stderr
+  ---
+  duration_ms: 6089.827791
+  type: 'test'
+  ...
+# Subtest: keepalive ignores first SIGINT
+ok 9 - keepalive ignores first SIGINT
+  ---
+  duration_ms: 193.586736
+  type: 'test'
+  ...
+# Subtest: gateway reads SOLVER_URL from environment
+ok 10 - gateway reads SOLVER_URL from environment
+  ---
+  duration_ms: 1.37936
+  type: 'test'
+  ...
+# Subtest: gateway retains default solver URL
+ok 11 - gateway retains default solver URL
+  ---
+  duration_ms: 0.213969
+  type: 'test'
+  ...
+# Subtest: external link renders with arrow and class
+ok 12 - external link renders with arrow and class
+  ---
+  duration_ms: 9.213861
+  type: 'test'
+  ...
+# Subtest: internal link keeps text without external markers
+ok 13 - internal link keeps text without external markers
+  ---
+  duration_ms: 2.089005
+  type: 'test'
+  ...
+# Subtest: external link starting with arrow does not duplicate
+ok 14 - external link starting with arrow does not duplicate
+  ---
+  duration_ms: 1.618509
+  type: 'test'
+  ...
+# Error: Uncaught [ReferenceError: requestAnimationFrame is not defined]
+#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:19:23)
+#     at Test.runInAsyncScope (node:async_hooks:214:14)
+#     at Test.run (node:internal/test_runner/test:1047:25)
+#     at Test.start (node:internal/test_runner/test:944:17) ReferenceError: requestAnimationFrame is not defined
+#     at Document.eval (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:18:14), <anonymous>:781:60)
+#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:19:23)
+#     at Test.runInAsyncScope (node:async_hooks:214:14)
+#     at Test.run (node:internal/test_runner/test:1047:25)
+# Error: Uncaught [ReferenceError: requestAnimationFrame is not defined]
+#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
+#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
+#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
+#     at new Promise (<anonymous>)
+#     at onDOMContentLoad (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:523:14)
+#     at Object.check (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:76:23) ReferenceError: requestAnimationFrame is not defined
+#     at Document.eval (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:18:14), <anonymous>:781:60)
+#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
+#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
+#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
+#     at new Promise (<anonymous>)
+#     at onDOMContentLoad (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:523:14)
+# Error: Uncaught [ReferenceError: requestAnimationFrame is not defined]
+#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:45:23)
+#     at Test.runInAsyncScope (node:async_hooks:214:14)
+#     at Test.run (node:internal/test_runner/test:1047:25)
+#     at Test.processPendingSubtests (node:internal/test_runner/test:744:18) ReferenceError: requestAnimationFrame is not defined
+#     at Document.eval (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:44:14), <anonymous>:781:60)
+#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at DocumentImpl.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+#     at Document.dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+#     at TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:45:23)
+#     at Test.runInAsyncScope (node:async_hooks:214:14)
+#     at Test.run (node:internal/test_runner/test:1047:25)
+# Error: Uncaught [ReferenceError: requestAnimationFrame is not defined]
+#     at reportException (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
+#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
+#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
+#     at new Promise (<anonymous>)
+#     at onDOMContentLoad (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:523:14)
+#     at Object.check (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:76:23) ReferenceError: requestAnimationFrame is not defined
+#     at Document.eval (eval at <anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:44:14), <anonymous>:781:60)
+#     at Document.callTheUserObjectsOperation (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
+#     at innerInvokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
+#     at invokeEventListeners (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+#     at DocumentImpl._dispatch (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+#     at fireAnEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
+#     at dispatchEvent (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:520:9)
+#     at /workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:525:11
+#     at new Promise (<anonymous>)
+#     at onDOMContentLoad (/workspace/effusion-labs/node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:523:14)
+# Subtest: collage style includes base, ephemera, and lab modules
+not ok 15 - collage style includes base, ephemera, and lab modules
+  ---
+  duration_ms: 83.431049
+  type: 'test'
+  location: '/workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:8:1'
+  failureType: 'testCodeFailure'
+  error: |-
+    The expression evaluated to a falsy value:
+    
+      assert.ok(doc.querySelector('.mschf-grid'))
+    
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: true
+  actual: ~
+  operator: '=='
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:22:10)
+    Test.runInAsyncScope (node:async_hooks:214:14)
+    Test.run (node:internal/test_runner/test:1047:25)
+    Test.start (node:internal/test_runner/test:944:17)
+    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
+  ...
+# Subtest: auto style selects deterministic variant based on seed
+not ok 16 - auto style selects deterministic variant based on seed
+  ---
+  duration_ms: 15.970417
+  type: 'test'
+  location: '/workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:36:1'
+  failureType: 'testCodeFailure'
+  error: "Cannot read properties of null (reading 'dataset')"
+  code: 'ERR_TEST_FAILURE'
+  name: 'TypeError'
+  stack: |-
+    TestContext.<anonymous> (file:///workspace/effusion-labs/test/unit/mschf-overlay-style.test.mjs:47:21)
+    Test.runInAsyncScope (node:async_hooks:214:14)
+    Test.run (node:internal/test_runner/test:1047:25)
+    Test.processPendingSubtests (node:internal/test_runner/test:744:18)
+    Test.postRun (node:internal/test_runner/test:1173:19)
+    Test.run (node:internal/test_runner/test:1101:12)
+    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)
+  ...
+# Subtest: node shim version matches system node
+ok 17 - node shim version matches system node
+  ---
+  duration_ms: 136.770552
+  type: 'test'
+  ...
+# Subtest: node shim is executable
+ok 18 - node shim is executable
+  ---
+  duration_ms: 0.655469
+  type: 'test'
+  ...
+# Subtest: node shim lacks llm-constants reference
+ok 19 - node shim lacks llm-constants reference
+  ---
+  duration_ms: 0.312692
+  type: 'test'
+  ...
+# Subtest: prettier pinned version and format script
+ok 20 - prettier pinned version and format script
+  ---
+  duration_ms: 1.060109
+  type: 'test'
+  ...
+# Subtest: test/unit/pty-runner.test.mjs
+ok 11 - test/unit/pty-runner.test.mjs
+  ---
+  duration_ms: 835.175004
+  type: 'test'
+  ...
+# Subtest: merges tag-like metadata into unified tags and categories
+ok 22 - merges tag-like metadata into unified tags and categories
+  ---
+  duration_ms: 2.212769
+  type: 'test'
+  ...
+# Subtest: deduplicates tag values
+ok 23 - deduplicates tag values
+  ---
+  duration_ms: 0.252384
+  type: 'test'
+  ...
+# Subtest: categories returns empty array when spark_type absent
+ok 24 - categories returns empty array when spark_type absent
+  ---
+  duration_ms: 0.316523
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles basic single-digit numbers
+ok 25 - ordinalSuffix handles basic single-digit numbers
+  ---
+  duration_ms: 1.344586
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix handles negative numbers correctly
+ok 26 - ordinalSuffix handles negative numbers correctly
+  ---
+  duration_ms: 0.277493
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix uses "th" for all teen numbers
+ok 27 - ordinalSuffix uses "th" for all teen numbers
+  ---
+  duration_ms: 0.407423
+  type: 'test'
+  ...
+# Subtest: ordinalSuffix returns a valid suffix for all days in a month
+ok 28 - ordinalSuffix returns a valid suffix for all days in a month
+  ---
+  duration_ms: 0.616966
+  type: 'test'
+  ...
+# Subtest: readFileCached returns null for a nonexistent file path
+ok 29 - readFileCached returns null for a nonexistent file path
+  ---
+  duration_ms: 0.706954
+  type: 'test'
+  ...
+# Subtest: GitHub workflows use latest action versions
+ok 30 - GitHub workflows use latest action versions
+  ---
+  duration_ms: 1.49815
+  type: 'test'
+  ...
+1..30
+# tests 30
+# suites 0
+# pass 28
+# fail 2
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 6763.400599
+
+🔥 Tests failed with exit code 1

--- a/src/scripts/mschf-overlay.js
+++ b/src/scripts/mschf-overlay.js
@@ -42,6 +42,12 @@
     return null;
   }
 
+  // Resolve blend modes across Pixi versions
+  function resolveBlend(PIXI, name) {
+    const map = PIXI?.BLEND_MODES;
+    return map && map[name] !== undefined ? map[name] : name.toLowerCase().replace(/_/g, '-');
+  }
+
   // ————————————————————————————————————————
   // Global State
   // ————————————————————————————————————————
@@ -247,7 +253,7 @@
       function draw(cx, cy, baseR, color) {
         g.clear();
         g.alpha = .15;
-        g.blendMode = PIXI.BLEND_MODES.ADD;
+        g.blendMode = resolveBlend(PIXI,'ADD');
         g.lineStyle(1, color, 1);
         for (let i=0;i<3;i++) g.drawCircle(cx, cy, baseR + i*baseR*.33);
         g.endFill();
@@ -271,7 +277,7 @@
       const g = new PIXI.Graphics(); container.addChild(g);
 
       function draw(){
-        g.clear(); g.blendMode = PIXI.BLEND_MODES.SCREEN;
+        g.clear(); g.blendMode = resolveBlend(PIXI,'SCREEN');
         const w = innerWidth, h = innerHeight;
         const lines = 18;
         for (let i=0;i<lines;i++){
@@ -295,7 +301,7 @@
 
     makeStars(PIXI) {
       const container = new PIXI.Container(); container.alpha = .12;
-      container.blendMode = PIXI.BLEND_MODES.SCREEN;
+      container.blendMode = resolveBlend(PIXI,'SCREEN');
       const starTex = PIXI.Texture.WHITE;
       const sprites = [];
 


### PR DESCRIPTION
## Summary
- wrap blend-mode lookups to support PixiJS v8 string enums
- record test run

## Testing
- `npm run build`
- `node tools/validate-docs.js`
- `npm run dead-links`
- `node tools/runner.mjs` *(fails: collage style includes base, ephemera, and lab modules; auto style selects deterministic variant based on seed)*

------
https://chatgpt.com/codex/tasks/task_e_68af7194795c8330bedd776d7d9fe33c