### PR TITLE
fix consulting hero layout on mobile

### DIFF
--- a/src/consulting.njk
+++ b/src/consulting.njk
@@ -404,7 +404,7 @@ permalink: /consulting/
       <!-- moved outside grid for absolute positioning relative to the card wrapper -->
     </div>  <!-- close .hero-content grid -->
 
-    <div class="relative mockup-code bg-base-300 border-2 border-primary/50 w-auto text-xs md:text-sm shadow-2xl overflow-x-auto rounded-lg hb-console lg:hb-console hb-float hb-bleed-r hb-nudge lg:hb-float-cr">
+    <div class="relative mockup-code bg-base-300 border-2 border-primary/50 w-full md:w-auto text-xs md:text-sm shadow-2xl overflow-x-auto rounded-lg hb-console lg:hb-console hb-float hb-bleed-reset lg:hb-bleed-r hb-nudge lg:hb-float-cr mx-auto">
       {% for l in DATA.hero.code %}
         {% set isBreach = 'BREACH' in l %}
         {% set isCrit   = 'CRITICAL' in l %}

--- a/src/styles/utilities/layout.css
+++ b/src/styles/utilities/layout.css
@@ -1,4 +1,11 @@
 @layer utilities {
-  .stack { @apply flex flex-col gap-4; }
-  .center { @apply mx-auto max-w-screen-lg; }
+  .stack {
+    @apply flex flex-col gap-4;
+  }
+  .center {
+    @apply mx-auto max-w-screen-lg;
+  }
+  .hb-bleed-reset {
+    @apply mr-0 max-w-full;
+  }
 }


### PR DESCRIPTION
## Summary
- prevent hero code block from bleeding off-screen on small devices
- add reusable `hb-bleed-reset` utility

## Testing
- `npm test`
- `npm run lint:advisory`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd7becf93083308eee719cb00beb3f