### PR TITLE
chore(plan): add planning specs and dry-run generator

### DIFF
--- a/plan/build.spec.json
+++ b/plan/build.spec.json
@@ -1,0 +1,11 @@
+{
+  "passthrough": [
+    "src/content/docs/vendor-docs/**",
+    "src/content/docs/flower/normalized/**",
+    "src/content/docs/flower/reports/**"
+  ],
+  "cleanup": {
+    "file": "tools/runner.mjs",
+    "line": "console.log(`// HEARTBEAT @ ${new Date().toISOString()}: Test runner is active.`);"
+  }
+}

--- a/plan/make-plan.mjs
+++ b/plan/make-plan.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+async function main() {
+  // refuse if git status dirty
+  const git = spawnSync('git', ['status', '--porcelain'], { encoding: 'utf8' });
+  if (git.stdout.trim()) {
+    console.error('Working tree dirty. Commit or stash changes before running.');
+    process.exit(1);
+  }
+
+  const repoRoot = process.cwd();
+  const varDir = path.join(repoRoot, 'var');
+  const inspectDir = path.join(varDir, 'inspect');
+  const planDir = path.join(varDir, 'plan');
+  const reportDir = path.join(varDir, 'reports');
+  fs.mkdirSync(inspectDir, { recursive: true });
+  fs.mkdirSync(planDir, { recursive: true });
+  fs.mkdirSync(reportDir, { recursive: true });
+
+  // Eleventy discovery
+  const eleventyConfigPath = path.join(repoRoot, 'eleventy.config.mjs');
+  const eleventyModule = await import(pathToFileURL(eleventyConfigPath));
+  const stub = {
+    addPassthroughCopy() {},
+    addGlobalData() {},
+    addFilter() {},
+    addNunjucksFilter() {},
+    addPairedShortcode() {},
+    addCollection() {},
+    amendLibrary() {},
+    on() {},
+    markdownLibrary: { parse(){}, renderer:{ render(){ return ''; } }, options:{} }
+  };
+  const result = eleventyModule.default ? eleventyModule.default(stub) : eleventyModule;
+  const eleventyInfo = {
+    input: result.dir?.input || 'src',
+    includes: result.dir?.includes || '_includes',
+    data: result.dir?.data || '_data',
+    formats: result.templateFormats || []
+  };
+
+  // file enumeration using fd or git ls-files
+  let files = [];
+  const fd = spawnSync('fd', ['--type', 'f', '--hidden', '--strip-cwd-prefix', '.', repoRoot, '--exclude', 'node_modules', '--exclude', '.git', '--exclude', 'bin', '--exclude', 'markdown_gateway', '--exclude', 'mcp-stack'], { encoding: 'utf8' });
+  if (fd.status === 0) {
+    files = fd.stdout.trim().split('\n').filter(Boolean);
+  } else {
+    const ls = spawnSync('git', ['ls-files'], { encoding: 'utf8' });
+    files = ls.stdout.trim().split('\n').filter(Boolean).filter(f => !f.startsWith('node_modules/') && !f.startsWith('.git/') && !f.startsWith('bin/') && !f.startsWith('markdown_gateway/') && !f.startsWith('mcp-stack/'));
+  }
+
+  // tree.before.txt
+  spawnSync('npx', ['tree', '-a', '-I', 'node_modules|.git', '-o', path.join(inspectDir, 'tree.before.txt')], { encoding:'utf8', stdio:'ignore' });
+
+  // refscan.txt
+  const refscanPatterns = [
+    '\\bimport\\s+',
+    '\\bfrom\\s+[\"\']',
+    '\\brequire\\(',
+    '\\{\\%\\s*(include|extends|from|render|macro)\\b',
+    '^\\s*(layout|permalink)\\s*:',
+    'href=',
+    'src=',
+    '<link\\s+rel=[\"\']stylesheet[\"\']',
+    '<script[^>]*\\ssrc=',
+    'url\\(',
+    '/(assets|docs|archives|work)'
+  ];
+  const rgArgs = ['--no-ignore', '--hidden', '-n'];
+  for (const p of refscanPatterns) rgArgs.push('-e', p);
+  rgArgs.push('--');
+  rgArgs.push('.');
+  const rg = spawnSync('rg', rgArgs, { encoding: 'utf8' });
+  await fsp.writeFile(path.join(inspectDir, 'refscan.txt'), rg.stdout);
+
+  // writers.txt
+  const writerPatterns = ['fs\\.(write|append|createWriteStream|mkdir)', '>>', '\\btee\\b', 'rimraf', 'rm -rf'];
+  const wargs = ['--no-ignore', '--hidden', '-n'];
+  for (const p of writerPatterns) wargs.push('-e', p);
+  wargs.push('--');
+  wargs.push('.');
+  const wscan = spawnSync('rg', wargs, { encoding: 'utf8' });
+  const writerLines = wscan.stdout.split('\n').filter(l => /(lib|artifacts|logs|tmp)\//.test(l));
+  await fsp.writeFile(path.join(inspectDir, 'writers.txt'), writerLines.join('\n'));
+
+  // unreferenced
+  const refFiles = new Set(rg.stdout.split('\n').map(l => l.split(':')[0]).filter(Boolean));
+  const unref = files.filter(f => !refFiles.has(f) && !f.startsWith(`${eleventyInfo.input}/${eleventyInfo.includes}`) && !f.startsWith(`${eleventyInfo.input}/${eleventyInfo.data}`) && !f.endsWith('.11ty.js') && !f.startsWith('markdown_gateway/') && !f.startsWith('mcp-stack/'));
+  await fsp.writeFile(path.join(inspectDir, 'unref.txt'), unref.join('\n'));
+
+  // move-map.tsv
+  const moveMap = [];
+  function mapDir(srcDir, destDir) {
+    if (!fs.existsSync(srcDir)) return;
+    const res = spawnSync('fd', ['--type', 'f', '--strip-cwd-prefix', '.', srcDir], { encoding: 'utf8' });
+    if (res.status !== 0) return;
+    for (const line of res.stdout.split('\n').filter(Boolean)) {
+      const from = path.join(srcDir, line);
+      const to = path.join(destDir, line);
+      moveMap.push(`${from}\t${to}`);
+    }
+  }
+  mapDir('docs', 'src/content/docs');
+  mapDir('docs/vendor', 'src/content/docs/vendor-docs');
+  mapDir('docs/vendors', 'src/content/docs/vendor-docs');
+  mapDir('flower_reports_showcase', 'src/content/docs/flower');
+  await fsp.writeFile(path.join(planDir, 'move-map.tsv'), moveMap.join('\n'));
+
+  // src-move-map.tsv (placeholder: detect CSS in assets except app.css)
+  const srcMoves = [];
+  if (fs.existsSync('src/assets/css')) {
+    const cssFiles = await fsp.readdir('src/assets/css');
+    for (const f of cssFiles) {
+      if (f !== 'app.css' && f.endsWith('.css')) {
+        srcMoves.push(`src/assets/css/${f}\tsrc/styles/${f}`);
+      }
+    }
+  }
+  await fsp.writeFile(path.join(planDir, 'src-move-map.tsv'), srcMoves.join('\n'));
+
+  // rewrites.sed
+  const rewrites = [
+    's|docs/|src/content/docs/|g',
+    's|docs/vendor/|src/content/docs/vendor-docs/|g',
+    's|docs/vendors/|src/content/docs/vendor-docs/|g',
+    's|flower_reports_showcase/|src/content/docs/flower/|g'
+  ];
+  await fsp.writeFile(path.join(planDir, 'rewrites.sed'), rewrites.join('\n'));
+
+  // apply scripts
+  const scripts = {
+    'apply-moves.sh': '#!/bin/bash\nset -e\n[ "$I_UNDERSTAND" != "1" ] && echo "Refusing: set I_UNDERSTAND=1" && exit 1\necho "Previewing moves"\nwhile IFS="\t" read -r from to; do\n  [ -z "$from" ] && continue\n  echo "git mv \"$from\" \"$to\""\n  git add -N "$from" "$to"\ndone < var/plan/move-map.tsv\n',
+    'apply-rewrites.sh': '#!/bin/bash\nset -e\n[ "$I_UNDERSTAND" != "1" ] && echo "Refusing: set I_UNDERSTAND=1" && exit 1\necho "Would run sed -f var/plan/rewrites.sed on sources"\n',
+    'apply-build.sh': '#!/bin/bash\nset -e\n[ "$I_UNDERSTAND" != "1" ] && echo "Refusing: set I_UNDERSTAND=1" && exit 1\necho "Would configure passthrough copies"\n',
+    'apply-src.sh': '#!/bin/bash\nset -e\n[ "$I_UNDERSTAND" != "1" ] && echo "Refusing: set I_UNDERSTAND=1" && exit 1\necho "Previewing src normalization"\nwhile IFS="\t" read -r from to; do\n  [ -z "$from" ] && continue\n  echo "git mv \"$from\" \"$to\""\n  git add -N "$from" "$to"\ndone < var/plan/src-move-map.tsv\n'
+  };
+  for (const [name, content] of Object.entries(scripts)) {
+    const p = path.join(planDir, name);
+    await fsp.writeFile(p, content);
+    await fsp.chmod(p, 0o755);
+  }
+
+  // reports
+  const planMarkdown = [
+    '# Plan Report',
+    '## Overview',
+    'Dry-run planning of documentation relocation and src normalization.',
+    '## Eleventy Discovery',
+    `input: ${eleventyInfo.input}`,
+    `includes: ${eleventyInfo.includes}`,
+    `data: ${eleventyInfo.data}`,
+    `formats: ${eleventyInfo.formats.join(', ')}`,
+    '## Proposed Moves',
+    moveMap.length ? moveMap.map(m => '- ' + m).join('\n') : 'None',
+    '## Proposed Rewrites',
+    rewrites.map(r => '- ' + r).join('\n'),
+    '## Proposed Passthroughs',
+    '- src/content/docs/vendor-docs/**',
+    '- src/content/docs/flower/normalized/**',
+    '- src/content/docs/flower/reports/**',
+    '## Writers of lib|artifacts|logs|tmp',
+    writerLines.map(l => '- ' + l).join('\n'),
+    '## Unreferenced — Conjecture',
+    unref.map(f => `- ${f} — needs review`).join('\n'),
+    '## Edge Cases (as needed, evidence-driven)',
+    'None observed.'
+  ].join('\n');
+  await fsp.writeFile(path.join(reportDir, 'plan.md'), planMarkdown);
+
+  const planJson = {
+    eleventy: eleventyInfo,
+    moves: moveMap.map(m => {
+      const [from, to] = m.split('\t');
+      return { from, to };
+    }),
+    rewrites,
+    writers: writerLines,
+    unreferenced: unref,
+    edgeCases: [],
+    passthroughs: [
+      'src/content/docs/vendor-docs/**',
+      'src/content/docs/flower/normalized/**',
+      'src/content/docs/flower/reports/**'
+    ]
+  };
+  await fsp.writeFile(path.join(reportDir, 'plan.json'), JSON.stringify(planJson, null, 2));
+
+  console.log('DRY RUN COMPLETE :: artifacts at var/');
+}
+
+import { pathToFileURL } from 'node:url';
+main().catch(err => { console.error(err); process.exit(1); });

--- a/plan/relocate.spec.json
+++ b/plan/relocate.spec.json
@@ -1,0 +1,11 @@
+{
+  "dryRun": true,
+  "maxFilesPerBatch": 50,
+  "maxBatches": 10,
+  "intents": [
+    { "from": "docs/**", "to": "src/content/docs/**", "excludes": ["docs/vendor/**", "docs/vendors/**"] },
+    { "from": "docs/vendor/**", "to": "src/content/docs/vendor-docs/**" },
+    { "from": "docs/vendors/**", "to": "src/content/docs/vendor-docs/**" },
+    { "from": "flower_reports_showcase/**", "to": "src/content/docs/flower/**" }
+  ]
+}

--- a/plan/rewrites.spec.json
+++ b/plan/rewrites.spec.json
@@ -1,0 +1,11 @@
+{
+  "surfaces": ["**/*.{mjs,js,11ty.js,md,njk,html,css,json,jsonl,yml,yaml}"],
+  "excludes": ["markdown_gateway/**", "mcp-stack/**", "node_modules/**", ".git/**", "bin/**"],
+  "pairs": [
+    ["docs/", "src/content/docs/"],
+    ["docs/vendor/", "src/content/docs/vendor-docs/"],
+    ["docs/vendors/", "src/content/docs/vendor-docs/"],
+    ["flower_reports_showcase/", "src/content/docs/flower/"]
+  ],
+  "publicUrlChanges": []
+}

--- a/plan/src-normalize.spec.json
+++ b/plan/src-normalize.spec.json
@@ -1,0 +1,14 @@
+{
+  "allowOverlayAssets": true,
+  "roles": {
+    "routes": ["src/*.njk", "src/*.11ty.js", "src/archives/**", "src/work/**"],
+    "content": ["src/content/**"],
+    "data": ["src/_data/**"],
+    "includes": ["src/_includes/**"],
+    "scripts": ["src/scripts/**"],
+    "styles": ["src/styles/**"],
+    "assets": ["src/assets/**"],
+    "attic": ["src/_attic/**"]
+  },
+  "templatePattern": "**/*.11ty.js"
+}

--- a/test/plan/build-intent.test.mjs
+++ b/test/plan/build-intent.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+
+function readJSON(p){ return JSON.parse(fs.readFileSync(p,'utf8')); }
+
+const spec = readJSON('plan/build.spec.json');
+
+test('passthrough proposals exist', () => {
+  const p = spec.passthrough;
+  assert.ok(p.includes('src/content/docs/vendor-docs/**'));
+  assert.ok(p.includes('src/content/docs/flower/normalized/**'));
+  assert.ok(p.includes('src/content/docs/flower/reports/**'));
+});
+
+test('brittle harness line captured', () => {
+  assert.ok(spec.cleanup && spec.cleanup.line.includes('HEARTBEAT'));
+});

--- a/test/plan/dry-run-no-mutation.test.mjs
+++ b/test/plan/dry-run-no-mutation.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function run(cmd){ return execSync(cmd, {encoding:'utf8'}); }
+
+test('dry run leaves working tree and HEAD unchanged', () => {
+  const headBefore = run('git rev-parse HEAD').trim();
+  const statusBefore = run('git status --porcelain');
+  assert.strictEqual(statusBefore.trim(), '');
+  const output = run('node plan/make-plan.mjs');
+  assert.ok(output.includes('DRY RUN COMPLETE'));
+  const headAfter = run('git rev-parse HEAD').trim();
+  const statusAfter = run('git status --porcelain').split('\n').filter(l => l && !l.startsWith('?? var/')).join('\n');
+  assert.strictEqual(headAfter, headBefore);
+  assert.strictEqual(statusAfter, '');
+  const required = [
+    'var/inspect/tree.before.txt',
+    'var/inspect/refscan.txt',
+    'var/inspect/writers.txt',
+    'var/inspect/unref.txt',
+    'var/plan/move-map.tsv',
+    'var/plan/src-move-map.tsv',
+    'var/plan/rewrites.sed',
+    'var/plan/apply-moves.sh',
+    'var/plan/apply-rewrites.sh',
+    'var/plan/apply-build.sh',
+    'var/plan/apply-src.sh',
+    'var/reports/plan.md',
+    'var/reports/plan.json'
+  ];
+  for (const f of required) {
+    assert.ok(fs.existsSync(f), `${f} missing`);
+  }
+});

--- a/test/plan/edge-cases-as-needed.test.mjs
+++ b/test/plan/edge-cases-as-needed.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function ensurePlan(){
+  if (!fs.existsSync('var/reports/plan.md')) {
+    execSync('node plan/make-plan.mjs', {encoding:'utf8'});
+  }
+}
+
+test('edge cases section exists', () => {
+  ensurePlan();
+  const md = fs.readFileSync('var/reports/plan.md','utf8');
+  assert.ok(md.includes('Edge Cases (as needed, evidence-driven)'));
+  const json = JSON.parse(fs.readFileSync('var/reports/plan.json','utf8'));
+  assert.ok(Array.isArray(json.edgeCases));
+  if (json.publicUrlChanges && json.publicUrlChanges.length) {
+    assert.ok(md.includes('public URL'));
+  }
+});

--- a/test/plan/existence-and-shape.test.mjs
+++ b/test/plan/existence-and-shape.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+
+const files = [
+  'plan/relocate.spec.json',
+  'plan/rewrites.spec.json',
+  'plan/build.spec.json',
+  'plan/src-normalize.spec.json',
+  'plan/make-plan.mjs'
+];
+
+for (const f of files) {
+  test(`exists: ${f}`, () => {
+    assert.ok(fs.existsSync(f));
+  });
+}
+
+test('relocate spec has required intents', () => {
+  const spec = JSON.parse(fs.readFileSync('plan/relocate.spec.json', 'utf8'));
+  const intents = spec.intents || [];
+  const has = (from, to) => intents.some(i => i.from === from && i.to === to);
+  assert.strictEqual(spec.dryRun, true);
+  assert.ok(has('docs/**', 'src/content/docs/**'));
+  assert.ok(has('docs/vendor/**', 'src/content/docs/vendor-docs/**'));
+  assert.ok(has('docs/vendors/**', 'src/content/docs/vendor-docs/**'));
+  assert.ok(has('flower_reports_showcase/**', 'src/content/docs/flower/**'));
+});
+
+test('rewrites spec covers required pairs and publicUrlChanges', () => {
+  const spec = JSON.parse(fs.readFileSync('plan/rewrites.spec.json', 'utf8'));
+  const pairs = spec.pairs.map(p => p.join('->'));
+  ['docs/->src/content/docs/',
+   'docs/vendor/->src/content/docs/vendor-docs/',
+   'docs/vendors/->src/content/docs/vendor-docs/',
+   'flower_reports_showcase/->src/content/docs/flower/'].forEach(p => assert.ok(pairs.includes(p)));
+  assert.deepStrictEqual(spec.publicUrlChanges, []);
+});
+
+test('build spec includes passthroughs and cleanup line', () => {
+  const spec = JSON.parse(fs.readFileSync('plan/build.spec.json', 'utf8'));
+  assert.ok(spec.passthrough.includes('src/content/docs/vendor-docs/**'));
+  assert.ok(spec.passthrough.includes('src/content/docs/flower/normalized/**'));
+  assert.ok(spec.passthrough.includes('src/content/docs/flower/reports/**'));
+  assert.ok(spec.cleanup && spec.cleanup.file && spec.cleanup.line);
+});
+
+test('src-normalize spec encodes overlay allowance and template rule', () => {
+  const spec = JSON.parse(fs.readFileSync('plan/src-normalize.spec.json', 'utf8'));
+  assert.strictEqual(spec.allowOverlayAssets, true);
+  assert.ok(spec.templatePattern && spec.templatePattern.includes('11ty.js'));
+});

--- a/test/plan/relocate-coverage.test.mjs
+++ b/test/plan/relocate-coverage.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function ensurePlan(){
+  if (!fs.existsSync('var/plan/move-map.tsv')) {
+    execSync('node plan/make-plan.mjs', {encoding:'utf8'});
+  }
+}
+
+test('relocate spec declares doc intents', () => {
+  const spec = JSON.parse(fs.readFileSync('plan/relocate.spec.json','utf8'));
+  const intents = spec.intents.map(i => i.from);
+  ['docs/**','docs/vendor/**','docs/vendors/**','flower_reports_showcase/**'].forEach(p => assert.ok(intents.includes(p)));
+});
+
+test('move-map has rows when source dirs exist', () => {
+  ensurePlan();
+  const moveMap = fs.readFileSync('var/plan/move-map.tsv','utf8').trim();
+  const hasDocs = fs.existsSync('docs');
+  const hasFlower = fs.existsSync('flower_reports_showcase');
+  if (hasDocs || hasFlower) {
+    assert.ok(moveMap.length > 0);
+  } else {
+    assert.ok(fs.existsSync('var/plan/move-map.tsv'));
+  }
+});

--- a/test/plan/rewrites-coverage.test.mjs
+++ b/test/plan/rewrites-coverage.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function ensurePlan(){
+  if (!fs.existsSync('var/plan/rewrites.sed')) {
+    execSync('node plan/make-plan.mjs', {encoding:'utf8'});
+  }
+}
+
+test('rewrites spec has required pairs and publicUrlChanges empty', () => {
+  const spec = JSON.parse(fs.readFileSync('plan/rewrites.spec.json','utf8'));
+  const pairs = spec.pairs.map(p => p.join('->'));
+  ['docs/->src/content/docs/',
+   'docs/vendor/->src/content/docs/vendor-docs/',
+   'docs/vendors/->src/content/docs/vendor-docs/',
+   'flower_reports_showcase/->src/content/docs/flower/'].forEach(p => assert.ok(pairs.includes(p)));
+  assert.deepStrictEqual(spec.publicUrlChanges, []);
+});
+
+test('rewrites.sed compiles required pairs', () => {
+  ensurePlan();
+  const sed = fs.readFileSync('var/plan/rewrites.sed','utf8');
+  ['s|docs/|src/content/docs/|g',
+   's|docs/vendor/|src/content/docs/vendor-docs/|g',
+   's|docs/vendors/|src/content/docs/vendor-docs/|g',
+   's|flower_reports_showcase/|src/content/docs/flower/|g'].forEach(r => assert.ok(sed.includes(r)));
+});

--- a/test/plan/size-discipline.test.mjs
+++ b/test/plan/size-discipline.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+test('only plan and test/plan modified; plan files small', () => {
+  const lines = execSync('git status --porcelain', {encoding:'utf8'}).trim().split('\n').filter(Boolean);
+  const filtered = lines.filter(l => !l.startsWith('?? var/'));
+  const bad = filtered.filter(l => {
+    const file = l.slice(3);
+    return !(file.startsWith('plan/') || file.startsWith('test/plan/'));
+  });
+  assert.strictEqual(bad.length, 0);
+  const planFiles = [
+    'plan/relocate.spec.json',
+    'plan/rewrites.spec.json',
+    'plan/build.spec.json',
+    'plan/src-normalize.spec.json',
+    'plan/make-plan.mjs'
+  ];
+  for (const f of planFiles) {
+    const stat = fs.statSync(f);
+    assert.ok(stat.size < 131072, `${f} too large`);
+    const buf = fs.readFileSync(f);
+    assert.ok(!buf.includes(0), `${f} not text`);
+  }
+});

--- a/test/plan/src-role-map.test.mjs
+++ b/test/plan/src-role-map.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+
+const spec = JSON.parse(fs.readFileSync('plan/src-normalize.spec.json','utf8'));
+
+test('canonical role homes declared', () => {
+  const r = spec.roles || {};
+  ['routes','content','data','includes','scripts','styles','assets'].forEach(k => assert.ok(Array.isArray(r[k])));
+  assert.strictEqual(spec.allowOverlayAssets, true);
+  assert.ok(spec.templatePattern.includes('11ty.js'));
+});
+
+test('archives dynamic templates treated as templates', () => {
+  const pattern = spec.templatePattern;
+  assert.ok(pattern.includes('11ty.js'));
+});
+
+test('published CSS app.css exists', () => {
+  assert.ok(fs.existsSync('src/assets/css/app.css'));
+});

--- a/test/plan/writers-and-unref.test.mjs
+++ b/test/plan/writers-and-unref.test.mjs
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function ensurePlan(){
+  if (!fs.existsSync('var/inspect/writers.txt')) {
+    execSync('node plan/make-plan.mjs', {encoding:'utf8'});
+  }
+}
+
+test('writers and unreferenced reported', () => {
+  ensurePlan();
+  const writers = fs.readFileSync('var/inspect/writers.txt','utf8').trim().split('\n').filter(Boolean);
+  assert.ok(writers.some(l => /(lib|artifacts|logs|tmp)\//.test(l)));
+  const unref = fs.readFileSync('var/inspect/unref.txt','utf8').trim().split('\n').filter(Boolean);
+  const md = fs.readFileSync('var/reports/plan.md','utf8');
+  const json = JSON.parse(fs.readFileSync('var/reports/plan.json','utf8'));
+  for (const f of unref) {
+    assert.ok(md.includes(f) || (json.unreferenced||[]).includes(f));
+  }
+});


### PR DESCRIPTION
## Summary
- seed relocation intents for docs, vendor mirrors, and flower showcase【F:plan/relocate.spec.json†L1-L9】
- map rewrite pairs for future sed-based path updates【F:plan/rewrites.spec.json†L1-L10】
- add dry-run generator that refuses dirty worktrees and emits move maps【F:plan/make-plan.mjs†L7-L44】【F:plan/make-plan.mjs†L180-L192】

## Testing
- `node -v`【7752bd†L1-L2】
- `git status --porcelain`【f10653†L1-L2】
- `npm test` (fails: Legacy Redirect alias stub page exists)【b41ab8†L1-L8】【121186†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68bf914a7d6c833081390f8a7af24c67