### PR TITLE
Fix retry_exec sentinel handling and align bin shims

### DIFF
--- a/bin/_lib.sh
+++ b/bin/_lib.sh
@@ -7,6 +7,25 @@ can_sudo() {
   command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1
 }
 
+path_without_repo_bin() {
+  local new_path=""
+  local part
+  local -a path_parts=()
+  IFS=':' read -ra path_parts <<<"${PATH:-}"
+  for part in "${path_parts[@]}"; do
+    [[ -z "$part" ]] && part='.'
+    if [[ "$part" == "$REPO_ROOT/bin" ]]; then
+      continue
+    fi
+    if [[ -z "$new_path" ]]; then
+      new_path="$part"
+    else
+      new_path+=":$part"
+    fi
+  done
+  printf '%s' "$new_path"
+}
+
 apt_install() {
   local pkg="${1:-}"
   [[ -z "$pkg" ]] && return 1
@@ -18,17 +37,46 @@ apt_install() {
 }
 
 retry_exec() {
-  local args=()
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --) shift; break;;
-      *) args+=("$1"); shift;;
-    esac
+  local -a all_args=("$@")
+  local sentinel_index=-1
+  for (( idx=${#all_args[@]}-1; idx>=0; idx-- )); do
+    if [[ "${all_args[idx]}" == "--" ]]; then
+      sentinel_index=$idx
+      break
+    fi
   done
-  local candidates=("$@")
+
+  if (( sentinel_index < 0 )); then
+    echo "retry_exec: missing '--' separator" >&2
+    return 1
+  fi
+
+  local -a args=()
+  if (( sentinel_index > 0 )); then
+    args=("${all_args[@]:0:sentinel_index}")
+  fi
+
+  local -a candidates=()
+  if (( sentinel_index + 1 < ${#all_args[@]} )); then
+    candidates=("${all_args[@]:sentinel_index+1}")
+  fi
+
+  if (( ${#candidates[@]} == 0 )); then
+    echo "retry_exec: no fallback executables provided" >&2
+    return 1
+  fi
+
+  local c resolved
   for c in "${candidates[@]}"; do
-    if [[ -x "$c" ]]; then exec "$c" "${args[@]}"; fi
-    if command -v "$c" >/dev/null 2>&1; then exec "$c" "${args[@]}"; fi
+    [[ -z "$c" ]] && continue
+    if [[ -x "$c" ]]; then
+      exec "$c" "${args[@]}"
+    fi
+    resolved="$(command -v "$c" 2>/dev/null || true)"
+    if [[ -n "$resolved" ]]; then
+      exec "$resolved" "${args[@]}"
+    fi
   done
+
   return 1
 }

--- a/bin/node
+++ b/bin/node
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
-DIR="$(cd "$(dirname "$0")" && pwd)"
-PATH_WITHOUT_DIR=$(printf "%s" "$PATH" | sed "s|$DIR:||;s|:$DIR||;s|$DIR||")
-REAL_NODE="$(PATH="$PATH_WITHOUT_DIR" command -v node)"
-if [ -z "$REAL_NODE" ]; then
+. "$(cd "$(dirname "$0")" && pwd)/_lib.sh"
+
+PATH_WITHOUT_REPO_BIN="$(path_without_repo_bin)"
+REAL_NODE=""
+if [[ -n "$PATH_WITHOUT_REPO_BIN" ]]; then
+  REAL_NODE="$(PATH="$PATH_WITHOUT_REPO_BIN" command -v node 2>/dev/null || true)"
+fi
+
+if [[ -z "$REAL_NODE" ]]; then
   echo "node binary not found" >&2
   exit 127
 fi
+
 exec "$REAL_NODE" "$@"

--- a/bin/npm
+++ b/bin/npm
@@ -1,9 +1,27 @@
 #!/usr/bin/env bash
-# Repo-local npm shim: inject keepalive for npm test invocations.
+# Repo-local npm shim: inject keepalive for npm test invocations and reuse bin/_lib helpers.
 set -euo pipefail
+. "$(cd "$(dirname "$0")" && pwd)/_lib.sh"
+
 orig_args=("$@")
 if [[ "${1:-}" == "test" ]] || { [[ "${1:-}" == "run" ]] && [[ "${2:-}" == "test" ]]; }; then
   export NODE_OPTIONS="${NODE_OPTIONS:-} --import=./test/setup/llm-keepalive.mjs"
 fi
-REAL_NPM="$(command -v -a npm | awk 'NR==2{print;exit}')"
-exec "${REAL_NPM:-/usr/bin/npm}" "${orig_args[@]}"
+
+PATH_WITHOUT_REPO_BIN="$(path_without_repo_bin)"
+REAL_NPM=""
+if [[ -n "$PATH_WITHOUT_REPO_BIN" ]]; then
+  REAL_NPM="$(PATH="$PATH_WITHOUT_REPO_BIN" command -v npm 2>/dev/null || true)"
+fi
+
+candidates=(
+  "$REPO_ROOT/node_modules/.bin/npm"
+)
+if [[ -n "$REAL_NPM" ]]; then
+  candidates+=("$REAL_NPM")
+fi
+
+retry_exec "${orig_args[@]}" -- "${candidates[@]}"
+
+echo "❌ npm not available; ensure Node.js/npm is installed." >&2
+exit 127

--- a/bin/prettier
+++ b/bin/prettier
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-BIN_LOCAL="$REPO_ROOT/node_modules/.bin/prettier"
+. "$(cd "$(dirname "$0")" && pwd)/_lib.sh"
 
-# Ensure local devDependency exists (non‑interactive idempotent install)
-if [[ ! -x "$BIN_LOCAL" ]]; then
+ensure_local_prettier() {
+  local bin_local="$REPO_ROOT/node_modules/.bin/prettier"
+  if [[ -x "$bin_local" ]]; then
+    return 0
+  fi
+
   if command -v npm >/dev/null 2>&1; then
     echo "📦 Installing prettier (devDependency)..." >&2
-    # Pin major to 3 for stability; exact patch can float via lockfile.
     npm install --save-dev --save-exact prettier@3 >/dev/null 2>&1 || true
   fi
-fi
+}
 
-if [[ -x "$BIN_LOCAL" ]]; then
-  exec "$BIN_LOCAL" "$@"
-fi
+ensure_local_prettier
 
-# Fallback to global (if present)
-if command -v prettier >/dev/null 2>&1; then
-  exec prettier "$@"
-fi
+retry_exec "$@" -- \
+  "$REPO_ROOT/node_modules/.bin/prettier" \
+  "$TOOLS_DIR/prettier/prettier" \
+  prettier
 
 echo "❌ prettier not available and local install failed. Ensure npm is usable or preinstall devDeps." >&2
 exit 127

--- a/test/unit/retry-exec.test.mjs
+++ b/test/unit/retry-exec.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+
+const run = (script) =>
+  execFileSync('bash', ['-lc', script], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+test('retry_exec falls back to the first available executable', () => {
+  const output = run(`
+    set -euo pipefail
+    source ./bin/_lib.sh
+    retry_exec "%s\\n" hi -- /nonexistent "$(command -v printf)"
+  `)
+
+  assert.equal(output, 'hi\n')
+})
+
+test('retry_exec preserves literal -- arguments before the separator', () => {
+  const output = run(`
+    set -euo pipefail
+    source ./bin/_lib.sh
+    retry_exec "%s %s\\n" "--" "value" -- "$(command -v printf)"
+  `)
+
+  assert.equal(output, '-- value\n')
+})
+
+test('retry_exec errors when the separator is missing', () => {
+  try {
+    run(`
+      set -euo pipefail
+      source ./bin/_lib.sh
+      retry_exec foo bar
+    `)
+    assert.fail('retry_exec should exit with an error when the separator is absent')
+  } catch (err) {
+    assert.equal(err.status, 1)
+    assert.match(err.stderr, /missing '--' separator/)
+  }
+})


### PR DESCRIPTION
## Summary
- teach `retry_exec` to split caller arguments from fallback candidates reliably and add a helper to remove the repo bin directory from PATH lookups
- refactor the npm, node, and prettier shims to source `_lib`, reuse the shared helpers, and lean on the repaired `retry_exec`
- add a focused unit test suite for `retry_exec`, covering fallback resolution, literal `--` handling, and missing separator errors

## Testing
- node --test test/unit/retry-exec.test.mjs
- npm test *(fails: Eleventy Liquid callout syntax error in existing content)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2380ec0c8330adf0c11866512139