### PR TITLE
Harden CI and Docker builds against upstream downloads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,14 @@ env:
   WEB_IMAGE: ghcr.io/toxicwind/effusion-labs
   GATEWAY_IMAGE: ghcr.io/toxicwind/markdown-gateway
   CI: true
+  PUPPETEER_SKIP_DOWNLOAD: 'true'
+  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 'true'
+  http_proxy: ''
+  https_proxy: ''
+  npm_config_proxy: ''
+  npm_config_https_proxy: ''
+  npm_config_http_proxy: ''
 
 permissions:
   contents: read

--- a/.portainer/Dockerfile
+++ b/.portainer/Dockerfile
@@ -10,7 +10,15 @@ RUN apk add --no-cache build-base python3 libc6-compat
 
 # Keep install in "dev" mode so devDependencies are present for the build
 ENV npm_config_fund=false \
-    npm_config_audit=false
+    npm_config_audit=false \
+    npm_config_proxy= \
+    npm_config_https_proxy= \
+    npm_config_http_proxy= \
+    http_proxy= \
+    https_proxy= \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 COPY package*.json ./
 COPY patches/ ./patches/
@@ -28,7 +36,15 @@ ENV COMMIT_SHA=${COMMIT_SHA}
 
 # Production signals for the toolchain
 ENV NODE_ENV=production \
-    ELEVENTY_ENV=production
+    ELEVENTY_ENV=production \
+    npm_config_proxy= \
+    npm_config_https_proxy= \
+    npm_config_http_proxy= \
+    http_proxy= \
+    https_proxy= \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 COPY --from=deps /app/node_modules /app/node_modules
 COPY package*.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -22830,6 +22830,33 @@
         "rustywind": "bin/rustywind"
       }
     },
+    "node_modules/rustywind/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/rustywind/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "serve": "npx @11ty/eleventy --serve",
     "bench": "DEBUG=Eleventy:Benchmark* npx @11ty/eleventy",
     "build": "npx @11ty/eleventy",
+    "verify:patches": "patch-package --check",
     "clean": "del-cli _site",
     "format:check": "dprint check -c dprint.json",
     "format": "dprint fmt -c dprint.json",
@@ -173,6 +174,11 @@
   },
   "engines": {
     "node": ">=22.19.0"
+  },
+  "overrides": {
+    "rustywind": {
+      "https-proxy-agent": "5.0.1"
+    }
   },
   "dependencies": {
     "iconify-icon": "3.0.1"


### PR DESCRIPTION
## Summary
- add patch verification script and npm override to keep rustywind’s proxy dependency on a Node 16 compatible release
- harden the Portainer build image by skipping browser downloads and clearing proxy environment variables so npm ci succeeds reliably
- propagate the same no-download/no-proxy environment defaults into the deploy workflow to keep GitHub Actions builds deterministic

## Testing
- `npm ci`
- `npm test`
- `npm run build` *(fails: outbound asset fetch blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c6d4dca8833096bccb7b15389dc8