### PR TITLE
Fix Portainer runtime healthcheck to avoid 502s

### DIFF
--- a/.portainer/Dockerfile
+++ b/.portainer/Dockerfile
@@ -64,8 +64,13 @@ RUN node tools/check-chromium.mjs && \
 # runtime (tiny, static)
 ############################
 FROM nginx:1.27-bookworm
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/_site/ /usr/share/nginx/html/
 COPY .portainer/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s \
-  CMD wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1
+  CMD curl --fail --silent --show-error http://127.0.0.1/ >/dev/null 2>&1 || exit 1

--- a/.portainer/nginx.conf
+++ b/.portainer/nginx.conf
@@ -3,6 +3,7 @@
 
 server {
   listen 80;
+  listen [::]:80;
   server_name _;
 
   root /usr/share/nginx/html;


### PR DESCRIPTION
## Summary
- install curl in the runtime image and switch the healthcheck to curl so the container reports healthy
- open the nginx listener on IPv6 alongside IPv4 to cover Portainer ingress expectations

## Testing
- npm ci
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d64fe4ec608330831b07e6ab69fa02