### PR TITLE
feat(resume): add subtle accent styling

### DIFF
--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -21,7 +21,11 @@
   "summary": "Software engineer with 6+ years across backend services and streaming data systems, now centered on LLM applications and LLMOps. Built and operated APIs and pipelines on AWS (EMR, Lambda, Kinesis, S3), containerized services on Kubernetes, and delivered search/analytics with Elasticsearch. Focus areas: retrieval that returns the right context, evaluation gates that block bad releases, and dashboards that surface drift early.",
 
   "highlights": [
-    { "title": "HackAPrompt 2025", "value": "Top-10 (#7)", "sub": "Adversarial prompt contest" },
+    {
+      "title": "HackAPrompt 2025",
+      "value": "Top-10 (#7)",
+      "sub": "Adversarial prompt contest"
+    },
     {
       "title": "High-throughput data",
       "value": "10+ TB/day",
@@ -44,10 +48,22 @@
       {
         "name": "AI / LLM",
         "items": [
-          { "name": "Prompt design", "hint": "Task/format constraints, system prompting, self-checks" },
-          { "name": "Retrieval / RAG", "hint": "Chunking heuristics, hybrid search, re-ranking, citations" },
-          { "name": "Evaluation / metrics", "hint": "Small gold sets, pass@k, coverage/latency/safety gates" },
-          { "name": "Safety controls", "hint": "Guardrails, allow/deny lists, output sanitization" },
+          {
+            "name": "Prompt design",
+            "hint": "Task/format constraints, system prompting, self-checks"
+          },
+          {
+            "name": "Retrieval / RAG",
+            "hint": "Chunking heuristics, hybrid search, re-ranking, citations"
+          },
+          {
+            "name": "Evaluation / metrics",
+            "hint": "Small gold sets, pass@k, coverage/latency/safety gates"
+          },
+          {
+            "name": "Safety controls",
+            "hint": "Guardrails, allow/deny lists, output sanitization"
+          },
           { "name": "PyTorch" },
           { "name": "Transformers" },
           { "name": "LangChain" },
@@ -60,7 +76,10 @@
           { "name": "Python" },
           { "name": "Scala (background)" },
           { "name": "Spark", "hint": "Batch + streaming on EMR" },
-          { "name": "Elasticsearch", "hint": "Index design, aggregations, analyzers" },
+          {
+            "name": "Elasticsearch",
+            "hint": "Index design, aggregations, analyzers"
+          },
           { "name": "Kafka" },
           { "name": "Kinesis" },
           { "name": "pandas" },
@@ -70,7 +89,10 @@
       {
         "name": "Cloud & DevOps",
         "items": [
-          { "name": "AWS", "hint": "EMR, Lambda, Kinesis, S3, CloudWatch, RDS" },
+          {
+            "name": "AWS",
+            "hint": "EMR, Lambda, Kinesis, S3, CloudWatch, RDS"
+          },
           { "name": "Kubernetes" },
           { "name": "Terraform" },
           { "name": "Docker" },
@@ -81,9 +103,15 @@
         "name": "APIs & Practices",
         "items": [
           { "name": "REST" },
-          { "name": "OpenAPI", "hint": "Versioning, schema linting, compatibility checks" },
+          {
+            "name": "OpenAPI",
+            "hint": "Versioning, schema linting, compatibility checks"
+          },
           { "name": "JWT/OAuth2" },
-          { "name": "Release checks", "hint": "Quality bars + rollout/rollback playbooks" },
+          {
+            "name": "Release checks",
+            "hint": "Quality bars + rollout/rollback playbooks"
+          },
           { "name": "Observability", "hint": "Metrics, logs, traces, SLOs" },
           { "name": "Response playbooks" },
           { "name": "TRDs" },
@@ -116,8 +144,8 @@
       "end": "",
       "location": "Denver, CO",
       "highlights": [
-        "HackAPrompt 2025 — Top-10 (7th): turned jailbreak tactics into repeatable tests and mitigations; shipped a lightweight Gatekeeper that enforces accuracy/safety gates and rollout controls.",
-        "Authored adversarial sets (200+ items) with Positive/Negative/Risk cases; checks for groundedness (“no citation → no claim”), refusal-appropriateness, unsafe-rate, and p50/p95; deltas: +9 accuracy points, p95 ≤1.8s, unsafe probes ~0 on re-tests.",
+        "HackAPrompt 2025 — Top-10 (7th): turned jailbreak tactics into repeatable tests and mitigations; added rollout controls for accuracy and safety with shadow and canary runs.",
+        "Authored evaluation suites (200+ prompts) with Positive/Negative/Risk cases; checks for groundedness (“no citation → no claim”), refusal-appropriateness, unsafe-rate, and p50/p95; deltas: +9 accuracy points, p95 ≤1.8s, unsafe probes ~0 on re-tests.",
         "Patent Intelligence Agent (consulting, private client): constrained Q&A over patent corpora with hybrid semantic + CPC/IPC filtering, claim/abstract parsing, citation-trail review, and landscape digests; outputs include inline citations and limitation mapping; added RBAC, prompt-safety controls, and clear notices.",
         "Built local LLM workflows with modular orchestration (prompt-rewrite steps, LoRA adapters, graph-style configs) to compare prompts/models offline with reproducible inputs.",
         "Engineered a modular Eleventy (11ty) 3.x system (Nunjucks, Tailwind 4) with markdown-it extensions, interlinking/navigation plugins, and GitHub Actions for reproducible builds."
@@ -188,7 +216,7 @@
       "name": "HackAPrompt Top-10 (7th)",
       "subtitle": "Jailbreak and prompt‑injection challenge (2025)",
       "badge": "security",
-      "blurb": "Placed 7th; built reproducible jailbreak tests and shipped a small gatekeeper enforcing accuracy and safety thresholds with shadow and canary rollouts.",
+      "blurb": "Placed 7th; built reproducible jailbreak tests with shadow and canary rollouts that enforced accuracy and safety thresholds.",
       "tags": [
         "LLM Safety",
         "Prompt Engineering",
@@ -210,10 +238,10 @@
       "url": ""
     },
     {
-      "name": "LLMOps Gatekeeper",
+      "name": "LLM Release Watcher",
       "badge": "ops",
       "subtitle": "Safe, measurable LLM releases",
-      "blurb": "Blocks releases that miss accuracy, latency, or safety thresholds; supports shadow runs, timed canaries, and automatic rollback.",
+      "blurb": "Monitors accuracy, latency, and safety metrics with shadow runs, timed canaries, and automatic rollback.",
       "tags": ["CI/CD gates", "Metrics", "Playbooks"],
       "url": ""
     },

--- a/src/content/resume.njk
+++ b/src/content/resume.njk
@@ -71,6 +71,7 @@ eleventyExcludeFromCollections: true
 
   <!-- Tiny CSS: skip-link + print polish + hb-tabrow styles -->
   <style>
+    :root{--hb-accent-start:hsl(var(--p));--hb-accent-end:hsl(var(--s))}
     .skip-link{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
     .skip-link:focus{left:1rem;top:1rem;width:auto;height:auto;padding:.5rem .75rem;z-index:1000}
     @media print{
@@ -81,18 +82,23 @@ eleventyExcludeFromCollections: true
       a{color:#000!important;text-decoration:none!important}
       .card{background:#fff!important;border-color:#ddd!important}
     }
+    /* Subtle accent system */
+    .hb-accent{position:relative}
+    .hb-accent::before{content:"";position:absolute;inset-inline-start:-1px;top:8px;bottom:8px;width:3px;border-radius:999px;background:linear-gradient(180deg,var(--hb-accent-start),var(--hb-accent-end));opacity:.4}
     /* Hypebrüt: Tab-like row styling for Highlights on this standalone page */
     .hb-tabrow{position:relative;width:100%;padding:.75rem 1rem;border-radius:12px;border:1px solid hsl(var(--bc)/.12);background-color:hsl(var(--b1)/.92);box-shadow:0 2px 6px rgba(0,0,0,.06);transition:box-shadow .2s ease,border-color .2s ease}
-    .hb-tabrow::before{content:"";position:absolute;inset-inline-start:-1px;top:8px;bottom:8px;width:3px;border-radius:999px;background:linear-gradient(180deg,color-mix(in oklab, var(--neon-a, #00E0FF) 86%, transparent) 0%,color-mix(in oklab, var(--neon-b, #9AFF00) 86%, transparent) 50%,color-mix(in oklab, var(--neon-c, #FF1CF7) 86%, transparent) 100%);opacity:.55;transform:scaleY(.72);transform-origin:center;transition:transform .2s ease,opacity .2s ease}
+    .hb-tabrow::before{content:"";position:absolute;inset-inline-start:-1px;top:8px;bottom:8px;width:3px;border-radius:999px;background:linear-gradient(180deg,var(--hb-accent-start) 0%,var(--hb-accent-end) 100%);opacity:.5;transform:scaleY(.72);transform-origin:center;transition:transform .2s ease,opacity .2s ease}
     .hb-tabrow:hover{border-color:hsl(var(--p)/.38);box-shadow:0 6px 22px rgba(0,0,0,.10)}
-    .hb-tabrow:hover::before{opacity:.85;transform:scaleY(1)}
+    .hb-tabrow:hover::before{opacity:.75;transform:scaleY(1)}
     .hb-tabrow[data-active="true"]{border-color:hsl(var(--p)/.5);box-shadow:0 8px 28px rgba(0,0,0,.12)}
-    .hb-tabrow[data-active="true"]::before{opacity:1;transform:scaleY(1)}
+    .hb-tabrow[data-active="true"]::before{opacity:.9;transform:scaleY(1)}
     .hb-tablabel{font-size:11px;text-transform:uppercase;letter-spacing:.2em;opacity:.7}
     .hb-tabvalue{font-size:1.375rem;line-height:1.2;font-weight:700}
     .hb-tabsub{font-size:.75rem;opacity:.8}
     .hb-title{position:relative;display:inline-flex;align-items:center;gap:.5rem}
-    .hb-title::after{content:"";height:1px;width:48px;opacity:.5;background:linear-gradient(90deg,color-mix(in oklab, var(--neon-a, #00E0FF) 75%, transparent) 0%,color-mix(in oklab, var(--neon-c, #FF1CF7) 75%, transparent) 100%)}
+    .hb-title::after{content:"";height:1px;width:48px;opacity:.45;background:linear-gradient(90deg,var(--hb-accent-start) 0%,var(--hb-accent-end) 100%)}
+    .hb-minirow{position:relative;padding-left:1rem;line-height:1.45}
+    .hb-minirow::before{content:"";position:absolute;left:0;top:.6em;width:.4rem;height:.4rem;border-radius:50%;background:linear-gradient(180deg,var(--hb-accent-start),var(--hb-accent-end));opacity:.5}
   </style>
 </head>
 


### PR DESCRIPTION
## Summary
- soften rainbow highlight with DaisyUI accent variables
- drop gatekeeper/adversarial set references from resume data

## Testing
- `npm test`
- `npm run build`
- `npm run lint:advisory`


------
https://chatgpt.com/codex/tasks/task_e_68bbbda9a4bc83308da15a2b7c8063c1