### PR TITLE
Tame MSCHF overlay load for UHD viewports

### DIFF
--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -1654,4 +1654,29 @@ html {
   #mschf-overlay-root[data-mschf-profile="essay"] .mschf-pip::after {
     opacity: 0.65;
   }
+
+  #mschf-overlay-root[data-mschf-tier="uhd"] {
+    --mschf-noise: 0.035;
+  }
+  #mschf-overlay-root[data-mschf-tier="uhd"] .mschf-scanline {
+    animation-duration: calc(var(--mschf-scan-speed, 9s) * 1.45);
+  }
+  #mschf-overlay-root[data-mschf-tier="uhd"] .mschf-glitch {
+    animation-duration: 1.6s;
+  }
+  #mschf-overlay-root[data-mschf-tier="uhd"] .mschf-holo {
+    animation-duration: 20s;
+  }
+  #mschf-overlay-root[data-mschf-tier="uhd"] .mschf-callout {
+    animation-duration: 7s;
+  }
+  #mschf-overlay-root[data-mschf-tier="uhd"] .mschf-flower {
+    animation-duration: 28s;
+  }
+  #mschf-overlay-root[data-mschf-tier="uhd"] .mschf-stars {
+    animation-duration: 18s;
+  }
+  #mschf-overlay-root[data-mschf-tier="uhd"] .mschf-wm-line {
+    animation-duration: 36s;
+  }
 }


### PR DESCRIPTION
## Summary
- Detect heavy UHD viewports and clamp overlay density, node budgets, recomposition cadence, and rare events while skipping GPU init on ultra-wide screens.
- Slow overlay-specific CSS animations when the root reports `data-mschf-tier="uhd"` to reduce simultaneous motion.

## Testing
- `npm run lint` *(fails: existing regex/style violations in legacy LV tooling paths)*
- `npx eslint src/assets/js/mschf-overlay.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d50b8935c0833085f0be321d387692