### PR TITLE
Expand Chromium installer automation

### DIFF
--- a/bin/install-chromium.sh
+++ b/bin/install-chromium.sh
@@ -8,6 +8,67 @@ log() {
   printf '%s\n' "$*" >&2
 }
 
+playwright_wrappers() {
+  cat <<'EOF'
+npx --yes
+npm exec --yes
+pnpm dlx
+yarn dlx
+bunx
+corepack pnpm dlx
+corepack yarn dlx
+EOF
+}
+
+run_playwright_command() {
+  local require_root=0
+  if [[ ${1:-} == "--sudo" ]]; then
+    require_root=1
+    shift
+  fi
+
+  local subcommand="$1"
+  shift
+  local -a args=("$@")
+
+  local attempted=0
+  while IFS= read -r wrapper; do
+    [[ -n "$wrapper" ]] || continue
+    # shellcheck disable=SC2206
+    local tokens=($wrapper)
+    local bin="${tokens[0]}"
+    if ! command -v "$bin" >/dev/null 2>&1; then
+      continue
+    fi
+    attempted=1
+    local -a cmd=("${tokens[@]}" playwright "$subcommand")
+    cmd+=("${args[@]}")
+
+    if ((require_root)) && [[ ${EUID:-0} -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+      if sudo "${cmd[@]}" >/dev/null 2>&1; then
+        log "Playwright $subcommand succeeded via sudo ${wrapper}"
+        return 0
+      else
+        log "Playwright $subcommand via sudo ${wrapper} failed; continuing"
+        continue
+      fi
+    fi
+
+    if "${cmd[@]}" >/dev/null 2>&1; then
+      log "Playwright $subcommand succeeded via ${wrapper}"
+      return 0
+    fi
+
+    log "Playwright $subcommand via ${wrapper} failed; continuing"
+  done < <(playwright_wrappers)
+
+  if ((attempted == 0)); then
+    log "No Playwright wrapper commands available"
+  fi
+
+  return 1
+}
+
 find_chromium() {
   node "$RESOLVER" 2>/dev/null || true
 }
@@ -38,23 +99,34 @@ ensure_apt_chromium() {
   fi
 
   export DEBIAN_FRONTEND=noninteractive
-  $sudo_cmd apt-get update -y >/dev/null
-  if ! $sudo_cmd apt-get install -y chromium >/dev/null 2>&1; then
-    $sudo_cmd apt-get install -y chromium-browser >/dev/null 2>&1
+  if ! $sudo_cmd apt-get update -y >/dev/null 2>&1; then
+    log "apt-get update failed; skipping system package install"
+    return 1
   fi
-}
 
-ensure_playwright_deps() {
-  if ! command -v npx >/dev/null 2>&1; then
+  if $sudo_cmd apt-get install -y chromium >/dev/null 2>&1; then
     return 0
   fi
 
-  local runner=(npx --yes playwright install-deps chromium)
-  if [[ ${EUID:-0} -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
-    sudo "${runner[@]}" >/dev/null
-  else
-    "${runner[@]}" >/dev/null
+  if $sudo_cmd apt-get install -y chromium-browser >/dev/null 2>&1; then
+    return 0
   fi
+
+  log "apt-get install chromium|chromium-browser failed"
+  return 1
+}
+
+ensure_playwright_deps() {
+  if run_playwright_command --sudo install-deps chromium; then
+    return 0
+  fi
+
+  if run_playwright_command install-deps chromium; then
+    return 0
+  fi
+
+  log "Playwright dependency setup failed across available wrappers"
+  return 1
 }
 
 main() {
@@ -63,19 +135,17 @@ main() {
   if validate_chromium "$existing"; then
     log "Chromium already available at $existing"
   else
-    log "Chromium not found; attempting installation via apt-get"
+    log "Chromium not found; attempting apt-get install before Playwright fallback"
     ensure_apt_chromium || {
-      log "Failed to install Chromium automatically."
+      log "System package installation failed; will try Playwright-managed download"
       existing=""
     }
     existing="$(find_chromium)"
     if ! validate_chromium "$existing"; then
       log "Falling back to Playwright-managed Chromium download"
-      if command -v npx >/dev/null 2>&1; then
-        ensure_playwright_deps
-        npx --yes playwright install chromium >/dev/null
-      else
-        log "npx unavailable; unable to download Chromium via Playwright."
+      ensure_playwright_deps || log "Continuing without Playwright system deps; proceeding with download"
+      if ! run_playwright_command install chromium; then
+        log "Automatic Playwright download attempts exhausted"
         exit 1
       fi
       existing="$(find_chromium)"

--- a/tools/resolve-chromium.mjs
+++ b/tools/resolve-chromium.mjs
@@ -86,9 +86,7 @@ export function resolveChromium() {
       // continue searching
     }
   }
-  throw new Error(
-    'Chromium not found. Install via ./bin/install-chromium.sh or `npx playwright install chromium`.',
-  )
+  throw new Error('Chromium not found after automated provisioning attempts (bin/install-chromium.sh).')
 }
 
 const modulePath = fileURLToPath(import.meta.url)


### PR DESCRIPTION
## Summary
- add a reusable helper so the installer can try multiple Playwright wrappers (npx, npm, pnpm, yarn, bun, corepack)
- reuse the helper for dependency prep and downloads to avoid surfacing recoverable errors to the user
- update the resolver message to reflect the fully automated provisioning flow

## Testing
- bash -n bin/install-chromium.sh
- node --check tools/resolve-chromium.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d7af9846008330ad69b4ff58de6022