### PR TITLE
feat(interlinker): normalize DOM inputs with toHtmlString

### DIFF
--- a/artifacts/worklogs/2025-09-02T10:19:44Z.md
+++ b/artifacts/worklogs/2025-09-02T10:19:44Z.md
@@ -1,0 +1,4 @@
+- Patched @photogabble/eleventy-plugin-interlinker to coerce DOM nodes via new toHtmlString helper.
+- Updated HTMLLinkParser, Interlinker, and WikilinkParser to use helper; preserved markdown guard.
+- Added unit test verifying DOM Document parsing and link detection.
+- Generated patch-package patch; executed targeted test and full Eleventy build.

--- a/patches/@photogabble+eleventy-plugin-interlinker+1.1.0.patch
+++ b/patches/@photogabble+eleventy-plugin-interlinker+1.1.0.patch
@@ -1,8 +1,14 @@
 diff --git a/node_modules/@photogabble/eleventy-plugin-interlinker/src/html-link-parser.js b/node_modules/@photogabble/eleventy-plugin-interlinker/src/html-link-parser.js
-index 5c98846..a4105c0 100644
+index 5c98846..b2c7835 100644
 --- a/node_modules/@photogabble/eleventy-plugin-interlinker/src/html-link-parser.js
 +++ b/node_modules/@photogabble/eleventy-plugin-interlinker/src/html-link-parser.js
