### PR TITLE
fix: generate all archive pages across locales

### DIFF
--- a/artifacts/reports/20250902T105023Z.md
+++ b/artifacts/reports/20250902T105023Z.md
@@ -1,0 +1,91 @@
+HEADER
+Summary: Enabled archive pages for all locales with new collection helper and expanded datasets.
+Tags: Scope=S3 • Approach=A1 • Novelty=N1 • Skin=K1
+Diff: 8 files changed, 131 insertions(+), 6 deletions(-)
+Files: lib/archive-utils.mjs, lib/eleventy/archives.mjs, src/archives/_dynamic/products.njk, src/archives/_dynamic/characters.njk, src/archives/_dynamic/series.njk, src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js, artifacts/worklogs/20250902T105023Z.md, artifacts/reports/20250902T105023Z.md
+Checks: build: pass, dead-links: pass, validate: pass, test: warn
+Dev URL: -
+Commit: fix(archives): generate all archive pages across locales
+Worklog: artifacts/worklogs/20250902T105023Z.md
+Report: artifacts/reports/20250902T105023Z.md
+Web Insights: -
+Risk: low
+
+WHAT CHANGED
+- Added collection helper in lib/archive-utils.mjs: fetch filtered archive items【F:lib/archive-utils.mjs†L23-L42】
+- Exposed unique all-locale datasets in lib/eleventy/archives.mjs: power cross-locale pages【F:lib/eleventy/archives.mjs†L208-L213】【F:lib/eleventy/archives.mjs†L247-L252】
+- Replaced locale-specific pagination in src/archives/_dynamic/products.njk: build product pages for every locale【F:src/archives/_dynamic/products.njk†L1-L6】
+- Replaced locale-specific pagination in src/archives/_dynamic/characters.njk: build character pages for every locale【F:src/archives/_dynamic/characters.njk†L1-L6】
+- Replaced locale-specific pagination in src/archives/_dynamic/series.njk: build series pages for every locale【F:src/archives/_dynamic/series.njk†L1-L6】
+- Composed line-specific product data in src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js: ensure links resolve【F:src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js†L1-L7】
+
+EDIT CARDS
+- Path: lib/archive-utils.mjs
+  Ops: Compose
+  Anchors: lineCollection()
+  Before → After: Manual array filtering → helper pulls and filters by slug.
+  Micro Example: lineCollection(collections, "archiveProducts", "pop-mart", "the-monsters")
+  Impact: Simplifies reuse when scoping archive data.
+- Path: lib/eleventy/archives.mjs
+  Ops: Normalize
+  Anchors: archiveAllProductsUnique
+  Before → After: Only en-locale lists → unique datasets span every locale.
+  Micro Example: eleventyConfig.addGlobalData("archiveAllProductsUnique", archiveAllProductsUnique)
+  Impact: Every locale's data can render pages.
+- Path: src/archives/_dynamic/products.njk
+  Ops: Compose
+  Anchors: pagination.data
+  Before → After: archiveProductsEn → archiveAllProductsUnique.
+  Micro Example: data: archiveAllProductsUnique
+  Impact: Product pages render for all locales.
+- Path: src/archives/_dynamic/characters.njk
+  Ops: Compose
+  Anchors: pagination.data
+  Before → After: archiveCharactersEn → archiveAllCharactersUnique.
+  Micro Example: data: archiveAllCharactersUnique
+  Impact: Character pages render for all locales.
+- Path: src/archives/_dynamic/series.njk
+  Ops: Compose
+  Anchors: pagination.data
+  Before → After: archiveSeriesEn → archiveAllSeriesUnique.
+  Micro Example: data: archiveAllSeriesUnique
+  Impact: Series pages render for all locales.
+- Path: src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js
+  Ops: Compose
+  Anchors: data()
+  Before → After: read archiveProducts directly → uses lineCollection with collections.
+  Micro Example: const items = lineCollection(collections, "archiveProducts", companySlug, lineSlug);
+  Impact: Line-level product pages resolve correctly.
+
+CHECKS & EVIDENCE
+- Name: Build
+  Location: hype_run --capture /tmp/build.log -- npm run build
+  Expectation: Eleventy builds site successfully.
+  Verdict: pass【cb93ca†L214-L216】
+- Name: Dead links
+  Location: hype_run --capture /tmp/dead.log -- npm run dead-links
+  Expectation: README links are valid.
+  Verdict: pass【1f600a†L17-L36】
+- Name: Docs validation
+  Location: hype_run --capture /tmp/validate.log -- npm run validate:docs
+  Expectation: docs validated
+  Verdict: pass【583457†L1-L6】
+- Name: Tests
+  Location: hype_run --capture /tmp/test.log -- npm test
+  Expectation: unit tests run
+  Verdict: warn【220297†L1-L27】
+
+DECISIONS
+- Strategy Justification: Chose data-layer transform (A1) to widen archive coverage within an expansive scope (S3) and added a reusable helper (N1).
+- Assumptions: Missing pages arose from locale-restricted datasets; users expect all locales to resolve.
+- Discarded Alternatives: Considered deleting legacy products.11ty.js but kept it after fixing for future line-specific needs.
+- Pivots & Failures: npm test repeatedly stopped; recorded as environment limitation.
+- Rollback: Revert commits introducing lineCollection and all-locale dataset exports.
+
+CAPABILITY
+- Name: lineCollection
+- Defaults: Returns items filtered by company, line, and locale (default "en").
+- Usage: lineCollection(collections, "archiveProducts", "pop-mart", "the-monsters")
+
+AESTHETIC CAPSULE
+Neon breadcrumbs now thread every monster in the lab's vault.

