### PR TITLE
fix: improve consulting mobile layout

### DIFF
--- a/artifacts/reports/20250907T123838Z.md
+++ b/artifacts/reports/20250907T123838Z.md
@@ -1,0 +1,79 @@
+HEADER
+Summary: Improved consulting page mobile responsiveness with fluid headings and constrained floating console.
+Tags: Scope=S2 • Approach=A2 • Novelty=N1,N5 • Skin=K2
+Diff: 4 files changed, 94 insertions(+), 8 deletions(-)
+Files: src/styles/utilities/layout.css, src/consulting.njk, artifacts/worklogs/20250907T123838Z.md, artifacts/reports/20250907T123838Z.md
+Checks: tests: pass, lint:advisory: pass, lint:product-links: pass
+Dev URL: N/A
+Commit: fix(consulting): improve mobile responsiveness (+4 docs commits)
+Worklog: artifacts/worklogs/20250907T123838Z.md
+Report: artifacts/reports/20250907T123838Z.md
+Web Insights: Tailwind docs confirm mobile-first responsive variants
+Risk: low
+
+WHAT CHANGED
+- Added fluid heading utilities in src/styles/utilities/layout.css to scale typography across breakpoints. 【F:src/styles/utilities/layout.css†L4-L6】
+- Replaced fixed sizes with fluid classes in src/consulting.njk for hero and section headings. 【F:src/consulting.njk†L383-L390】
+- Composed hero console container with lg-only float utilities in src/consulting.njk to prevent mobile overflow. 【F:src/consulting.njk†L407】
+- Aestheticized hero card padding for tighter mobile spacing in src/consulting.njk. 【F:src/consulting.njk†L383-L390】
+
+EDIT CARDS
+Path: src/styles/utilities/layout.css
+Ops: [Normalize]
+Anchors: .hb-fluid-h1, .hb-fluid-h2, .hb-fluid-kicker
+Before → After: No responsive heading utilities → Unified fluid typography helpers.
+Micro Example: `.hb-fluid-h1 { @apply text-4xl sm:text-5xl md:text-7xl lg:text-8xl; }`
+Impact: Enables consistent mobile scaling for headings across templates.
+
+Path: src/consulting.njk
+Ops: [Compose, Aestheticize]
+Anchors: hb-fluid-h1, lg:hb-float
+Before → After: Overlarge text and always-floating console → Fluid typography and float limited to large screens.
+Micro Example: `<div class="... lg:hb-float lg:hb-bleed-r lg:hb-nudge lg:hb-float-cr">`
+Impact: Consulting page reads cleanly on phones without losing hypebrut flair.
+
+Path: artifacts/worklogs/20250907T123838Z.md
+Ops: [Document]
+Anchors: worklog
+Before → After: N/A → Added worklog entry.
+Micro Example: `- Added fluid heading utilities in src/styles/utilities/layout.css`
+Impact: Provides audit trail.
+
+Path: artifacts/reports/20250907T123838Z.md
+Ops: [Document]
+Anchors: report
+Before → After: N/A → Added final report.
+Micro Example: `Summary: Improved consulting page mobile responsiveness...`
+Impact: Persists final report.
+
+CHECKS & EVIDENCE
+Name: tests
+Location: `npm test`
+Expectation: All tests pass.
+Micro Example: `nav.js |     100 |      100 |     100 |     100` 【d64ebe†L2-L12】
+Verdict: pass
+Name: lint:advisory
+Location: `npm run lint:advisory`
+Expectation: No advisory namespace lint findings.
+Micro Example: `0 findings` 【80994a†L1-L7】
+Verdict: pass
+Name: lint:product-links
+Location: `npm run lint:product-links`
+Expectation: No product link hygiene issues.
+Micro Example: `count= 0` 【bf9644†L1-L7】
+Verdict: pass
+
+DECISIONS
+Strategy Justification: Used Template Composition (A2) at Standard scope (S2) to refactor page markup and utilities; introduced reusable fluid heading utilities for future pages (N1) while preserving hypebrut aesthetic (N5).
+Assumptions: User desired mobile readability without sacrificing visual style; Tailwind's mobile-first approach guides responsive utility design. 【850a71†L2-L4】
+Discarded Alternatives: Considered rewriting hero as flex column with separate component, but deemed overkill; avoided adding JS for dynamic resizing.
+Pivots & Failures: Initial attempt to toggle hero console float via CSS fallback caused unintended absolute positioning; resolved by gating float utilities behind lg: variants.
+Rollback: Revert files `src/styles/utilities/layout.css` and `src/consulting.njk`, then remove worklog/report entries.
+
+CAPABILITY
+Name: hb-fluid-h1/h2/kicker utilities
+Defaults: Mobile-first heading sizes that scale at sm/md/lg breakpoints.
+Usage: `<h1 class="hb-fluid-h1">Title</h1>`
+
+AESTHETIC CAPSULE
+Neon rails now collapse gracefully, letting the hero breathe on the smallest glass rectangle.