-@@ -57,12 +57,17 @@ export default class HTMLLinkParser {
+@@ -1,4 +1,5 @@
+ import {JSDOM} from 'jsdom';
++import { toHtmlString } from './to-html.js';
+ export default class HTMLLinkParser {
+ 
+   /**
+@@ -57,12 +58,13 @@ export default class HTMLLinkParser {
  
    /**
     * Find's all internal href links within an HTML document and returns the parsed result.
@@ -14,26 +20,29 @@ index 5c98846..a4105c0 100644
 -  find(document, pageDirectory) {
 -    const dom = new JSDOM(document);
 +  find(html, pageDirectory) {
-+    // Eleventy v3 + custom templates can surface non-strings here.
-+    // Coerce defensively to avoid crashes during computed data.
-+    if (typeof html !== 'string') {
-+      html = html == null ? '' : String(html);
-+    }
++    html = toHtmlString(html);
 +    const dom = new JSDOM(html);
      const anchors = dom.window.document.getElementsByTagName('a');
      const toParse = [];
  
 diff --git a/node_modules/@photogabble/eleventy-plugin-interlinker/src/interlinker.js b/node_modules/@photogabble/eleventy-plugin-interlinker/src/interlinker.js
-index c64053f..e5f035f 100644
+index c64053f..6244c02 100644
 --- a/node_modules/@photogabble/eleventy-plugin-interlinker/src/interlinker.js
 +++ b/node_modules/@photogabble/eleventy-plugin-interlinker/src/interlinker.js
-@@ -65,7 +65,8 @@ export default class Interlinker {
+@@ -2,6 +2,7 @@ import HTMLLinkParser from './html-link-parser.js';
+ import WikilinkParser from './wikilink-parser.js';
+ import DeadLinks from './dead-links.js';
+ import {pageLookup} from './find-page.js';
++import { toHtmlString } from './to-html.js';
+ 
+ /**
+  * Interlinker:
+@@ -65,7 +66,7 @@ export default class Interlinker {
      const template = await currentPage.template.read();
  
      if (template?.content) {
 -      const pageContent = template.content;
-+      // Coerce template.content defensively; Eleventy may surface non-strings
-+      const pageContent = typeof template.content === 'string' ? template.content : String(template.content ?? '');
++      const pageContent = toHtmlString(template.content);
        const outboundLinks = [
          ...this.wikiLinkParser.find(pageContent, pageDirectory, currentPage.filePathStem),
          ...this.HTMLLinkParser.find(pageContent, pageDirectory),
@@ -50,11 +59,29 @@ index b67c8c7..b117ebf 100644
    const matches = state.src.match(wikilinkParser.wikiLinkRegExp);
    if (!matches) return false;
  
+diff --git a/node_modules/@photogabble/eleventy-plugin-interlinker/src/to-html.js b/node_modules/@photogabble/eleventy-plugin-interlinker/src/to-html.js
+new file mode 100644
+index 0000000..a0f5bd8
+--- /dev/null
++++ b/node_modules/@photogabble/eleventy-plugin-interlinker/src/to-html.js
+@@ -0,0 +1,6 @@
++export function toHtmlString(value) {
++  if (typeof value === 'string') return value;
++  if (value?.documentElement?.outerHTML) return value.documentElement.outerHTML;
++  if (value?.outerHTML) return value.outerHTML;
++  return String(value ?? '');
++}
 diff --git a/node_modules/@photogabble/eleventy-plugin-interlinker/src/wikilink-parser.js b/node_modules/@photogabble/eleventy-plugin-interlinker/src/wikilink-parser.js
-index fbd6206..8853346 100644
+index fbd6206..b2603a7 100644
 --- a/node_modules/@photogabble/eleventy-plugin-interlinker/src/wikilink-parser.js
 +++ b/node_modules/@photogabble/eleventy-plugin-interlinker/src/wikilink-parser.js
-@@ -152,14 +152,19 @@ export default class WikilinkParser {
+@@ -1,3 +1,5 @@
++import { toHtmlString } from './to-html.js';
++
+ export default class WikilinkParser {
+   /**
+    * This regex finds all WikiLink style links: [[id|optional text]] as well as WikiLink style embeds: ![[id]]
+@@ -152,14 +154,15 @@ export default class WikilinkParser {
     * Finds all wikilinks within a document (HTML or otherwise) and returns their
     * parsed result.
     *
@@ -66,11 +93,7 @@ index fbd6206..8853346 100644
     */
 -  find(document, pageDirectory, filePathStem) {
 +  find(content, pageDirectory, filePathStem) {
-+    // Eleventy v3 can surface non-string "document" during computed data.
-+    // Coerce defensively so builds don’t crash.
-+    if (typeof content !== 'string') {
-+      content = content == null ? '' : String(content);
-+    }
++    content = toHtmlString(content);
      return this.parseMultiple(
 -      (document.match(this.wikiLinkRegExp) || []),
 +      (content.match(this.wikiLinkRegExp) || []),

--- a/test/unit/patch-interlinker.test.mjs
+++ b/test/unit/patch-interlinker.test.mjs
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import assert from 'node:assert';
 import { JSDOM } from 'jsdom';
 
 // Directly import the patched source file from node_modules to ensure
@@ -7,15 +8,18 @@ const interlinkerPath = '../../node_modules/@photogabble/eleventy-plugin-interli
 const { default: WikilinkParser } = await import(interlinkerPath);
 
 await test('interlinker: find handles non-string document without throwing', () => {
-  const parser = new WikilinkParser();
+  const parser = new WikilinkParser({}, { add: () => {} }, new Map());
 
   const domDoc = new JSDOM('<p>[[Link]]</p>').window.document;
+  const stubDir = { findByLink: () => ({ found: false }) };
   const cases = [null, undefined, 0, 42, true, false, { a: 1 }, [1, 2, 3], domDoc];
   for (const doc of cases) {
-    const out = parser.find(doc, '.', 'dummy');
-    if (!Array.isArray(out)) {
-      throw new Error(`Expected array for doc=${String(doc)}, got ${typeof out}`);
-    }
+    const out = parser.find(doc, stubDir, 'dummy');
+    assert(Array.isArray(out));
   }
+
+  const out = parser.find(domDoc, stubDir, 'dummy');
+  assert.equal(out.length, 1);
+  assert.equal(out[0].name, 'Link');
 });
 


### PR DESCRIPTION
## Summary
- add DOM-aware `toHtmlString` utility to interlinker plugin
- parse product documents safely for links
- verify wikilink parser handles DOM nodes

## Testing
- `node test/unit/patch-interlinker.test.mjs`
- `npx @11ty/eleventy`


------
https://chatgpt.com/codex/tasks/task_e_68b6c339e1588330aa24a0f3f09e343b