### PR TITLE
Revamp LV gallery with lazy loading and host filters

### DIFF
--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -198,6 +198,12 @@ html {
 /* Utilities            */
 /* -------------------- */
 @layer utilities {
+  .clamp-1 {
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
   .clamp-2 {
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -956,4 +962,42 @@ html {
 .mschf-specimen strong {
   font-weight: 700;
   color: var(--mschf-ink);
+}
+
+@layer utilities {
+  [x-cloak] {
+    display: none !important;
+  }
+
+  img[data-lazy-src] {
+    transition: opacity 0.35s ease, filter 0.35s ease;
+  }
+
+  img[data-state="idle"],
+  img[data-state="loading"] {
+    opacity: 0;
+    filter: saturate(70%);
+  }
+
+  img[data-state="loaded"] {
+    opacity: 1;
+    filter: none;
+  }
+
+  img[data-state="error"] {
+    opacity: 0;
+  }
+
+  [data-image-fallback] {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  img[data-state="error"] ~ [data-image-fallback] {
+    opacity: 1;
+  }
+
+  img[data-state="loaded"] ~ [data-image-fallback] {
+    opacity: 0;
+  }
 }

--- a/src/assets/js/lvreport-app.js
+++ b/src/assets/js/lvreport-app.js
@@ -12,6 +12,7 @@ const payload = payloadSource ? JSON.parse(payloadSource) : {}
 const baseHref = payload.baseHref || ''
 const sections = payload.page?.sections || {}
 const sectionKeys = Object.keys(sections)
+const galleryPayload = payload.images || {}
 
 const fuseConfigs = {
   sitemaps: { keys: ['host', 'url', 'type', 'status'], threshold: 0.35, ignoreLocation: true },
@@ -202,6 +203,320 @@ function downloadCsv(filename, rows) {
     link.remove()
   }, 300)
 }
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' })
+
+function formatDate(value) {
+  if (!value) return '—'
+  const date = value instanceof Date ? value : new Date(value)
+  if (!date || Number.isNaN(date.valueOf())) return '—'
+  return dateFormatter.format(date)
+}
+
+function toTimestamp(value) {
+  if (!value) return 0
+  const date = value instanceof Date ? value : new Date(value)
+  if (!date || Number.isNaN(date.valueOf())) return 0
+  return date.valueOf()
+}
+
+function hostFromValue(value) {
+  if (!value) return ''
+  const text = String(value).trim()
+  if (!text) return ''
+  if (text.includes('://')) {
+    try {
+      return new URL(text).host.toLowerCase()
+    } catch {}
+  }
+  try {
+    return new URL(`https://${text}`).host.toLowerCase()
+  } catch {
+    return text.replace(/^https?:\/\//i, '').split('/')[0].toLowerCase()
+  }
+}
+
+function createLazyImageQueue({ concurrency = 6 } = {}) {
+  const queue = []
+  let active = 0
+
+  const observer = typeof IntersectionObserver !== 'undefined'
+    ? new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting || entry.intersectionRatio > 0) {
+          observer.unobserve(entry.target)
+          enqueue(entry.target)
+        }
+      }
+    }, { rootMargin: '240px 0px', threshold: 0.05 })
+    : null
+
+  function enqueue(img) {
+    if (!img) return
+    if (img.dataset.state === 'loaded' || img.dataset.state === 'error') return
+    if (img.dataset.loading === 'active' || img.dataset.loading === 'queued') return
+    img.dataset.loading = 'queued'
+    queue.push(img)
+    process()
+  }
+
+  function process() {
+    if (active >= concurrency) return
+    const img = queue.shift()
+    if (!img) return
+    if (img.dataset.state === 'loaded' || img.dataset.state === 'error') {
+      img.dataset.loading = ''
+      process()
+      return
+    }
+    if (!document.contains(img)) {
+      img.dataset.loading = ''
+      process()
+      return
+    }
+    const src = img.dataset.lazySrc || img.dataset.src
+    if (!src) {
+      img.dataset.loading = ''
+      img.dataset.state = 'error'
+      process()
+      return
+    }
+    active++
+    img.dataset.loading = 'active'
+    img.dataset.state = 'loading'
+    const cleanup = (state) => {
+      active = Math.max(0, active - 1)
+      img.dataset.loading = ''
+      img.dataset.state = state
+      if (state === 'loaded') {
+        img.removeAttribute('data-lazy-src')
+      }
+      process()
+    }
+    const onLoad = () => {
+      img.removeEventListener('load', onLoad)
+      img.removeEventListener('error', onError)
+      cleanup('loaded')
+    }
+    const onError = () => {
+      img.removeEventListener('load', onLoad)
+      img.removeEventListener('error', onError)
+      cleanup('error')
+    }
+    img.addEventListener('load', onLoad, { once: true })
+    img.addEventListener('error', onError, { once: true })
+    img.src = src
+  }
+
+  return {
+    observe(root) {
+      if (!root) return
+      const images = root.querySelectorAll('img[data-lazy-src]')
+      images.forEach((img) => {
+        if (img.dataset.state === 'loaded' || img.dataset.state === 'error') return
+        if (observer) {
+          observer.observe(img)
+        } else {
+          enqueue(img)
+        }
+      })
+    },
+  }
+}
+
+const lazyLoader = createLazyImageQueue({ concurrency: 6 })
+
+Alpine.data('lvGallery', () => ({
+  items: [],
+  fresh: [],
+  hosts: [],
+  stats: { total: 0, active: 0, deprecated: 0, duplicates: 0, filtered: 0 },
+  query: '',
+  hostFilter: 'all',
+  sort: 'newest',
+  pageSize: 25,
+  page: 1,
+  pageCount: 1,
+  visible: [],
+  filteredTotal: 0,
+  rangeLabel: '0',
+  showDuplicates: false,
+  showDeprecated: false,
+  init() {
+    const raw = Array.isArray(galleryPayload.items) ? galleryPayload.items : []
+    this.items = raw.map((item) => this.normaliseItem(item))
+    this.hosts = Array.from(new Set(this.items.map((item) => item.host).filter(Boolean))).sort((
+      a,
+      b,
+    ) => a.localeCompare(b))
+    this.fresh = this.items
+      .slice()
+      .sort((a, b) => b.lastSeenTs - a.lastSeenTs || b.firstSeenTs - a.firstSeenTs)
+      .slice(0, 12)
+    this.stats = this.computeStats()
+    this.pageSize = 25
+    this.page = 1
+    this.rangeLabel = '0'
+    this.refresh()
+  },
+  normaliseItem(item = {}) {
+    const firstSeenTs = toTimestamp(item.firstSeen)
+    const lastSeenTs = toTimestamp(item.lastSeen) || firstSeenTs
+    const host = hostFromValue(item.host) || hostFromValue(item.pageUrl) || hostFromValue(item.src)
+    const basename = (item.basename || '').trim() || (item.id || '')
+    const displayTitle = (item.title || '').trim() || basename || item.src || item.id || 'Image'
+    const searchText = [
+      displayTitle,
+      basename,
+      host,
+      item.pageUrl,
+      item.sitemap,
+      item.id,
+      item.duplicateOf,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+    return {
+      ...item,
+      host,
+      basename,
+      displayTitle,
+      searchText,
+      firstSeenTs,
+      lastSeenTs,
+      firstSeenLabel: formatDate(item.firstSeen),
+      lastSeenLabel: formatDate(item.lastSeen || item.firstSeen),
+      isDeprecated: Boolean(item.removedAt),
+      isDuplicate: Boolean(item.duplicateOf),
+    }
+  },
+  computeStats() {
+    const totals = galleryPayload.totals || {}
+    const total = typeof totals.images === 'number' ? totals.images : this.items.length
+    const active = typeof totals.active === 'number'
+      ? totals.active
+      : this.items.filter((item) => !item.isDeprecated).length
+    const deprecated = typeof totals.deprecated === 'number'
+      ? totals.deprecated
+      : Math.max(0, total - active)
+    const duplicates = typeof totals.duplicates === 'number'
+      ? totals.duplicates
+      : this.items.filter((item) => item.isDuplicate && !item.isDeprecated).length
+    const filtered = typeof totals.filtered === 'number' ? Math.max(0, totals.filtered) : 0
+    return { total, active, deprecated, duplicates, filtered }
+  },
+  getFilteredList() {
+    let list = this.items.slice()
+    if (!this.showDeprecated) {
+      list = list.filter((item) => !item.isDeprecated)
+    }
+    if (this.showDuplicates) {
+      list = list.filter((item) => item.isDuplicate)
+    }
+    if (this.hostFilter && this.hostFilter !== 'all') {
+      list = list.filter((item) => item.host === this.hostFilter)
+    }
+    if (this.query) {
+      const lower = this.query.toLowerCase()
+      list = list.filter((item) => item.searchText.includes(lower))
+    }
+    return list
+  },
+  sortList(list) {
+    switch (this.sort) {
+      case 'host':
+        list.sort((a, b) =>
+          (a.host || '').localeCompare(b.host || '') || a.basename.localeCompare(b.basename)
+        )
+        break
+      case 'basename':
+        list.sort((a, b) => a.basename.localeCompare(b.basename) || b.lastSeenTs - a.lastSeenTs)
+        break
+      case 'duplicates':
+        list.sort((a, b) => {
+          const dupA = a.isDuplicate ? 1 : 0
+          const dupB = b.isDuplicate ? 1 : 0
+          if (dupA !== dupB) return dupB - dupA
+          return b.lastSeenTs - a.lastSeenTs || a.basename.localeCompare(b.basename)
+        })
+        break
+      default:
+        list.sort((a, b) =>
+          b.lastSeenTs - a.lastSeenTs || b.firstSeenTs - a.firstSeenTs
+          || a.basename.localeCompare(b.basename)
+        )
+    }
+  },
+  refresh() {
+    const list = this.getFilteredList()
+    this.sortList(list)
+    this.filteredTotal = list.length
+    this.pageCount = Math.max(1, Math.ceil(list.length / this.pageSize))
+    if (this.page > this.pageCount) this.page = this.pageCount
+    if (this.page < 1) this.page = 1
+    const start = (this.page - 1) * this.pageSize
+    const end = start + this.pageSize
+    this.visible = list.slice(start, end)
+    this.rangeLabel = this.visible.length ? `${start + 1}–${start + this.visible.length}` : '0'
+    this.$nextTick(() => {
+      if (this.$refs?.grid) lazyLoader.observe(this.$refs.grid)
+      if (this.$refs?.fresh) lazyLoader.observe(this.$refs.fresh)
+    })
+  },
+  setQuery(value) {
+    this.query = (value || '').trim()
+    this.page = 1
+    this.refresh()
+  },
+  setHost(value) {
+    this.hostFilter = value || 'all'
+    this.page = 1
+    this.refresh()
+  },
+  setSort(value) {
+    this.sort = value || 'newest'
+    this.page = 1
+    this.refresh()
+  },
+  setPageSize(value) {
+    const size = Number.parseInt(value, 10)
+    this.pageSize = Number.isFinite(size) && size > 0 ? size : 25
+    this.page = 1
+    this.refresh()
+  },
+  toggleDuplicates() {
+    this.showDuplicates = !this.showDuplicates
+    this.page = 1
+    this.refresh()
+  },
+  toggleDeprecated() {
+    this.showDeprecated = !this.showDeprecated
+    this.page = 1
+    this.refresh()
+  },
+  nextPage() {
+    if (this.page < this.pageCount) {
+      this.page += 1
+      this.refresh()
+    }
+  },
+  prevPage() {
+    if (this.page > 1) {
+      this.page -= 1
+      this.refresh()
+    }
+  },
+  jumpPage(value) {
+    const target = Number.parseInt(value, 10)
+    if (!Number.isFinite(target)) return
+    const clamped = Math.min(Math.max(target, 1), this.pageCount)
+    if (clamped !== this.page) {
+      this.page = clamped
+      this.refresh()
+    }
+  },
+}))
 
 const exportSchemas = {
   sitemaps: {

--- a/src/content/projects/lv-images/config/hosts.banned.ndjson
+++ b/src/content/projects/lv-images/config/hosts.banned.ndjson
@@ -450,3 +450,5 @@
 {"host":"vvv-seoul.louisvuitton.com","reason":"zero-content-sitemaps","discoveredAt":"2025-10-03T19:10:39.485Z"}
 {"host":"wait.louisvuitton.com","reason":"zero-content-sitemaps","discoveredAt":"2025-10-03T19:10:39.485Z"}
 {"host":"wardrobing.louisvuitton.com","reason":"zero-content-sitemaps","discoveredAt":"2025-10-03T19:10:39.485Z"}
+{"host":"www.olyv.co.in","reason":"blocked-gallery-host","discoveredAt":"2025-10-06T07:10:00.000Z"}
+{"host":"app.urlgeni.us","reason":"blocked-gallery-host","discoveredAt":"2025-10-06T07:10:00.000Z"}

--- a/src/content/projects/lv-images/report.11tydata.js
+++ b/src/content/projects/lv-images/report.11tydata.js
@@ -61,6 +61,28 @@ export default async function() {
             bundleLabel: context.lvreport?.dataset?.bundleLabel || null,
             runMode: context.lvreport?.dataset?.runMode || null,
           },
+          images: {
+            items: (context.lvreport?.allImages || []).map(image => ({
+              id: image.id,
+              src: image.src,
+              basename: image.basename,
+              title: image.title,
+              host: image.host,
+              pageUrl: image.pageUrl,
+              sitemap: image.sitemap,
+              firstSeen: image.firstSeen,
+              lastSeen: image.lastSeen,
+              removedAt: image.removedAt,
+              duplicateOf: image.duplicateOf,
+            })),
+            totals: {
+              images: context.lvreport?.totals?.images ?? null,
+              active: context.lvreport?.totals?.activeImages ?? null,
+              deprecated: context.lvreport?.totals?.deprecatedImages ?? null,
+              duplicates: context.lvreport?.totals?.duplicateImages ?? null,
+              filtered: context.lvreport?.totals?.filteredImages ?? null,
+            },
+          },
           page: {
             number: context.lvReportPage?.pageNumber ?? 0,
             count: context.lvReportPage?.pageCount ?? 1,

--- a/src/content/projects/lv-images/report.njk
+++ b/src/content/projects/lv-images/report.njk
@@ -353,6 +353,293 @@ metaDisable: true
   </div>
 </section>
 
+<section
+  id="lv-gallery"
+  class="mt-12 space-y-8"
+  x-data="lvGallery()"
+  x-init="init()"
+  x-cloak
+  data-gallery-root
+>
+  <div class="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+    <div class="card border border-base-content/10 bg-base-100/60 shadow-md backdrop-blur">
+      <div class="card-body space-y-4">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 class="text-2xl font-semibold">Fresh arrivals</h2>
+            <p class="text-sm opacity-70">Newest assets by last seen timestamp.</p>
+          </div>
+          <div class="badge badge-outline" x-show="fresh.length">
+            Last {{ fresh.length }}
+          </div>
+        </div>
+        <template x-if="!fresh.length">
+          <p class="text-sm opacity-60">No recent arrivals in this dataset.</p>
+        </template>
+        <div class="overflow-x-auto pb-1" x-show="fresh.length">
+          <div class="flex min-w-[280px] gap-4" x-ref="fresh">
+            <template x-for="image in fresh" :key="image.id">
+              <a
+                class="group flex w-48 flex-col gap-3 rounded-2xl border border-base-content/10 bg-base-200/70 p-3 shadow-sm transition hover:border-primary/40 hover:shadow-lg"
+                :href="image.pageUrl || image.src"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <div class="relative aspect-[4/5] overflow-hidden rounded-xl bg-base-300/70" data-image-card>
+                  <img
+                    :data-lazy-src="image.src"
+                    data-state="idle"
+                    loading="lazy"
+                    decoding="async"
+                    :alt="image.displayTitle"
+                    class="h-full w-full object-cover opacity-0 transition-opacity duration-500"
+                  />
+                  <div
+                    class="pointer-events-none absolute inset-0 flex items-center justify-center bg-base-200/80 text-[11px] font-medium uppercase tracking-wide text-base-content/60"
+                    data-image-fallback
+                  >
+                    Unavailable
+                  </div>
+                  <div
+                    class="absolute left-2 top-2 flex items-center gap-1 rounded-full bg-base-100/90 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-base-content/80"
+                  >
+                    <span class="inline-flex items-center gap-1">
+                      <span class="h-1.5 w-1.5 rounded-full bg-success" x-show="!image.isDeprecated"></span>
+                      <span class="h-1.5 w-1.5 rounded-full bg-error" x-show="image.isDeprecated"></span>
+                      <span x-text="image.isDeprecated ? 'Deprecated' : 'Active'"></span>
+                    </span>
+                  </div>
+                </div>
+                <div class="space-y-2">
+                  <p class="clamp-2 text-sm font-semibold leading-tight" x-text="image.displayTitle"></p>
+                  <p class="text-[11px] uppercase tracking-wide text-base-content/50" x-text="image.host || '—'"></p>
+                  <div class="text-[11px] leading-tight text-base-content/70">
+                    <p>
+                      <span class="font-medium text-base-content/80">Last seen:</span>
+                      <span x-text="image.lastSeenLabel"></span>
+                    </p>
+                    <p>
+                      <span class="font-medium text-base-content/80">First seen:</span>
+                      <span x-text="image.firstSeenLabel"></span>
+                    </p>
+                  </div>
+                </div>
+              </a>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card border border-base-content/10 bg-base-100/60 shadow-md backdrop-blur">
+      <div class="card-body space-y-4">
+        <h2 class="text-2xl font-semibold">Gallery health</h2>
+        <dl class="grid grid-cols-2 gap-3 text-sm">
+          <div class="rounded-xl border border-base-content/10 bg-base-200/70 p-4 text-center shadow-sm">
+            <dt class="text-xs uppercase tracking-[0.3em] text-base-content/50">Total</dt>
+            <dd class="mt-1 text-2xl font-semibold" x-text="stats.total"></dd>
+          </div>
+          <div class="rounded-xl border border-success/30 bg-success/10 p-4 text-center shadow-sm">
+            <dt class="text-xs uppercase tracking-[0.3em] text-success/70">Active</dt>
+            <dd class="mt-1 text-2xl font-semibold text-success" x-text="stats.active"></dd>
+          </div>
+          <div class="rounded-xl border border-warning/30 bg-warning/10 p-4 text-center shadow-sm">
+            <dt class="text-xs uppercase tracking-[0.3em] text-warning/80">Duplicates</dt>
+            <dd class="mt-1 text-2xl font-semibold text-warning" x-text="stats.duplicates"></dd>
+          </div>
+          <div class="rounded-xl border border-error/30 bg-error/10 p-4 text-center shadow-sm">
+            <dt class="text-xs uppercase tracking-[0.3em] text-error/80">Deprecated</dt>
+            <dd class="mt-1 text-2xl font-semibold text-error" x-text="stats.deprecated"></dd>
+          </div>
+        </dl>
+        <p class="text-xs italic text-base-content/60" x-show="stats.filtered">
+          <span x-text="stats.filtered"></span> assets filtered from upstream by banned hosts.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="card border border-base-content/10 bg-base-100/70 shadow-lg backdrop-blur">
+    <div class="card-body space-y-6">
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          <label class="form-control w-full">
+            <div class="label pb-1">
+              <span class="label-text text-xs uppercase tracking-[0.25em] text-base-content/60">Search</span>
+            </div>
+            <input
+              type="search"
+              class="input input-bordered input-sm"
+              placeholder="Search title, basename, host…"
+              @input.debounce.200ms="setQuery($event.target.value)"
+            />
+          </label>
+          <label class="form-control w-full">
+            <div class="label pb-1">
+              <span class="label-text text-xs uppercase tracking-[0.25em] text-base-content/60">Host</span>
+            </div>
+            <select class="select select-bordered select-sm" @change="setHost($event.target.value)">
+              <option value="all">All hosts</option>
+              <template x-for="host in hosts" :key="host">
+                <option :value="host" x-text="host"></option>
+              </template>
+            </select>
+          </label>
+          <label class="form-control w-full">
+            <div class="label pb-1">
+              <span class="label-text text-xs uppercase tracking-[0.25em] text-base-content/60">Sort</span>
+            </div>
+            <select class="select select-bordered select-sm" @change="setSort($event.target.value)">
+              <option value="newest">Newest</option>
+              <option value="host">Host A→Z</option>
+              <option value="basename">Basename A→Z</option>
+              <option value="duplicates">Duplicates first</option>
+            </select>
+          </label>
+          <label class="form-control w-full">
+            <div class="label pb-1">
+              <span class="label-text text-xs uppercase tracking-[0.25em] text-base-content/60">Page size</span>
+            </div>
+            <select class="select select-bordered select-sm" @change="setPageSize($event.target.value)">
+              <option value="25">25</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </label>
+          <div class="form-control">
+            <div class="label pb-1">
+              <span class="label-text text-xs uppercase tracking-[0.25em] text-base-content/60">Filters</span>
+            </div>
+            <div class="join join-vertical lg:join-horizontal">
+              <button type="button" class="btn btn-sm join-item" :class="{ 'btn-primary': showDuplicates }" @click="toggleDuplicates()">
+                Duplicates
+              </button>
+              <button type="button" class="btn btn-sm join-item" :class="{ 'btn-primary': showDeprecated }" @click="toggleDeprecated()">
+                Deprecated
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="text-sm text-base-content/70">
+          <p>
+            Showing
+            <span class="font-semibold" x-text="rangeLabel"></span>
+            of
+            <span class="font-semibold" x-text="filteredTotal"></span>
+            images.
+          </p>
+          <p class="text-xs opacity-60" x-show="query">
+            Filtered by “<span x-text="query"></span>”.
+          </p>
+        </div>
+      </div>
+
+      <template x-if="!visible.length">
+        <div class="alert alert-info">
+          <span>No images match the current filters.</span>
+        </div>
+      </template>
+
+      <div
+        class="grid gap-5 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
+        x-show="visible.length"
+        x-ref="grid"
+      >
+        <template x-for="image in visible" :key="image.id">
+          <article
+            class="group flex flex-col overflow-hidden rounded-3xl border border-base-content/10 bg-base-200/60 shadow-sm transition hover:-translate-y-1 hover:border-primary/40 hover:shadow-xl"
+            :class="{ 'opacity-80': image.isDeprecated }"
+            data-image-card
+          >
+            <a :href="image.pageUrl || image.src" target="_blank" rel="noreferrer" class="relative block aspect-[4/5] overflow-hidden bg-base-300/60">
+              <img
+                :data-lazy-src="image.src"
+                data-state="idle"
+                loading="lazy"
+                decoding="async"
+                :alt="image.displayTitle"
+                class="h-full w-full object-cover opacity-0 transition-opacity duration-500"
+              />
+              <div
+                class="pointer-events-none absolute inset-0 flex items-center justify-center bg-base-200/85 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60"
+                data-image-fallback
+              >
+                Unavailable
+              </div>
+              <div class="pointer-events-none absolute left-3 top-3 flex flex-wrap gap-2">
+                <span
+                  class="badge badge-sm border-none bg-success/90 text-success-content"
+                  x-show="!image.isDeprecated"
+                >Active</span>
+                <span
+                  class="badge badge-sm border-none bg-error/90 text-error-content"
+                  x-show="image.isDeprecated"
+                >Deprecated</span>
+                <span
+                  class="badge badge-sm border-none bg-warning/90 text-warning-content"
+                  x-show="image.isDuplicate"
+                >Duplicate</span>
+              </div>
+            </a>
+            <div class="flex flex-1 flex-col gap-3 p-4">
+              <div class="space-y-1">
+                <p class="text-sm font-semibold leading-tight" x-text="image.displayTitle"></p>
+                <a
+                  class="inline-flex w-fit items-center gap-1 text-xs text-primary/90 hover:text-primary"
+                  :href="image.pageUrl || image.src"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {{ 'external-link' | lucide({ class: 'h-3.5 w-3.5 shrink-0 text-primary' }) | safe }}
+                  <span class="clamp-1" x-text="image.pageUrl || image.src"></span>
+                </a>
+              </div>
+              <div class="flex flex-wrap gap-2 text-xs text-base-content/70">
+                <span class="badge badge-sm border border-base-content/20 bg-base-100/60" x-text="image.host || 'unknown host'"></span>
+                <span class="badge badge-sm border border-base-content/20 bg-base-100/60" x-text="image.basename"></span>
+              </div>
+              <div class="mt-auto grid grid-cols-2 gap-2 text-[11px] leading-tight text-base-content/60">
+                <div>
+                  <p class="uppercase tracking-[0.3em] text-base-content/50">First seen</p>
+                  <p class="font-medium text-base-content/80" x-text="image.firstSeenLabel"></p>
+                </div>
+                <div>
+                  <p class="uppercase tracking-[0.3em] text-base-content/50">Last seen</p>
+                  <p class="font-medium text-base-content/80" x-text="image.lastSeenLabel"></p>
+                </div>
+              </div>
+              <div class="flex items-center justify-between text-[11px] text-base-content/60">
+                <span x-show="image.duplicateOf">Canonical: <span class="font-mono" x-text="image.duplicateOf"></span></span>
+                <span x-show="!image.duplicateOf">Unique image</span>
+              </div>
+            </div>
+          </article>
+        </template>
+      </div>
+
+      <div class="flex flex-col gap-3 border-t border-base-content/10 pt-4 text-sm text-base-content/70" x-show="pageCount > 1">
+        <div class="flex items-center justify-between">
+          <button type="button" class="btn btn-sm btn-outline" @click="prevPage" :disabled="page <= 1">Previous</button>
+          <div class="flex items-center gap-2">
+            <span>Page</span>
+            <span class="font-semibold" x-text="page"></span>
+            <span>of</span>
+            <span class="font-semibold" x-text="pageCount"></span>
+          </div>
+          <button type="button" class="btn btn-sm btn-outline" @click="nextPage" :disabled="page >= pageCount">Next</button>
+        </div>
+        <input
+          type="range"
+          min="1"
+          :max="pageCount"
+          class="range range-xs"
+          x-model.number="page"
+          @change="jumpPage(page)"
+        />
+      </div>
+    </div>
+  </div>
+</section>
+
 {% if pagination and pagination.hrefs and (pagination.hrefs | length) > 1 %}
   <nav class="mt-6 flex flex-wrap items-center justify-center gap-2">
     {% for href in pagination.hrefs %}

--- a/tests/playwright/lv-report.spec.mjs
+++ b/tests/playwright/lv-report.spec.mjs
@@ -29,4 +29,12 @@ test.describe('LV Image Atlas report wiring', () => {
       await expect(emptyState).toContainText('No cached documents')
     }
   })
+
+  test('renders gallery controls with pagination select', async ({ page, baseURL }) => {
+    await gotoReport(page, baseURL)
+    const gallery = page.locator('#lv-gallery[data-gallery-root]')
+    await expect(gallery).toBeVisible()
+    const pageSizeSelect = gallery.locator('select').filter({ hasText: '25' }).first()
+    await expect(pageSizeSelect).toBeVisible()
+  })
 })


### PR DESCRIPTION
## Summary
- filter LV aggregates with a banned-host set so gallery metrics and payload omit blocked domains
- hydrate the Eleventy page with gallery data and render a redesigned Alpine-driven gallery featuring lazy queued image loading, filters, and pagination controls
- refresh gallery styling with clickable cards, fresh arrivals strip, and utility classes for lazy-image transitions

## Testing
- `node -e "import('./src/_data/lvreport.js')"`
- `npx eslint src/assets/js/lvreport-app.js`
- `npm run lint:ci` *(fails: existing unicorn/better-regex errors in eleventy.config.mjs and dprint formatting noise in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e29ad52d40833094c91e72eac446dd