### PR TITLE
fix: restore css import for vite build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tmp/
 
 # Generated CSS
 src/assets/css/*
+!src/assets/css/app.css
 !src/assets/css/.gitkeep
 !src/assets/css/*.tailwind.css
 !src/assets/css/mschf-overlay.css

--- a/config/register.mjs
+++ b/config/register.mjs
@@ -42,11 +42,12 @@ export default function register(eleventyConfig) {
   });
 
   // --- Asset Passthroughs & Watch Targets ---
-  eleventyConfig.addPassthroughCopy({ "src/assets/js": "assets/js" });
-  eleventyConfig.addPassthroughCopy({ "src/favicon.ico": "favicon.ico" });
-  eleventyConfig.addPassthroughCopy({ "src/assets/static": "assets" });
-  eleventyConfig.addPassthroughCopy({ "src/assets/icons": "assets/icons" });
-  eleventyConfig.addWatchTarget("src/assets/css/");
+    eleventyConfig.addPassthroughCopy({ "src/assets/js": "assets/js" });
+    eleventyConfig.addPassthroughCopy({ "src/assets/css": "assets/css" });
+    eleventyConfig.addPassthroughCopy({ "src/favicon.ico": "favicon.ico" });
+    eleventyConfig.addPassthroughCopy({ "src/assets/static": "assets" });
+    eleventyConfig.addPassthroughCopy({ "src/assets/icons": "assets/icons" });
+    eleventyConfig.addWatchTarget("src/assets/css/");
 
   // After build: write unresolved report (log-only, no CI fail)
   eleventyConfig.on("eleventy.after", () => {

--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -1,0 +1,10 @@
+@import 'tailwindcss';
+@plugin "@tailwindcss/typography";
+
+:root {
+  --hb-accent: #ff00ff;
+}
+
+body {
+  @apply bg-background text-text;
+}

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -3,7 +3,7 @@
 // Consolidates: footnote nav, theme toggle, code copy, work filters.
 // Lazily loads the heavy overlay only when conditions are good.
 
-import "@/assets/css/app.css";
+import "../css/app.css";
 
 /* -------------------------------
    tiny utils

--- a/src/content/docs/knowledge/github-issue-vite-import-20250912T201457Z.json
+++ b/src/content/docs/knowledge/github-issue-vite-import-20250912T201457Z.json
@@ -1,0 +1,2 @@
+"[BUG] Firebase import error - \"Failed to resolve import 'firebase/auth'\""
+"https://github.com/SCR01/scr-game/issues/86"

--- a/src/content/docs/knowledge/vite-shared-options-20250912T201533Z.md
+++ b/src/content/docs/knowledge/vite-shared-options-20250912T201533Z.md
@@ -1,0 +1,14 @@
+## resolve.alias
+
+- **Type:**
+  `Record<string, string> | Array<{ find: string | RegExp, replacement: string, customResolver?: ResolverFunction | ResolverObject }>`
+
+Will be passed to `@rollup/plugin-alias` as its [entries option](https://github.com/rollup/plugins/tree/master/packages/alias#entries). Can either be an object, or an array of `{ find, replacement, customResolver }` pairs.
+
+When aliasing to file system paths, always use absolute paths. Relative alias values will be used as-is and will not be resolved into file system paths.
+
+More advanced custom resolution can be achieved through [plugins](/guide/api-plugin).
+
+::: warning Using with SSR
+If you have configured aliases for [SSR externalized dependencies](/guide/ssr.md#ssr-externals), you may want to alias the actual `node_modules` packages. Both [Yarn](https://classic.yarnpkg.com/en/docs/cli/add/#toc-yarn-add-alias) and [pnpm](https://pnpm.io/aliases/) support aliasing via the `npm:` prefix.
+:::

--- a/src/content/docs/reports/20250912T202100Z.md
+++ b/src/content/docs/reports/20250912T202100Z.md
@@ -1,0 +1,3 @@
+# Fix Vite CSS import
+
+See commit message for details.

--- a/src/content/docs/worklogs/20250912T202059Z.md
+++ b/src/content/docs/worklogs/20250912T202059Z.md
@@ -1,0 +1,6 @@
+# Worklog 2025-09-12
+- investigated Vite CSS import error
+- created `src/assets/css/app.css` with Tailwind entry
+- enabled Eleventy passthrough copy for CSS in `config/register.mjs`
+- switched JS import to relative path to satisfy build
+- ran tests and build; both succeeded


### PR DESCRIPTION
## Summary
- add Tailwind-driven `src/assets/css/app.css`
- copy CSS through Eleventy and use relative import

## Testing
- `./bin/npm test`
- `./bin/npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c47b6ed0dc8330a8db3077dffc1720