### PR TITLE
feat(ui): ground surfaces for readability

### DIFF
--- a/artifacts/worklogs/2025-09-06T080433Z.md
+++ b/artifacts/worklogs/2025-09-06T080433Z.md
@@ -1,0 +1,6 @@
+## Worklog 2025-09-06T080433Z
+- Activated environment and verified llm tools
+- Attempted web.run research; tool unavailable
+- Introduced `surface-ground` primitive in Tailwind CSS for grounded panels
+- Updated `feed-entry` and `hero-tile` templates to use new surface
+- Ran tests and lints (npm test, npm run lint:advisory, npm run validate:docs)

--- a/src/_includes/components/feed-entry.njk
+++ b/src/_includes/components/feed-entry.njk
@@ -1,7 +1,7 @@
 {# Feed entry: convert to a daisyUI-flavored cardish anchor #}
 {% macro feedEntry(item) -%}
 <li data-type="{{ item.type }}">
-  <a href="{{ item.url }}" class="group block h-full surface-solid slab no-elevate with-rail p-5 sm:p-6 transition-colors hover:border-base-300 text-left">
+  <a href="{{ item.url }}" class="group block h-full surface-ground hb-tile with-rail p-5 sm:p-6 transition-colors text-left">
     <div>
       {% set t = (item.type or item.data.type) | lower %}
       {% set typeClass = 'pill--meta' %}

--- a/src/_includes/components/hero-tile.njk
+++ b/src/_includes/components/hero-tile.njk
@@ -2,13 +2,13 @@
 {% macro heroTile(type, title, description, href, primary=false) -%}
 <a
   href="{{ href }}"
-  class="group block rounded-xl border transition bg-base-100/80 backdrop-blur
+  class="group block surface-ground hb-tile transition
          {% if primary %}
            border-primary/60 ring-1 ring-primary/20 bg-gradient-to-br from-primary/5 to-transparent
          {% else %}
-           border-base-content/15 hover:border-primary/50
+           border-base-content/15
          {% endif %}
-         hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus-visible:ring focus-visible:ring-primary/40 p-6 text-left"
+         hover:-translate-y-0.5 focus:outline-none focus-visible:ring focus-visible:ring-primary/40 p-6 text-left"
 >
   <span class="badge badge-ghost badge-xs uppercase tracking-wider">{{ type | safe }}</span>
   <h3 class="mt-2 font-heading text-lg text-base-content group-hover:text-primary transition-colors">{{ title | safe }}</h3>

--- a/src/styles/app.tailwind.css
+++ b/src/styles/app.tailwind.css
@@ -72,6 +72,20 @@
   .anim-soft{ transition: color 160ms ease, background-color 160ms ease, border-color 160ms ease; }
 }
 
+/* Grounded surface primitive for readable panels and cards */
+@layer components {
+  .surface-ground {
+    background: color-mix(in oklab, hsl(var(--b1)) 86%, hsl(var(--b2)) 14%);
+    border: 1px solid hsl(var(--bc)/.14);
+    border-radius: 0.75rem;
+    box-shadow:
+      0 1px 0 hsl(var(--bc)/.06) inset,
+      0 0 0 1px hsl(var(--bc)/.08) inset,
+      0 8px 24px rgba(0,0,0,.15);
+    backdrop-filter: blur(4px);
+  }
+}
+
 /* Spectrum, structural (rails, hairlines, edges) */
 @layer components{
   .with-rail{ position:relative; }


### PR DESCRIPTION
## Summary
- ground work and hero cards with reusable `surface-ground` style
- improve readability with bordered, blurred panels

## Testing
- `npm test`
- `npm run lint:advisory`
- `npm run validate:docs`


------
https://chatgpt.com/codex/tasks/task_e_68bbe9bb587c8330bba4744448768746