### PR TITLE
fix: restore POP MART product pages

### DIFF
--- a/artifacts/reports/20250902T100346Z.md
+++ b/artifacts/reports/20250902T100346Z.md
@@ -1,0 +1,59 @@
+1) HEADER
+Summary: Restored POP MART product pages with a reusable filter for archive collections.
+Tags: Scope=S2 • Approach=A3 • Novelty=N1 • Skin=K1
+Diff: 2 files changed, 44 insertions(+), 19 deletions(-)
+Files: lib/archive-utils.mjs, src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js
+Checks: npm test: pass, npm run build: pass, product slug build: pass
+Dev URL: n/a
+Commit: chore: sync report metadata
+Worklog: artifacts/worklogs/20250902T100346Z.md
+Report: artifacts/reports/20250902T100346Z.md
+Risk: low
+
+2) WHAT CHANGED
+- Added lineProducts helper in lib/archive-utils.mjs: reusable filter for company/line/locale queries.【F:lib/archive-utils.mjs†L1-L21】
+- Replaced manual filtering with lineProducts in products.11ty.js to emit correct slugs.【F:src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js†L1-L10】
+- Added pagination guard and direct permalink usage in products.11ty.js to prevent undefined pages.【F:src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js†L6-L7】【F:src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js†L21】
+
+3) EDIT CARDS
+- Path: lib/archive-utils.mjs
+  Ops: Compose
+  Anchors: lineProducts()
+  Before → After: no shared filter → dedicated line-aware filter.
+  Micro Example: `lineProducts(archiveProducts, "pop-mart", "the-monsters")`
+  Impact: simplifies reuse of archive queries.
+- Path: src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js
+  Ops: Normalize
+  Anchors: data()
+  Before → After: inline collection filtering with undefined slugs → helper-driven pagination with safe permalink.
+  Micro Example: `pagination: { data: items, size: 1, alias: "product" }`
+  Impact: builds product pages at deterministic URLs.
+
+4) CHECKS & EVIDENCE
+- Name: npm test
+  Location: npm test
+  Expectation: all tests pass
+  Verdict: pass【6fa373†L1-L6】
+- Name: npm run build
+  Location: npm run build
+  Expectation: Eleventy build completes
+  Verdict: pass【a9a362†L1-L5】
+- Name: product slug build
+  Location: /tmp/build.log
+  Expectation: mokoko fall-into-spring product page generated
+  Verdict: pass【2ab7c9†L1-L4】
+
+5) DECISIONS
+- Strategy Justification: Adopted a pipeline redesign (A3) to reuse filtered collections (S2) via a new helper (N1).
+- Assumptions: product archive data is authoritative and available as global data.
+- Discarded Alternatives: deleting products.11ty.js in favor of dynamic templates only; retained file for explicit control.
+- Pivots & Failures: initial tests failed due to missing collections; added default arguments and permalink guard to stabilize.
+- Rollback: remove lib/archive-utils.mjs and restore previous products.11ty.js.
+
+6) CAPABILITY
+- Name: lineProducts
+- Defaults: returns products for a company/line, locale defaults to "en"
+- Usage: `lineProducts(archiveProducts, 'pop-mart', 'the-monsters')`
+
+7) AESTHETIC CAPSULE
+Neon threads stitch the archive; each plush now finds its corridor.

--- a/artifacts/worklogs/20250902T100346Z.md
+++ b/artifacts/worklogs/20250902T100346Z.md
@@ -1,0 +1,6 @@
+## Worklog 2025-09-02T10:03:46Z
+- Activated environment and installed dependencies.
+- Investigated product page generation; identified failing products.11ty.js using collections before data loaded.
+- Added reusable lineProducts helper to filter archive collections by company, line, and locale.
+- Rewrote products.11ty.js to use helper and global data, adding safeguards for empty collections and direct permalink usage.
+- Ran `npm test` and `npm run build` to confirm product pages generate without errors.

--- a/lib/archive-utils.mjs
+++ b/lib/archive-utils.mjs
@@ -1,0 +1,21 @@
+/**
+ * Archive helper utilities.
+ * @module archive-utils
+ */
+
+/**
+ * Filter archive products by company, line, and locale.
+ * @param {Array} products - Collection items from archiveProducts.
+ * @param {string} companySlug - Company slug to match.
+ * @param {string} lineSlug - Product line slug to match.
+ * @param {string} [locale="en"] - Locale to match (defaults to 'en').
+ * @returns {Array} Filtered products belonging to the company/line/locale.
+ */
+export function lineProducts(products, companySlug, lineSlug, locale = "en") {
+  return (products ?? []).filter(
+    (p) =>
+      p?.data?.companySlug === companySlug &&
+      p?.data?.lineSlug === lineSlug &&
+      p?.data?.locale === locale
+  );
+}

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js
@@ -1,22 +1,27 @@
-export const data = () => ({
-  layout: 'layout.njk',
-  eleventyComputed: {
-    pagination: (data) => {
-      const all = Array.isArray(data.collections?.archiveProducts) ? data.collections.archiveProducts : [];
-      const filtered = all.filter(p => (
-        p?.data?.companySlug === 'pop-mart' &&
-        p?.data?.lineSlug === 'the-monsters' &&
-        p?.data?.locale === 'en'
-      ));
-      return { data: filtered, size: 1, alias: 'product' };
+import { lineProducts } from "../../../../../../lib/archive-utils.mjs";
+
+export const data = ({ archiveProducts } = {}) => {
+  const companySlug = "pop-mart";
+  const lineSlug = "the-monsters";
+  const items = lineProducts(archiveProducts, companySlug, lineSlug);
+  if (!items.length) return { permalink: false };
+  return {
+    layout: "layout.njk",
+    pagination: { data: items, size: 1, alias: "product" },
+    eleventyComputed: {
+      companySlug: () => companySlug,
+      lineSlug: () => lineSlug,
+      productSlug: ({ product }) => product?.data?.productSlug,
+      title: ({ product }) =>
+        `POP MART — The Monsters — ${
+          product?.data?.product_id ||
+          product?.data?.title ||
+          product?.data?.productSlug
+        }`,
+      permalink: ({ product }) => product?.data?.url,
     },
-    companySlug: () => 'pop-mart',
-    lineSlug: () => 'the-monsters',
-    productSlug: ({ product }) => product?.data?.productSlug,
-    title: ({ product }) => `POP MART — The Monsters — ${product?.data?.product_id || product?.data?.title || product?.data?.productSlug}`,
-    permalink: ({ companySlug, lineSlug, productSlug }) => `/archives/collectables/designer-toys/${companySlug}/${lineSlug}/products/${productSlug}/index.html`,
-  },
-});
+  };
+};
 
 export const render = (data) => `
 <nav class="breadcrumbs text-sm mb-2 overflow-x-auto whitespace-nowrap" aria-label="Breadcrumb">
@@ -45,4 +50,3 @@ export const render = (data) => `
   </div>
 </section>
 `;
-


### PR DESCRIPTION
## Summary
- add reusable `lineProducts` helper for archive filtering
- fix POP MART The Monsters product pagination to emit real slugs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6bf49661c8330853df4d8cfb4c67b