### PR TITLE
Throttle LV gallery loading and ban hostile hosts

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -207,14 +207,17 @@ export default function(eleventyConfig) {
         return (tree) => {
           const sanitize = (value) => {
             if (typeof value !== 'string') return ''
-            return value.trim().replace(/^['"]+/, '').replace(/['"]+$/, '')
+            return value.trim().replace(/^["']+/, '').replace(/["']+$/, '')
           }
 
           const markRemote = (node, attr) => {
             const raw = node?.attrs?.[attr]
             if (typeof raw !== 'string') return node
             const normalized = sanitize(raw)
-            if (/^https?:\/\//i.test(normalized) || /^\/\//.test(normalized) || normalized.startsWith('data:')) {
+            if (
+              /^https?:\/\//i.test(normalized) || /^\/\//.test(normalized)
+              || normalized.startsWith('data:')
+            ) {
               node.attrs ||= {}
               node.attrs[attr] = normalized
               if (!('eleventy:ignore' in node.attrs)) {

--- a/src/content/projects/lv-images/report.njk
+++ b/src/content/projects/lv-images/report.njk
@@ -33,6 +33,8 @@ metaDisable: true
 {% set duplicates = duplicatesPage.items or [] %}
 {% set topProducts = topProductsPage.items or [] %}
 {% set hostStats = hostStatsPage.items or [] %}
+{% set imagesPage = pageSections.images or {} %}
+{% set imageStream = imagesPage.items or [] %}
 {% set sample   = lv.sample   or [] %}
 {% set metrics  = lv.metrics  or {} %}
 {% set robotsMetrics = metrics.robots or {} %}
@@ -75,6 +77,57 @@ metaDisable: true
     "info": "bg-info/15 text-info"
   }
 %}
+{% set quickTiles = [
+  {
+    key: 'images',
+    href: '#images',
+    label: 'Image stream',
+    tagline: 'Newest captures',
+    accent: 'from-secondary/40 via-primary/40 to-accent/40',
+  },
+  {
+    key: 'duplicates',
+    href: '#duplicates-section',
+    label: 'Duplicates',
+    tagline: 'Cluster hotspots',
+    accent: 'from-pink-500/30 via-rose-500/20 to-orange-400/25',
+  },
+  {
+    key: 'topProducts',
+    href: '#products-section',
+    label: 'Top products',
+    tagline: 'High-volume pages',
+    accent: 'from-amber-400/25 via-warning/20 to-secondary/20',
+  },
+  {
+    key: 'hostStats',
+    href: '#hosts-section',
+    label: 'Hosts',
+    tagline: 'Origin domains',
+    accent: 'from-sky-400/30 via-info/20 to-primary/20',
+  },
+  {
+    key: 'sitemaps',
+    href: '#sitemaps',
+    label: 'Sitemaps',
+    tagline: 'Entry inventory',
+    accent: 'from-purple-500/25 via-fuchsia-500/20 to-secondary/20',
+  },
+  {
+    key: 'docs',
+    href: '#docs',
+    label: 'Cached docs',
+    tagline: 'XML · JSON · TXT',
+    accent: 'from-emerald-400/25 via-success/20 to-secondary/20',
+  },
+  {
+    key: 'robots',
+    href: '#robots',
+    label: 'Robots',
+    tagline: 'Crawl directives',
+    accent: 'from-lime-400/25 via-success/20 to-accent/20',
+  },
+] %}
 
 {# Compute flagged percentages for radial progress indicators.  The logical
    short‑circuit ensures we avoid division by zero when there are no items. #}
@@ -353,20 +406,335 @@ metaDisable: true
   </div>
 </section>
 
-{% if pagination and pagination.hrefs and (pagination.hrefs | length) > 1 %}
-  <nav class="mt-6 flex flex-wrap items-center justify-center gap-2">
-    {% for href in pagination.hrefs %}
-      {% set pageIndex = loop.index0 %}
-      {% set isCurrent = pageIndex == pagination.pageNumber %}
-      <a
-        href="{{ href }}"
-        class="btn btn-sm md:btn-md {{ 'btn-primary' if isCurrent else 'btn-outline' }}"
-      >
-        Page {{ pageIndex + 1 }}
-      </a>
-    {% endfor %}
-  </nav>
+{% set actionableTiles = quickTiles | selectattr('key') | list %}
+{% if actionableTiles | length %}
+  <section class="mt-10">
+    <h2 class="text-xl font-semibold tracking-tight text-base-content/90">Dashboard orbit</h2>
+    <p class="mt-1 text-sm opacity-70 max-w-2xl">
+      Jump into the primary dataset arenas — the cards surface total records and how many static
+      pages Eleventy generated for each slice.
+    </p>
+    <div class="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {% for tile in actionableTiles %}
+        {% set meta = paginationSections[tile.key] or {} %}
+        <a
+          href="{{ tile.href }}"
+          class="group relative overflow-hidden rounded-3xl border border-base-content/10 bg-base-200/70 p-5 transition hover:border-secondary/60 hover:shadow-xl"
+        >
+          <div class="absolute inset-0 -z-[1] opacity-0 transition group-hover:opacity-100 bg-gradient-to-br {{ tile.accent }}"></div>
+          <div class="flex flex-col gap-4">
+            <div>
+              <p class="text-[11px] uppercase tracking-[0.32em] text-base-content/60">
+                {{ tile.tagline }}
+              </p>
+              <h3 class="mt-2 text-2xl font-semibold text-base-content">
+                {{ tile.label }}
+              </h3>
+            </div>
+            <div class="flex flex-wrap items-end justify-between gap-4">
+              <div>
+                <p class="text-xs uppercase opacity-60">Total records</p>
+                <p class="text-3xl font-bold">
+                  {{ meta.totalItems or 0 }}
+                </p>
+              </div>
+              <div class="text-right">
+                <p class="text-xs uppercase opacity-60">Pages</p>
+                <p class="text-lg font-semibold">
+                  {% if tile.key == 'images' %}
+                    {{ (imagesPage.pageNumber or 0) + 1 }} / {{ imagesPage.pageCount or 1 }}
+                  {% else %}
+                    {{ meta.pageCount or 1 }}
+                  {% endif %}
+                </p>
+                <p class="text-[11px] opacity-60">
+                  {{ meta.size or 0 }} per page
+                </p>
+              </div>
+            </div>
+            <span class="text-xs font-semibold uppercase tracking-[0.28em] text-secondary group-hover:text-secondary-focus">
+              View section →
+            </span>
+          </div>
+        </a>
+      {% endfor %}
+    </div>
+  </section>
 {% endif %}
+
+<section id="images" class="mt-12 space-y-5">
+  <div class="flex flex-wrap items-end justify-between gap-4">
+    <div>
+      <h2 class="text-3xl font-semibold">Image stream</h2>
+      <p class="text-sm opacity-70 max-w-2xl">
+        Every cached image sorted by most recent sighting. Use the controls to zoom into fresh drops
+        or isolate duplicate clusters before triaging downstream.
+      </p>
+    </div>
+    <div class="text-xs uppercase tracking-[0.28em] text-base-content/60">
+      {{ imagesPage.totalItems or 0 }} cached • static batch {{ imagesPage.size or 0 }}
+    </div>
+  </div>
+  <div class="flex flex-wrap items-center gap-3">
+    <label class="input input-bordered flex items-center gap-2 w-full sm:w-80 lg:w-96">
+      <span class="opacity-60">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="11" cy="11" r="8"></circle>
+          <path d="m21 21-3.5-3.5"></path>
+        </svg>
+      </span>
+      <input
+        type="search"
+        class="grow"
+        placeholder="Search host, title, basename…"
+        autocomplete="off"
+        data-search-input="images"
+      />
+    </label>
+    <div class="flex flex-wrap items-center gap-3">
+      <div class="join" data-image-mode-group>
+        <button type="button" class="btn btn-sm join-item btn-primary" data-image-mode="all">
+          All
+        </button>
+        <button type="button" class="btn btn-sm join-item btn-outline" data-image-mode="unique">
+          Unique
+        </button>
+        <button type="button" class="btn btn-sm join-item btn-outline" data-image-mode="duplicates">
+          Duplicates
+        </button>
+      </div>
+      <label
+        class="flex items-center gap-2 rounded-full border border-base-content/20 bg-base-200/60 px-3 py-2 text-[11px] uppercase tracking-[0.18em] shadow-sm"
+        title="Include deprecated captures in the gallery"
+      >
+        <input
+          type="checkbox"
+          class="toggle toggle-xs toggle-warning"
+          data-image-include-deprecated
+          aria-label="Include deprecated images"
+        />
+        <span>Include deprecated</span>
+      </label>
+      <label class="flex items-center gap-2 rounded-full border border-base-content/20 bg-base-200/60 px-3 py-2 text-[11px] uppercase tracking-[0.18em] shadow-sm">
+        <span>Page size</span>
+        <select class="select select-xs select-bordered" data-image-page-size>
+          <option value="25">25</option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+        </select>
+      </label>
+      <button class="btn btn-sm btn-outline" data-export-section="images" type="button">
+        Export CSV
+      </button>
+    </div>
+  </div>
+  <div class="flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-[0.18em]" data-image-active-filters></div>
+  {% if dataset.bannedHosts and (dataset.bannedHosts | length) %}
+    <p class="text-[11px] uppercase tracking-[0.22em] text-error/70">
+      Banned hosts removed from view: {{ dataset.bannedHosts | join(', ') }}
+    </p>
+  {% endif %}
+  {% if imagesPage.totalItems %}
+    <p class="text-xs opacity-60" data-filter-summary="images" data-image-pagination-summary>
+      Showing {{ imagesPage.from or 0 }}–{{ imagesPage.to or 0 }} of {{ imagesPage.totalItems or 0 }}
+      images • Page {{ (imagesPage.pageNumber or 0) + 1 }} of {{ imagesPage.pageCount or 1 }}
+    </p>
+  {% endif %}
+  {% set freshArrivals = imageStream | slice(0, 10) %}
+  {% if freshArrivals | length %}
+    <div class="mt-4 space-y-3 rounded-3xl border border-base-content/10 bg-base-200/70 p-5 shadow-inner">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-[0.24em] text-base-content/80">Fresh arrivals</h3>
+          <p class="text-xs opacity-70">Last handful of captures — hover for host context and open instantly.</p>
+        </div>
+        <div class="text-[11px] uppercase tracking-[0.2em] text-base-content/60">Auto refreshed every bundle</div>
+      </div>
+      <div class="scrollbar-thin flex gap-3 overflow-x-auto" data-image-fresh-rail>
+        {% for image in freshArrivals %}
+          <article
+            class="group relative h-36 w-36 shrink-0 overflow-hidden rounded-2xl border border-base-content/10 bg-base-100/70 shadow-sm transition hover:border-primary/60 hover:shadow-lg"
+            data-image-card
+            data-entry-id="{{ image.id }}"
+            data-image-fresh
+            data-image-index="{{ loop.index0 }}"
+          >
+            <a
+              href="{{ image.src }}"
+              target="_blank"
+              rel="noreferrer"
+              class="block h-full w-full"
+              aria-label="Open image {{ image.title or image.basename or loop.index }}"
+            >
+              <img
+                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+                data-image-src="{{ image.src }}"
+                loading="lazy"
+                decoding="async"
+                alt=""
+                class="h-full w-full object-cover transition duration-500 group-hover:scale-110"
+              />
+              <noscript>
+                <img src="{{ image.src }}" alt="" class="h-full w-full object-cover" />
+              </noscript>
+            </a>
+            <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-base-200/80 via-transparent to-transparent"></div>
+            <div class="absolute inset-x-2 bottom-2 rounded-full bg-base-100/80 px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.3em] text-base-content/80">
+              {{ image.host or '—' }}
+            </div>
+          </article>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+  <p class="mt-4 text-xs text-warning/80">
+    Deprecated captures are hidden by default. Toggle them on to audit removals.
+  </p>
+  {% if imageStream and (imageStream | length) %}
+    <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5" data-image-grid>
+      {% for image in imageStream %}
+        <article
+          class="group overflow-hidden rounded-3xl border border-base-content/10 bg-base-200/70 shadow-sm transition hover:border-primary/50 hover:shadow-lg"
+          data-section-row="images"
+          data-entry-id="{{ image.id }}"
+          data-image-card
+          data-image-index="{{ loop.index0 }}"
+        >
+          <div class="relative aspect-square overflow-hidden" data-image-visual>
+            <a href="{{ image.src }}" target="_blank" rel="noreferrer" class="block h-full w-full" aria-label="Open image {{ image.basename or image.title or loop.index }}">
+              <img
+                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+                data-image-src="{{ image.src }}"
+                loading="lazy"
+                decoding="async"
+                alt=""
+                class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+              />
+              <noscript>
+                <img src="{{ image.src }}" alt="" class="h-full w-full object-cover" />
+              </noscript>
+            </a>
+            <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-base-200/70 via-transparent to-transparent"></div>
+            {% if image.clusterSize and image.clusterSize > 1 %}
+              <span class="absolute left-3 top-3 badge badge-error badge-sm shadow">
+                ×{{ image.clusterSize }}
+              </span>
+            {% else %}
+              <span class="absolute left-3 top-3 badge badge-success badge-sm shadow">unique</span>
+            {% endif %}
+            {% if image.isDeprecated %}
+              <span class="absolute right-3 top-3 badge badge-warning badge-sm shadow">Deprecated</span>
+            {% endif %}
+            <div
+              data-image-fallback
+              class="absolute inset-0 hidden grid place-items-center bg-base-200/90 text-center text-[11px] font-semibold uppercase tracking-[0.2em] text-base-content/70"
+            >
+              Image unavailable
+            </div>
+          </div>
+          <div class="space-y-3 p-4">
+            <div class="flex items-start justify-between gap-3">
+              <h3 class="text-sm font-semibold leading-tight line-clamp-2">
+                {% if image.pageUrl %}
+                  <a href="{{ image.pageUrl }}" target="_blank" rel="noreferrer" class="link link-hover">
+                    {{ image.title or image.basename or image.src or 'Image' }}
+                  </a>
+                {% else %}
+                  <a href="{{ image.src }}" target="_blank" rel="noreferrer" class="link link-hover">
+                    {{ image.title or image.basename or image.src or 'Image' }}
+                  </a>
+                {% endif %}
+              </h3>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs rounded-full border border-base-content/20 bg-base-100/80 text-[10px] font-semibold uppercase tracking-[0.3em] text-base-content/70 transition hover:border-secondary/60 hover:text-secondary disabled:cursor-default disabled:opacity-50"
+                data-image-host="{{ (image.host or '') | lower }}"
+                {% if not image.host %}disabled{% endif %}
+              >
+                {{ image.host or '—' }}
+              </button>
+            </div>
+            <dl class="grid grid-cols-2 gap-3 text-xs">
+              <div>
+                <dt class="uppercase opacity-50">Last seen</dt>
+                <dd class="font-medium">{{ image.lastSeen or '—' }}</dd>
+              </div>
+              <div>
+                <dt class="uppercase opacity-50">First seen</dt>
+                <dd class="font-medium">{{ image.firstSeen or '—' }}</dd>
+              </div>
+            </dl>
+            {% if image.isDeprecated %}
+              <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-warning">
+                Deprecated {{ image.removedAt or image.lastSeen or '—' }}
+              </p>
+            {% endif %}
+            <div class="flex flex-wrap gap-2">
+              <a
+                class="btn btn-xs btn-primary"
+                href="{{ image.src }}"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open image
+              </a>
+              {% if image.pageUrl %}
+                <a
+                  class="btn btn-xs btn-outline"
+                  href="{{ image.pageUrl }}"
+                  target="_blank"
+                  rel="noreferrer"
+                  data-image-page-url
+                >
+                  Source page
+                </a>
+              {% endif %}
+              {% if image.duplicateOf %}
+                <span class="badge badge-outline badge-warning text-[11px]">
+                  {% set canonicalId = image.duplicateOf or '' %}
+                  Canonical: {{ canonicalId | slice(0, 24) }}{% if canonicalId | length > 24 %}…{% endif %}
+                </span>
+              {% endif %}
+            </div>
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="alert alert-info">
+      <span>No cached images found — run <code>npm run lv-images:sync</code> to populate the bundle.</span>
+    </div>
+  {% endif %}
+  {% if pagination and pagination.hrefs and (pagination.hrefs | length) > 1 %}
+    <div class="mt-6 flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-base-content/10 bg-base-200/80 p-4">
+      <div class="text-xs uppercase tracking-[0.24em] opacity-60">
+        Eleventy page {{ (pagination.pageNumber or 0) + 1 }} of {{ pagination.hrefs | length }}
+      </div>
+      <nav class="join" data-image-pagination-nav>
+        {% for href in pagination.hrefs %}
+          {% set pageIndex = loop.index0 %}
+          {% set isCurrent = pageIndex == pagination.pageNumber %}
+          <a
+            href="{{ href }}"
+            class="btn btn-sm join-item {{ 'btn-primary' if isCurrent else 'btn-outline' }}"
+            data-image-page-target="{{ pageIndex }}"
+          >
+            {{ pageIndex + 1 }}
+          </a>
+        {% endfor %}
+      </nav>
+    </div>
+  {% endif %}
+</section>
 
 {% if (datasetFlags | length) or (datasetCapture | length) %}
   {% set captureCount = datasetCapture | length %}
@@ -460,8 +828,16 @@ metaDisable: true
         <h2 class="card-title text-lg">Atlas totals</h2>
         <div class="grid grid-cols-2 gap-3 text-sm">
           <div>
-            <p class="text-xs uppercase opacity-60">Unique images</p>
+            <p class="text-xs uppercase opacity-60">Images captured</p>
             <p class="text-2xl font-semibold">{{ totals.images or 0 }}</p>
+          </div>
+          <div>
+            <p class="text-xs uppercase opacity-60">Active images</p>
+            <p class="text-xl font-semibold">{{ totals.activeImages or totals.images or 0 }}</p>
+          </div>
+          <div>
+            <p class="text-xs uppercase opacity-60">Deprecated images</p>
+            <p class="text-xl font-semibold">{{ totals.deprecatedImages or 0 }}</p>
           </div>
           <div>
             <p class="text-xs uppercase opacity-60">Unique pages</p>

--- a/tools/lv-images/bundle-lib.mjs
+++ b/tools/lv-images/bundle-lib.mjs
@@ -35,7 +35,8 @@ const summaryPath = path.join(lvDir, 'summary.json')
 
 const CANONICAL_BUNDLE = {
   commit: '499f568f2973f5eba7ae80e61d49720390137847',
-  url: 'https://raw.githubusercontent.com/toxicwind/effusion-labs/499f568f2973f5eba7ae80e61d49720390137847/src/content/projects/lv-images/generated/lv.bundle.tgz',
+  url:
+    'https://raw.githubusercontent.com/toxicwind/effusion-labs/499f568f2973f5eba7ae80e61d49720390137847/src/content/projects/lv-images/generated/lv.bundle.tgz',
   sha256: '49a2e64a98d0c4c39257b1ba211c0406c730894873892d82dcdfe2b9d18d1c93',
 }
 
@@ -85,7 +86,9 @@ async function updateProvenance({
   extra = {},
 } = {}) {
   const existing = (await loadProvenance()) || {}
-  const datasetRecord = datasetStatsValue ? buildDatasetRecord(datasetStatsValue) : existing.dataset || null
+  const datasetRecord = datasetStatsValue
+    ? buildDatasetRecord(datasetStatsValue)
+    : existing.dataset || null
   const archiveRecord = archiveStat ? buildArchiveRecord(archiveStat) : existing.archive || null
   const nowIso = new Date().toISOString()
 

--- a/tools/serve-static.mjs
+++ b/tools/serve-static.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
 import http from 'node:http'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
-import fs from 'node:fs'
-import fsp from 'node:fs/promises'
 
 const args = process.argv.slice(2)
 const options = {


### PR DESCRIPTION
## Summary
- redesign the LV image stream controls with host chips, page-size selection, banned-host messaging, and a fresh arrivals ribbon
- extend the gallery client to throttle image loading, expose host/page-size filters, and surface active filter chips with clear affordances
- drop banned hosts during dataset aggregation and record the manual exclusions in the exported bundle metadata

## Testing
- npm run quality:check
- npm run build:site *(fails: fetch failed while hydrating canonical bundle)*

------
https://chatgpt.com/codex/tasks/task_e_68e290600a988330ba2d1b5fe61d9ab7