### PR TITLE
Throttle MSCHF overlay on high-density screens

### DIFF
--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -658,6 +658,13 @@ html {
     isolation: isolate;
     color: var(--mschf-ink);
   }
+  body[data-mschf-tier='hi'] #mschf-overlay-root {
+    --mschf-noise: 0.045;
+  }
+  body[data-mschf-tier='ultra'] #mschf-overlay-root {
+    --mschf-noise: 0.03;
+    opacity: 0.9;
+  }
   #mschf-overlay-root::before {
     content: "";
     position: absolute;
@@ -668,6 +675,33 @@ html {
     opacity: 0.25;
     filter: blur(120px);
     mix-blend-mode: screen;
+  }
+  body[data-mschf-tier='hi'] #mschf-overlay-root .mschf-scanline {
+    animation-duration: calc(var(--mschf-scan-speed, 9s) * 1.4);
+  }
+  body[data-mschf-tier='hi'] #mschf-overlay-root .mschf-callout {
+    animation-duration: 6.8s;
+  }
+  body[data-mschf-tier='hi'] #mschf-overlay-root .mschf-topo {
+    animation-duration: 32s;
+  }
+  body[data-mschf-tier='hi'] #mschf-overlay-root .mschf-glitch {
+    animation-duration: 1.6s;
+  }
+  body[data-mschf-tier='hi'] #mschf-overlay-root .mschf-holo {
+    animation-duration: 18s;
+  }
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-scanline,
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-callout,
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-topo,
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-glitch,
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-holo,
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-marquee,
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-stars,
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-flower,
+  body[data-mschf-tier='ultra'] #mschf-overlay-root .mschf-rings {
+    animation: none !important;
+    transition: none !important;
   }
   #mschf-overlay-root::after {
     content: "";


### PR DESCRIPTION
## Summary
- detect viewport + device pixel density to assign MSCHF overlay performance tiers and tune node budgets, density targets, and motion preferences at boot
- throttle compositor loops, spawn counts, and rare events for high-resolution tiers while respecting explicit data attributes and GPU overrides
- add CSS fallbacks that slow or disable heavy overlay animations on `data-mschf-tier="hi"` and `"ultra"`

## Testing
- `npm run lint` *(fails: existing unicorn/better-regex, unused-vars, and import resolution violations in lvreport.js, lv-images scripts, html-to-markdown shim)*

------
https://chatgpt.com/codex/tasks/task_e_68d50b8935c0833085f0be321d387692