### PR TITLE
feat(layout): add hero band ring toggle

### DIFF
--- a/artifacts/reports/20250902T095354Z.md
+++ b/artifacts/reports/20250902T095354Z.md
@@ -1,0 +1,59 @@
+HEADER
+Summary: Removed static spectral rings from hero band and added toggle.
+Tags: Scope=S2 • Approach=A2 • Novelty=N2 • Skin=K1
+Diff: 4 files changed, 67 insertions(+), 1 deletion(-)
+Files: src/_data/site.json, src/_includes/layout.njk, artifacts/worklogs/20250902T095354Z.md, artifacts/reports/20250902T095354Z.md
+Checks: tests: pass, dead-links: pass, validate-docs: pass
+Dev URL: 
+Commit: feat(layout): add hero band ring toggle
+Worklog: artifacts/worklogs/20250902T095354Z.md
+Report: artifacts/reports/20250902T095354Z.md
+Web Insights: 
+Risk: low
+
+WHAT CHANGED
+- Added toggle in src/_data/site.json: allow enabling spectral rings per page.【F:src/_data/site.json†L1-L4】
+- Composed conditional rendering in src/_includes/layout.njk: hide spectral rings when toggle is false.【F:src/_includes/layout.njk†L143-L159】
+
+EDIT CARDS
+- Path: src/_data/site.json
+  Ops: [Normalize]
+  Anchors: heroBandRings
+  Before → After: No toggle for rings → global heroBandRings flag defaulting off.
+  Micro Example: "heroBandRings": false
+  Impact: Exposes site-wide switch to re-enable spectral rings when desired.
+- Path: src/_includes/layout.njk
+  Ops: [Compose]
+  Anchors: showHeroRings
+  Before → After: Rings rendered unconditionally → rings gated behind heroBandRings.
+  Micro Example: "{% if showHeroRings %}"
+  Impact: Removes static center rings while preserving crosshair overlay.
+
+CHECKS & EVIDENCE
+ - Name: tests
+   Location: ✅ `npm test`
+   Expectation: All suites pass
+   Verdict: pass【dbd8ee†L1-L59】
+ - Name: dead-links
+   Location: ✅ `npm run dead-links`
+   Expectation: README links valid
+   Verdict: pass【cc3d42†L1-L41】
+ - Name: validate-docs
+   Location: ✅ `npm run validate:docs`
+   Expectation: docs validated
+   Verdict: pass【5905b2†L1-L29】
+
+DECISIONS
+Strategy Justification: Template tweak with optional switch suited A2 and S2 scope; N2 achieved via heroBandRings toggle.
+Assumptions: Removing rings improves clarity while crosshair remains; pages may later re-enable rings via toggle.
+Discarded Alternatives: Hard deletion of SVG group—lacked reusability.
+Pivots & Failures: Initial test run revealed Nunjucks error; corrected set syntax.
+Rollback: Revert src/_data/site.json and src/_includes/layout.njk to previous commit.
+
+CAPABILITY
+Name: heroBandRings toggle
+Defaults: false
+Usage: set page.heroBandRings = true to show spectral rings.
+
+AESTHETIC CAPSULE
+SVG once spun halo—now a clean crosshair slices the page.

--- a/artifacts/worklogs/20250902T095354Z.md
+++ b/artifacts/worklogs/20250902T095354Z.md
@@ -1,0 +1,5 @@
+# Worklog 2025-09-02
+- Activated environment and set up worklog/report paths.
+- Added tunable switch for hero band rings and conditioned rendering in layout.
+- Fixed Nunjucks expression for ring toggle to use defined check.
+- Executed npm test, npm run dead-links, and npm run validate:docs with all passing.

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,3 +1,4 @@
 {
-  "heroBand": false
+  "heroBand": false,
+  "heroBandRings": false
 }

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -141,6 +141,7 @@
   {{ header(nav, page) }}
 
   {% if page.heroBand or site.heroBand %}
+  {% set showHeroRings = page.heroBandRings if page.heroBandRings is defined else site.heroBandRings %}
   <div class="pointer-events-none fixed inset-x-0 top-[6%] z-[45] flex flex-col items-center gap-1 text-primary">
     {# ——— SVG micro-instrumentation band (rings + crosshair + brackets) ——— #}
     <svg width="100%" height="84" viewBox="0 0 1200 84" aria-hidden="true" class="block">
@@ -148,12 +149,14 @@
       <path d="M24 18 h26 v-8 M24 66 h26 v8" fill="none" stroke="currentColor" stroke-width="2" opacity=".22"/>
       <!-- right bracket -->
       <path d="M1176 18 h-26 v-8 M1176 66 h-26 v8" fill="none" stroke="currentColor" stroke-width="2" opacity=".22"/>
+      {% if showHeroRings %}
       <!-- spectral rings -->
       <g opacity=".20">
         <circle cx="600" cy="42" r="18" fill="none" stroke="currentColor" stroke-width="1"/>
         <circle cx="600" cy="42" r="30" fill="none" stroke="currentColor" stroke-width="1"/>
         <circle cx="600" cy="42" r="42" fill="none" stroke="currentColor" stroke-width="1"/>
       </g>
+      {% endif %}
       <!-- crosshair -->
       <g opacity=".28">
         <line x1="600" y1="10" x2="600" y2="74" stroke="currentColor" stroke-width="1"/>


### PR DESCRIPTION
## Summary
- remove static spectral rings from hero band overlay
- add `heroBandRings` toggle for optional re-enable

## Testing
- `npm test`
- `npm run dead-links`
- `npm run validate-docs`


------
https://chatgpt.com/codex/tasks/task_e_68b6be4d713c8330973e3c872b7b4411