### PR TITLE
perf: cache lv report data and enable image caching

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -228,6 +228,11 @@ export default function(eleventyConfig) {
           .replace(/[^\da-z]+/g, '-')
         return `${s}-${width}.${format}`
       },
+      cacheOptions: {
+        directory: path.join(projectRoot, '.cache', 'eleventy-img'),
+        removeUrlQueryParams: false,
+        duration: '6w',
+      },
     })
   }
 


### PR DESCRIPTION
## Summary
- cache the lvreport global data payload and reuse it between builds when inputs are unchanged
- serialize robots parsing output so cached data can be stored on disk safely
- configure eleventy-img to persist its processed assets under .cache for faster rebuilds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d72f2c5e908330b51e762173f9f971