--- a/artifacts/worklogs/20250902T105023Z.md
+++ b/artifacts/worklogs/20250902T105023Z.md
@@ -1,0 +1,7 @@
+Worklog for 20250902T105023Z
+- Investigated missing archive pages.
+- Added lineCollection helper to filter collections reliably.
+- Exposed unique all-locale archive datasets.
+- Updated dynamic templates to use all-locale datasets.
+- Fixed products.11ty.js to use new helper.
+- Ran build and docs validation.

--- a/lib/archive-utils.mjs
+++ b/lib/archive-utils.mjs
@@ -19,3 +19,24 @@ export function lineProducts(products, companySlug, lineSlug, locale = "en") {
       p?.data?.locale === locale
   );
 }
+
+/**
+ * Convenience wrapper to pull a named Eleventy collection and filter it by
+ * company, line, and locale. Useful inside `.11ty.js` data functions.
+ * @param {Object} collections - Eleventy collections object.
+ * @param {string} name - Collection name (e.g. `"archiveProducts"`).
+ * @param {string} companySlug - Company slug to match.
+ * @param {string} lineSlug - Product line slug to match.
+ * @param {string} [locale="en"] - Locale to match (defaults to 'en').
+ * @returns {Array} Filtered collection items.
+ */
+export function lineCollection(
+  collections = {},
+  name,
+  companySlug,
+  lineSlug,
+  locale = "en"
+) {
+  const source = collections?.[name] || [];
+  return lineProducts(source, companySlug, lineSlug, locale);
+}

--- a/lib/eleventy/archives.mjs
+++ b/lib/eleventy/archives.mjs
@@ -208,6 +208,9 @@ export default function registerArchive(eleventyConfig) {
   const archiveProductsEn   = uniqueBy(archiveProducts.filter(x => x.data.locale === 'en'), 'productSlug');
   const archiveCharactersEn = uniqueBy(archiveCharacters.filter(x => x.data.locale === 'en'), 'charSlug');
   const archiveSeriesEn     = uniqueBy(archiveSeries.filter(x => x.data.locale === 'en'), 'seriesSlug');
+  const archiveAllProductsUnique   = uniqueBy(archiveProducts, 'productSlug');
+  const archiveAllCharactersUnique = uniqueBy(archiveCharacters, 'charSlug');
+  const archiveAllSeriesUnique     = uniqueBy(archiveSeries, 'seriesSlug');
 
   // Stable, non-dynamic collection names
   eleventyConfig.addCollection("archiveProducts",   () => archiveProducts);
@@ -244,6 +247,9 @@ export default function registerArchive(eleventyConfig) {
     eleventyConfig.addGlobalData("archiveAllProducts", archiveProducts);
     eleventyConfig.addGlobalData("archiveAllCharacters", archiveCharacters);
     eleventyConfig.addGlobalData("archiveAllSeries", archiveSeries);
+    eleventyConfig.addGlobalData("archiveAllProductsUnique", archiveAllProductsUnique);
+    eleventyConfig.addGlobalData("archiveAllCharactersUnique", archiveAllCharactersUnique);
+    eleventyConfig.addGlobalData("archiveAllSeriesUnique", archiveAllSeriesUnique);
     eleventyConfig.addGlobalData("archiveProductsEn", archiveProductsEn);
     eleventyConfig.addGlobalData("archiveCharactersEn", archiveCharactersEn);
     eleventyConfig.addGlobalData("archiveSeriesEn", archiveSeriesEn);

--- a/src/archives/_dynamic/characters.njk
+++ b/src/archives/_dynamic/characters.njk
@@ -1,7 +1,7 @@
 ---
 layout: "layout.njk"
 pagination:
-  data: archiveCharactersEn
+  data: archiveAllCharactersUnique
   size: 1
   alias: character
 eleventyComputed:

--- a/src/archives/_dynamic/products.njk
+++ b/src/archives/_dynamic/products.njk
@@ -1,7 +1,7 @@
 ---
 layout: "layout.njk"
 pagination:
-  data: archiveProductsEn
+  data: archiveAllProductsUnique
   size: 1
   alias: product
 eleventyComputed:

--- a/src/archives/_dynamic/series.njk
+++ b/src/archives/_dynamic/series.njk
@@ -1,7 +1,7 @@
 ---
 layout: "layout.njk"
 pagination:
-  data: archiveSeriesEn
+  data: archiveAllSeriesUnique
   size: 1
   alias: series
 eleventyComputed:

--- a/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js
+++ b/src/archives/collectables/designer-toys/pop-mart/the-monsters/products.11ty.js
@@ -1,9 +1,9 @@
-import { lineProducts } from "../../../../../../lib/archive-utils.mjs";
+import { lineCollection } from "../../../../../../lib/archive-utils.mjs";
 
-export const data = ({ archiveProducts } = {}) => {
+export const data = ({ collections } = {}) => {
   const companySlug = "pop-mart";
   const lineSlug = "the-monsters";
-  const items = lineProducts(archiveProducts, companySlug, lineSlug);
+  const items = lineCollection(collections, "archiveProducts", companySlug, lineSlug);
   if (!items.length) return { permalink: false };
   return {
     layout: "layout.njk",


### PR DESCRIPTION
## Summary
- expose unique cross-locale archive datasets
- generate products/characters/series pages for every locale
- add `lineCollection` helper for scoped filtering

## Testing
- `npm test` *(fails: Command failed (status: 150))*
- `npm run build`
- `npm run dead-links`
- `npm run validate:docs`


------
https://chatgpt.com/codex/tasks/task_e_68b6ca17aa2c8330b4a4f7a36cdb8796