### PR TITLE
fix: stabilize CI patch verification and proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format:classes": "rustywind --write \"src/**/*.{njk,html,js,jsx,ts,tsx}\"",
     "format:all": "npm run format:classes && npm run format",
     "format:check:all": "npm run format:check",
+    "verify:patches": "patch-package --error-on-fail",
     "lint": "npm-run-all --parallel lint:js lint:links",
     "lint:js": "eslint \"src/**/*.{js,mjs,ts,tsx}\" \"tools/**/*.mjs\" \"mcp-stack/**/*.mjs\" eleventy.config.mjs --report-unused-disable-directives",
     "lint:fix": "eslint \"src/**/*.{js,mjs,ts,tsx}\" \"tools/**/*.mjs\" \"mcp-stack/**/*.mjs\" eleventy.config.mjs --fix",

--- a/patches/rustywind+0.24.3.patch
+++ b/patches/rustywind+0.24.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/rustywind/lib/download.js b/node_modules/rustywind/lib/download.js
+index 7947b52..e127d1e 100644
+--- a/node_modules/rustywind/lib/download.js
++++ b/node_modules/rustywind/lib/download.js
+@@ -81,7 +81,7 @@ async function download(_url, dest, opts) {
+   // Handle proxy setup
+   const proxy = proxy_from_env.getProxyForUrl(url.parse(_url));
+   if (proxy) {
+-    const HttpsProxyAgent = require("https-proxy-agent");
++    const { HttpsProxyAgent } = require("https-proxy-agent");
+     opts = {
+       ...opts,
+       agent: new HttpsProxyAgent(proxy),


### PR DESCRIPTION
## Summary
- add a verify:patches npm script so the Docker build stage no longer calls an undefined task
- patch rustywind's proxy handling so installs succeed behind corporate proxies and CI caches

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1c82b4fb883308ce413ae313ea629