--- a/artifacts/worklogs/20250907T123838Z.md
+++ b/artifacts/worklogs/20250907T123838Z.md
@@ -1,0 +1,7 @@
+# Worklog — Mobile consulting fixes
+- Activated environment.
+- Researched Tailwind responsive design.
+- Added fluid heading utilities in `src/styles/utilities/layout.css`.
+- Updated `src/consulting.njk` to apply new utilities and limit hero console float on small screens.
+- Ran `npm test`.
+- Ran `npm run lint:advisory` and `npm run lint:product-links`.

--- a/src/consulting.njk
+++ b/src/consulting.njk
@@ -380,14 +380,14 @@ permalink: /consulting/
       </div>
     </div>
 <section id="top" class="mb-32">
-  <div class="chunky hb-brut-card hb-intensity-lite hb-accent hb-overflow-visible hb-open-r hb-lean-left hb-card-limit p-8 md:p-12">
+  <div class="chunky hb-brut-card hb-intensity-lite hb-accent hb-overflow-visible hb-open-r hb-lean-left hb-card-limit p-6 md:p-12">
     <!-- grid is predictable; text never gets crushed -->
     <div class="hero-content w-full grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12 p-0 items-start">
 
       <!-- TEXT column (left at lg) -->
       <div class="order-1 lg:order-1 col-span-12 lg:col-span-5 min-w-0">
-        <h1 class="text-6xl md:text-8xl hyper-title text-primary mb-2 hb-underline">{{ DATA.hero.headline }}</h1>
-        <p class="py-6 text-3xl font-mono text-primary/90">{{ DATA.hero.kicker }}</p>
+        <h1 class="hb-fluid-h1 hyper-title text-primary mb-2 hb-underline">{{ DATA.hero.headline }}</h1>
+        <p class="py-6 font-mono text-primary/90 hb-fluid-kicker">{{ DATA.hero.kicker }}</p>
         <div class="text-xl leading-relaxed copy max-w-xl md:max-w-2xl"><p>{{ DATA.hero.about }}</p></div>
 
         <div class="mt-10 flex flex-wrap gap-6">
@@ -404,7 +404,7 @@ permalink: /consulting/
       <!-- moved outside grid for absolute positioning relative to the card wrapper -->
     </div>  <!-- close .hero-content grid -->
 
-    <div class="relative mockup-code bg-base-300 border-2 border-primary/50 w-auto text-xs md:text-sm shadow-2xl overflow-x-auto rounded-lg hb-console lg:hb-console hb-float hb-bleed-r hb-nudge lg:hb-float-cr">
+    <div class="relative mockup-code bg-base-300 border-2 border-primary/50 w-auto max-w-full text-xs md:text-sm shadow-2xl overflow-x-auto rounded-lg hb-console lg:hb-console lg:hb-float lg:hb-bleed-r lg:hb-nudge lg:hb-float-cr">
       {% for l in DATA.hero.code %}
         {% set isBreach = 'BREACH' in l %}
         {% set isCrit   = 'CRITICAL' in l %}
