### PR TITLE
fix(css): load daisyui via tailwind plugin

### DIFF
--- a/src/assets/css/app.tailwind.css
+++ b/src/assets/css/app.tailwind.css
@@ -1,1 +1,3 @@
-@import "tailwindcss";
+@import 'tailwindcss';
+@plugin "@tailwindcss/typography";
+@plugin "daisyui";

--- a/src/assets/css/mschf-overlay.css
+++ b/src/assets/css/mschf-overlay.css
@@ -1,1 +1,3 @@
-@import "tailwindcss";
+@import 'tailwindcss';
+@plugin "@tailwindcss/typography";
+@plugin "daisyui";

--- a/src/content/docs/knowledge/daisyui-fetch-error-20250911T174939Z.log
+++ b/src/content/docs/knowledge/daisyui-fetch-error-20250911T174939Z.log
@@ -1,0 +1,74 @@
+node:internal/deps/undici/undici:13510
+      Error.captureStackTrace(err);
+            ^
+
+TypeError: fetch failed
+    at node:internal/deps/undici/undici:13510:13
+    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at async file:///workspace/effusion-labs/[eval1]:1:52 {
+  [cause]: AggregateError [ENETUNREACH]: 
+      at internalConnectMultiple (node:net:1134:18)
+      at internalConnectMultiple (node:net:1210:5)
+      at internalConnectMultiple (node:net:1210:5)
+      at internalConnectMultiple (node:net:1210:5)
+      at internalConnectMultiple (node:net:1210:5)
+      at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+      at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+      at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+    code: 'ENETUNREACH',
+    [errors]: [
+      Error: connect ENETUNREACH 2606:4700:3035::ac43:d8bc:443 - Local (:::0)
+          at internalConnectMultiple (node:net:1206:16)
+          at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+          at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+          at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+        errno: -101,
+        code: 'ENETUNREACH',
+        syscall: 'connect',
+        address: '2606:4700:3035::ac43:d8bc',
+        port: 443
+      },
+      Error: connect ENETUNREACH 172.67.216.188:443 - Local (0.0.0.0:0)
+          at internalConnectMultiple (node:net:1206:16)
+          at internalConnectMultiple (node:net:1210:5)
+          at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+          at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+          at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+        errno: -101,
+        code: 'ENETUNREACH',
+        syscall: 'connect',
+        address: '172.67.216.188',
+        port: 443
+      },
+      Error: connect ENETUNREACH 2606:4700:3030::6815:1822:443 - Local (:::0)
+          at internalConnectMultiple (node:net:1206:16)
+          at internalConnectMultiple (node:net:1210:5)
+          at internalConnectMultiple (node:net:1210:5)
+          at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+          at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+          at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+        errno: -101,
+        code: 'ENETUNREACH',
+        syscall: 'connect',
+        address: '2606:4700:3030::6815:1822',
+        port: 443
+      },
+      Error: connect ENETUNREACH 104.21.24.34:443 - Local (0.0.0.0:0)
+          at internalConnectMultiple (node:net:1206:16)
+          at internalConnectMultiple (node:net:1210:5)
+          at internalConnectMultiple (node:net:1210:5)
+          at internalConnectMultiple (node:net:1210:5)
+          at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+          at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+          at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+        errno: -101,
+        code: 'ENETUNREACH',
+        syscall: 'connect',
+        address: '104.21.24.34',
+        port: 443
+      }
+    ]
+  }
+}
+
+Node.js v22.19.0

--- a/src/content/docs/knowledge/tailwind-fetch-error-20250911T174938Z.log
+++ b/src/content/docs/knowledge/tailwind-fetch-error-20250911T174938Z.log
@@ -1,0 +1,74 @@
+node:internal/deps/undici/undici:13510
+      Error.captureStackTrace(err);
+            ^
+
+TypeError: fetch failed
+    at node:internal/deps/undici/undici:13510:13
+    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at async file:///workspace/effusion-labs/[eval1]:1:52 {
+  [cause]: AggregateError [ENETUNREACH]: 
+      at internalConnectMultiple (node:net:1134:18)
+      at internalConnectMultiple (node:net:1210:5)
+      at internalConnectMultiple (node:net:1210:5)
+      at internalConnectMultiple (node:net:1210:5)
+      at internalConnectMultiple (node:net:1210:5)
+      at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+      at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+      at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+    code: 'ENETUNREACH',
+    [errors]: [
+      Error: connect ENETUNREACH 2606:4700:10::ac42:9b74:443 - Local (:::0)
+          at internalConnectMultiple (node:net:1206:16)
+          at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+          at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+          at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+        errno: -101,
+        code: 'ENETUNREACH',
+        syscall: 'connect',
+        address: '2606:4700:10::ac42:9b74',
+        port: 443
+      },
+      Error: connect ENETUNREACH 104.20.19.83:443 - Local (0.0.0.0:0)
+          at internalConnectMultiple (node:net:1206:16)
+          at internalConnectMultiple (node:net:1210:5)
+          at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+          at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+          at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+        errno: -101,
+        code: 'ENETUNREACH',
+        syscall: 'connect',
+        address: '104.20.19.83',
+        port: 443
+      },
+      Error: connect ENETUNREACH 2606:4700:10::6814:1353:443 - Local (:::0)
+          at internalConnectMultiple (node:net:1206:16)
+          at internalConnectMultiple (node:net:1210:5)
+          at internalConnectMultiple (node:net:1210:5)
+          at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+          at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+          at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+        errno: -101,
+        code: 'ENETUNREACH',
+        syscall: 'connect',
+        address: '2606:4700:10::6814:1353',
+        port: 443
+      },
+      Error: connect ENETUNREACH 172.66.155.116:443 - Local (0.0.0.0:0)
+          at internalConnectMultiple (node:net:1206:16)
+          at internalConnectMultiple (node:net:1210:5)
+          at internalConnectMultiple (node:net:1210:5)
+          at internalConnectMultiple (node:net:1210:5)
+          at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
+          at GetAddrInfoReqWrap.emitLookup [as callback] (node:net:1552:7)
+          at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
+        errno: -101,
+        code: 'ENETUNREACH',
+        syscall: 'connect',
+        address: '172.66.155.116',
+        port: 443
+      }
+    ]
+  }
+}
+
+Node.js v22.19.0

--- a/src/content/docs/reports/20250911T175310Z.md
+++ b/src/content/docs/reports/20250911T175310Z.md
@@ -1,0 +1,3 @@
+# Report: Tailwind DaisyUI integration
+
+Updated Tailwind CSS pipeline to explicitly load `@tailwindcss/typography` and `daisyui` via `@plugin` directives. PostCSS build now emits DaisyUI components and passes Eleventy build and tests.

--- a/src/content/docs/worklogs/20250911T175310Z.md
+++ b/src/content/docs/worklogs/20250911T175310Z.md
@@ -1,0 +1,7 @@
+# CSS plugin integration worklog
+
+- Ensured repo environment active
+- Investigated Tailwind build issues; DaisyUI and typography plugins were missing
+- Added `@plugin` directives to Tailwind entry CSS files
+- Compiled PostCSS outputs verifying DaisyUI banner
+- Build and tests passed


### PR DESCRIPTION
## Summary
- enable daisyUI and typography via Tailwind `@plugin` directives in both CSS entry points
- document build process and store network failure logs

## Testing
- `./bin/npm exec postcss -- src/assets/css/app.tailwind.css -o /tmp/app.css --verbose`
- `./bin/npm run build`
- `./bin/npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c30b2a5734833097cb1aa06c595282