@@ -426,7 +426,7 @@ permalink: /consulting/
     <section class="mb-32">
       <div class="hb-neon hb-intensity-lite hb-stripes rounded-xl p-2">
         <div class="hb-inlay text-center mb-10 p-6 md:p-10 rounded-xl mx-auto max-w-5xl">
-          <h2 class="text-4xl md:text-6xl hyper-title text-primary/90 hb-underline">{{ DATA.metrics.headline }}</h2>
+          <h2 class="hb-fluid-h2 hyper-title text-primary/90 hb-underline">{{ DATA.metrics.headline }}</h2>
           <p class="font-mono mt-6 text-xl opacity-90">{{ DATA.metrics.sub }}</p>
         </div>
       </div>
@@ -446,7 +446,7 @@ permalink: /consulting/
 
     <section id="interventions" class="mb-32">
       <div class="text-center mb-20">
-        <h2 class="text-5xl md:text-7xl hyper-title text-primary hb-underline">SURGICAL INTERVENTIONS</h2>
+        <h2 class="hb-fluid-h2 hyper-title text-primary hb-underline">SURGICAL INTERVENTIONS</h2>
         <p class="font-mono mt-6 text-2xl">We deploy solutions. Your competition deploys excuses.</p>
       </div>
       <div class="grid lg:grid-cols-2 gap-10">
@@ -479,7 +479,7 @@ permalink: /consulting/
     <section id="methodology" class="mb-32">
       <div class="chunky hb-brut-card hb-intensity-lite hb-accent p-8 md:p-12">
         <div class="prose prose-invert max-w-none prose-xl copy">
-          <h2 class="font-mono text-4xl md:text-6xl text-primary not-prose mb-2 hb-underline">{{ DATA.methodology.headline }}</h2>
+          <h2 class="font-mono hb-fluid-h2 text-primary not-prose mb-2 hb-underline">{{ DATA.methodology.headline }}</h2>
           {% for p in DATA.methodology.paras %}<p class="text-xl mb-6">{{ p }}</p>{% endfor %}
           <div class="grid lg:grid-cols-3 gap-10 mt-16 not-prose">
             {% for pillar in DATA.methodology.pillars %}
@@ -501,7 +501,7 @@ permalink: /consulting/
 
     <section id="contact" class="mb-16">
       <div class="chunky hb-brut-card hb-neon hb-intensity-lite hb-inlay hb-accent p-8 md:p-12">
-        <h2 class="text-4xl md:text-6xl font-mono font-bold text-primary mb-2 hb-underline">{{ DATA.cta.headline }}</h2>
+        <h2 class="hb-fluid-h2 font-mono font-bold text-primary mb-2 hb-underline">{{ DATA.cta.headline }}</h2>
         <div class="mt-6 max-w-3xl copy"><p class="text-xl">{{ DATA.cta.text }}</p></div>
         <div class="mt-10">
           <form name="consulting-contact" method="POST" data-netlify="true" netlify class="grid grid-cols-1 lg:grid-cols-2 gap-6" action="/success/">

--- a/src/styles/utilities/layout.css
+++ b/src/styles/utilities/layout.css
@@ -1,4 +1,7 @@
 @layer utilities {
   .stack { @apply flex flex-col gap-4; }
   .center { @apply mx-auto max-w-screen-lg; }
+  .hb-fluid-h1 { @apply text-4xl sm:text-5xl md:text-7xl lg:text-8xl; }
+  .hb-fluid-h2 { @apply text-3xl sm:text-4xl md:text-6xl lg:text-7xl; }
+  .hb-fluid-kicker { @apply text-lg sm:text-xl md:text-2xl; }
 }


### PR DESCRIPTION
## Summary
- improve consulting page mobile typography and layout
- add fluid heading utility classes

## Testing
- `npm test`
- `npm run lint:advisory`
- `npm run lint:product-links`


------
https://chatgpt.com/codex/tasks/task_e_68bd7becf93083308eee719cb00beb3f