### PR TITLE
Throttle LV Images dashboard gallery and ban rogue hosts

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -132,6 +132,14 @@ export default function(eleventyConfig) {
   // --- End: Event Handlers ---
   eleventyConfig.setServerPassthroughCopyBehavior('copy')
   eleventyConfig.addPassthroughCopy('public')
+  eleventyConfig.addPassthroughCopy({
+    '.cache/lv-images/index.json': 'assets/data/lvreport/index.json',
+    '.cache/lv-images/meta.json': 'assets/data/lvreport/meta.json',
+    '.cache/lv-images/ingest-metrics.json': 'assets/data/lvreport/ingest-metrics.json',
+    '.cache/lv-images/lvreport.dataset.json': 'assets/data/lvreport/dataset.json',
+    '.cache/lv-images/lvreport.search-index.json': 'assets/data/lvreport/search-index.json',
+    '.cache/lv-images/lvreport.client.json': 'assets/data/lvreport/client.json',
+  })
   eleventyConfig.ignores.add('src/content/docs/**')
   const isTest = process.env.ELEVENTY_ENV === 'test'
 

--- a/src/_data/lvreport.js
+++ b/src/_data/lvreport.js
@@ -1,1532 +1,183 @@
-// src/_data/lvreport.js — prefers decoded robots JSON, falls back to text parser
-
-import fs from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 
 import MiniSearch from 'minisearch'
 
+import { buildIndex, ensureBundleAvailable } from '../../tools/lv-images/index-builder.mjs'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '..', '..')
-const LV_BASE = path.resolve(__dirname, '../content/projects/lv-images/generated/lv')
-const GENERATED_DIR = path.resolve(LV_BASE, '..')
-const DATASET_ROOT_HREF = '/content/projects/lv-images/'
-const CACHE_DIR = path.join(LV_BASE, 'cache')
-const ROBOTS_DIR = path.join(CACHE_DIR, 'robots')
-const SITEMAPS_DIR = path.join(CACHE_DIR, 'sitemaps')
-const ITEMS_DIR = path.join(LV_BASE, 'items')
+const PUBLIC_DATA_DIR = path.join(projectRoot, '.cache', 'lv-images')
+const DATASET_FILE = path.join(PUBLIC_DATA_DIR, 'lvreport.dataset.json')
+const SEARCH_INDEX_FILE = path.join(PUBLIC_DATA_DIR, 'lvreport.search-index.json')
+const CLIENT_PAYLOAD_FILE = path.join(PUBLIC_DATA_DIR, 'lvreport.client.json')
 
-const SUMMARY_JSON = path.join(LV_BASE, 'summary.json')
-const URLMETA_JSON = path.join(CACHE_DIR, 'urlmeta.json')
-const ITEMS_META_JSON = path.join(LV_BASE, 'items-meta.json')
-const ALL_IMAGES_JSON = path.join(LV_BASE, 'all-images.json')
-const ALL_PRODUCTS_JSON = path.join(LV_BASE, 'all-products.json')
-const RUNS_HISTORY_JSON = path.join(LV_BASE, 'runs-history.json')
-const BUNDLE_MANIFEST_JSON = path.join(GENERATED_DIR, 'lv.bundle.json')
-const BUNDLE_ARCHIVE_PATH = path.join(GENERATED_DIR, 'lv.bundle.tgz')
-export const DATASET_REPORT_FILE = path.join(LV_BASE, 'lvreport.dataset.json')
+let memoized = null
 
-const bundleLibUrl = pathToFileURL(path.join(projectRoot, 'tools', 'lv-images', 'bundle-lib.mjs')).href
+export const DATASET_REPORT_FILE = DATASET_FILE
 
-let datasetReadyPromise = null
-
-const MINI_SEARCH_OPTIONS = {
-  fields: ['title', 'description', 'tags'],
-  storeFields: ['id', 'title', 'description', 'href', 'section', 'badge', 'tags', 'meta'],
-  searchOptions: {
-    boost: { title: 2, tags: 1.5 },
-    prefix: true,
-    fuzzy: 0.2,
-  },
-}
-
-function toDatasetHref(relPath) {
-  if (!relPath) return ''
-  const normalized = String(relPath).trim().replace(/^\.\/?/, '').replace(/^\/+/, '')
-  if (!normalized) return ''
-  return `${DATASET_ROOT_HREF}${normalized}`
-}
-
-async function ensureDatasetReady() {
-  if (!datasetReadyPromise) {
-    datasetReadyPromise = (async () => {
-      try {
-        await fs.access(SUMMARY_JSON)
-        return false
-      } catch (error) {
-        if (error?.code !== 'ENOENT') throw error
-      }
-
-      const module = await import(bundleLibUrl)
-      if (typeof module?.hydrateDataset !== 'function') {
-        throw new Error('hydrateDataset export missing in bundle-lib.mjs')
-      }
-      const result = await module.hydrateDataset({ force: false, quiet: true })
-      if (!result?.hydrated) {
-        const reason = result?.reason || 'unknown'
-        throw new Error(`LV dataset hydrate failed (${reason})`)
-      }
-      return true
-    })().catch((error) => {
-      datasetReadyPromise = null
-      throw error
-    })
-  }
-  return datasetReadyPromise
-}
-
-async function loadJSON(p, fb) {
-  try {
-    return JSON.parse(await fs.readFile(p, 'utf8'))
-  } catch {
-    return fb
-  }
-}
-async function pathExists(p) {
-  try {
-    await fs.access(p)
-    return true
-  } catch {
-    return false
-  }
-}
-async function loadDecodedRobots(host) {
-  const decodedPath = path.join(ROBOTS_DIR, `${host}.json`)
-  try {
-    return JSON.parse(await fs.readFile(decodedPath, 'utf8'))
-  } catch {
-    return null
-  }
-}
-
-function buildReverseUrlmeta(urlmeta) {
-  const m = new Map()
-  for (const [u, v] of Object.entries(urlmeta || {})) {
-    if (v?.path) {
-      m.set(path.resolve(v.path), {
-        url: u,
-        status: v.status ?? '',
-        contentType: v.contentType || '',
-      })
-    }
-  }
-  return m
-}
-
-async function* walk(dir) {
-  try {
-    const entries = await fs.readdir(dir, { withFileTypes: true })
-    for (const e of entries) {
-      const p = path.join(dir, e.name)
-      if (e.isDirectory()) yield* walk(p)
-      else yield p
-    }
-  } catch {}
-}
-
-async function sampleItems(dir, max = 60) {
-  const out = []
-  try {
-    const names = (await fs.readdir(dir)).filter((n) => n.endsWith('.ndjson')).sort()
-    for (const name of names) {
-      const full = path.join(dir, name)
-      const fd = await fs.open(full, 'r')
-      const stat = await fd.stat()
-      const len = Math.min(stat.size, 1_500_000)
-      const buf = Buffer.alloc(len)
-      await fd.read(buf, 0, len, 0)
-      await fd.close()
-      const lines = buf.toString('utf8').split(/\r?\n/).filter(Boolean)
-      for (const line of lines) {
-        try {
-          const obj = JSON.parse(line)
-          if (obj?.src) out.push(obj)
-          if (out.length >= max) return out
-        } catch {}
-      }
-    }
-  } catch {}
-  return out
-}
-
-// Fallback minimal parser for robots.txt (used only if no decoded JSON exists)
-function parseRobots(text) {
-  const groups = []
-  const other = {}
-  let cur = null
-  let ruleCount = 0
-
-  const lines = (text || '').split(/\r?\n/)
-  for (const raw of lines) {
-    const line = raw.trim()
-    if (!line || line.startsWith('#')) continue
-    const m = line.match(/^([A-Za-z][A-Za-z-]*)\s*:\s*(.+)$/)
-    if (!m) continue
-    const key = m[1].toLowerCase()
-    const val = m[2].trim()
-
-    if (key === 'user-agent') {
-      cur = { agents: new Set([val.toLowerCase()]), rules: [] }
-      groups.push(cur)
-      continue
-    }
-    if (!cur) {
-      cur = { agents: new Set(['*']), rules: [] }
-      groups.push(cur)
-    }
-
-    if (['allow', 'disallow', 'noindex', 'crawl-delay', 'sitemap'].includes(key)) {
-      cur.rules.push({ type: key, path: val })
-      ruleCount++
-    } else {
-      const nk = key.replace(/[^\da-z]+/gi, '_')
-      ;(other[nk] ||= []).push(val)
-    }
-  }
-
-  const merged = { allow: [], disallow: [], noindex: [], crawlDelay: null, sitemaps: [] }
-  for (const g of groups) {
-    for (const r of g.rules) {
-      if (r.type === 'allow') merged.allow.push(r.path)
-      if (r.type === 'disallow') merged.disallow.push(r.path)
-      if (r.type === 'noindex') merged.noindex.push(r.path)
-      if (r.type === 'crawl-delay') {
-        const n = Number(r.path)
-        if (!Number.isNaN(n)) {
-          merged.crawlDelay = merged.crawlDelay == null
-            ? n
-            : Math.min(merged.crawlDelay, n)
-        }
-      }
-      if (r.type === 'sitemap') merged.sitemaps.push(r.path)
-    }
-  }
-  return { groups, merged, other, hasRules: ruleCount > 0 }
-}
-
-function classifySitemap(url) {
-  const u = String(url).toLowerCase()
-  if (u.includes('sitemap-image')) return 'image'
-  if (u.includes('sitemap-product')) return 'product'
-  if (u.includes('sitemap-content')) return 'content'
-  if (u.includes('sitemap-catalog')) return 'catalog'
-  if (u.endsWith('/sitemap.xml') || /\/sitemap[^/]*\.xml(\.gz)?$/.test(u)) return 'index'
-  return 'other'
-}
-
-const STATUS_NAME = {
-  301: 'Moved Permanently',
-  302: 'Found',
-  307: 'Temporary Redirect',
-  308: 'Permanent Redirect',
-  400: 'Bad Request',
-  401: 'Unauthorized',
-  403: 'Forbidden',
-  404: 'Not Found',
-  410: 'Gone',
-  429: 'Too Many Requests',
-  500: 'Internal Server Error',
-  503: 'Service Unavailable',
-}
-
-const ROBOTS_CATEGORY_META = {
-  ok: { label: 'Valid robots.txt', tone: 'ok', issue: false },
-  'html-error': { label: 'HTML error page', tone: 'error', issue: true },
-  'json-error': { label: 'JSON error', tone: 'error', issue: true },
-  json: { label: 'JSON payload', tone: 'info', issue: false },
-  text: { label: 'Plain text (no directives)', tone: 'warn', issue: true },
-  empty: { label: 'Empty response', tone: 'error', issue: true },
-  'no-cache': { label: 'No cached copy', tone: 'warn', issue: true },
-}
-
-const DOC_CATEGORY_META = {
-  xml: { label: 'XML document', tone: 'ok', issue: false },
-  'html-error': { label: 'HTML error page', tone: 'error', issue: true },
-  'json-error': { label: 'JSON error', tone: 'error', issue: true },
-  json: { label: 'JSON payload', tone: 'info', issue: false },
-  'robots-txt': { label: 'Robots/text directives', tone: 'info', issue: false },
-  text: { label: 'Plain text', tone: 'info', issue: false },
-  gzip: { label: 'Compressed (.gz)', tone: 'warn', issue: true },
-  empty: { label: 'Empty response', tone: 'error', issue: true },
-  unknown: { label: 'Unclassified', tone: 'warn', issue: true },
-}
-
-function normalizeReason(reason) {
-  if (!reason) return ''
-  return reason.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
-}
-function formatHttpStatus(code, reason) {
-  const normalized = normalizeReason(reason)
-  if (code && normalized) return `${code} ${normalized}`.trim()
-  if (code) return `${code} ${STATUS_NAME[code] || ''}`.trim()
-  return normalized
-}
-function classifyRobotsResponse(rawText, hasCached) {
-  if (!hasCached) {
-    const meta = ROBOTS_CATEGORY_META['no-cache']
-    return {
-      category: 'no-cache',
-      label: meta.label,
-      tone: meta.tone,
-      isIssue: meta.issue,
-      httpStatus: null,
-      httpLabel: '',
-    }
-  }
-
-  const trimmed = (rawText || '').trim()
-  if (!trimmed) {
-    const meta = ROBOTS_CATEGORY_META.empty
-    return {
-      category: 'empty',
-      label: meta.label,
-      tone: meta.tone,
-      isIssue: meta.issue,
-      httpStatus: null,
-      httpLabel: '',
-    }
-  }
-
-  if (/<!doctype html|<html/i.test(trimmed.substring(0, 200))) {
-    const status = extractHttpStatus(trimmed)
-    const meta = ROBOTS_CATEGORY_META['html-error']
-    return {
-      category: 'html-error',
-      label: meta.label,
-      tone: meta.tone,
-      isIssue: meta.issue,
-      httpStatus: status?.code ?? null,
-      httpLabel: status ? formatHttpStatus(status.code, status.reason) || meta.label : meta.label,
-    }
-  }
-
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-    const status = extractHttpStatus(trimmed)
-    const isError = typeof status?.code === 'number' && status.code >= 400
-    const category = isError ? 'json-error' : 'json'
-    const meta = ROBOTS_CATEGORY_META[category] || ROBOTS_CATEGORY_META.json
-    return {
-      category,
-      label: meta.label,
-      tone: meta.tone,
-      isIssue: meta.issue || isError,
-      httpStatus: status?.code ?? null,
-      httpLabel: status ? formatHttpStatus(status.code, status.reason) || meta.label : meta.label,
-    }
-  }
-
-  if (!/user-agent/i.test(trimmed)) {
-    const meta = ROBOTS_CATEGORY_META.text
-    return {
-      category: 'text',
-      label: meta.label,
-      tone: meta.tone,
-      isIssue: meta.issue,
-      httpStatus: null,
-      httpLabel: '',
-    }
-  }
-
-  const meta = ROBOTS_CATEGORY_META.ok
-  return {
-    category: 'ok',
-    label: meta.label,
-    tone: meta.tone,
-    isIssue: meta.issue,
-    httpStatus: null,
-    httpLabel: '',
-  }
-}
-function extractHttpStatus(text) {
-  if (!text) return null
-  const trimmed = text.trim()
-  if (!trimmed) return null
-
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-    try {
-      const obj = JSON.parse(trimmed)
-      if (typeof obj?.statusCode === 'number') {
-        const code = obj.statusCode
-        const reason = obj.error || obj.message || STATUS_NAME[code] || ''
-        return { code, reason: normalizeReason(reason) }
-      }
-    } catch {}
-  }
-  const titleMatch = trimmed.match(/<title>\s*(\d{3})\s*([^<]*)/i)
-  if (titleMatch) return { code: Number(titleMatch[1]), reason: normalizeReason(titleMatch[2]) }
-  const h1Match = trimmed.match(/<h1>\s*(\d{3})\s*([^<]*)/i)
-  if (h1Match) return { code: Number(h1Match[1]), reason: normalizeReason(h1Match[2]) }
-
-  const statusCodeMatch = trimmed.match(/\b(301|302|307|308|400|401|403|404|410|429|500|503)\b/)
-  let code = statusCodeMatch ? Number(statusCodeMatch[1]) : null
-
-  let reason = null
-  if (/forbidden/i.test(trimmed)) reason = 'Forbidden'
-  else if (/unauthorized/i.test(trimmed)) reason = 'Unauthorized'
-  else if (/not found/i.test(trimmed) || /cannot get/i.test(trimmed)) reason = 'Not Found'
-  else if (/too many requests/i.test(trimmed)) reason = 'Too Many Requests'
-  else if (/service unavailable|unavailable/i.test(trimmed)) reason = 'Service Unavailable'
-  else if (/access denied/i.test(trimmed)) reason = 'Access Denied'
-  else if (/bad request/i.test(trimmed)) reason = 'Bad Request'
-
-  if (!code && reason) {
-    const map = {
-      Forbidden: 403,
-      Unauthorized: 401,
-      'Not Found': 404,
-      'Too Many Requests': 429,
-      'Service Unavailable': 503,
-      'Access Denied': 403,
-      'Bad Request': 400,
-    }
-    code = map[reason] || null
-  }
-  if (code) return { code, reason: reason || STATUS_NAME[code] || '' }
-  if (reason) return { code: null, reason }
-  return null
-}
-
-function formatBytes(bytes) {
-  if (!bytes) return '0 B'
-  const units = ['B', 'KB', 'MB', 'GB', 'TB']
-  let value = bytes
-  let idx = 0
-  while (value >= 1024 && idx < units.length - 1) {
-    value /= 1024
-    idx++
-  }
-  const decimals = value >= 100 ? 0 : value >= 10 ? 1 : 2
-  return `${value.toFixed(decimals)} ${units[idx]}`
-}
-
-function enrichArchive(meta) {
-  if (!meta || typeof meta !== 'object') return null
-  return deepClean({
-    ...meta,
-    sizeLabel: typeof meta.size === 'number' ? formatBytes(meta.size) : null,
-    shaPreview: meta.sha256 ? String(meta.sha256).slice(0, 16) : null,
-    href: meta.path ? toDatasetHref(meta.path) : '',
-  })
-}
-
-function enrichDatasetMeta(meta) {
-  if (!meta || typeof meta !== 'object') return null
-  return deepClean({
-    ...meta,
-    sizeLabel: typeof meta.totalBytes === 'number' ? formatBytes(meta.totalBytes) : null,
-  })
-}
-
-function enrichHistoryEntry(entry) {
-  if (!entry || typeof entry !== 'object') return null
-  return deepClean({
-    ...entry,
-    sizeLabel: typeof entry.size === 'number' ? formatBytes(entry.size) : null,
-    href: entry.path ? toDatasetHref(entry.path) : '',
-    legacyHref: entry.legacyPath ? toDatasetHref(entry.legacyPath) : '',
-    shaPreview: entry.sha256 ? String(entry.sha256).slice(0, 16) : null,
-  })
-}
-
-function enrichHistory(history) {
-  if (!history || typeof history !== 'object') return null
-  const entries = Array.isArray(history.entries)
-    ? history.entries.map((entry) => enrichHistoryEntry(entry)).filter(Boolean)
-    : []
-  const latest = history.latest ? enrichHistoryEntry(history.latest) : entries[0] || null
-  return deepClean({
-    ...history,
-    entries,
-    latest,
-    manifestHref: history.manifestPath ? toDatasetHref(history.manifestPath) : '',
-    directoryHref: history.directory ? toDatasetHref(history.directory) : '',
-  })
-}
-
-function enrichManifest(manifest) {
-  if (!manifest || typeof manifest !== 'object') return null
-  return deepClean({
-    ...manifest,
-    archive: enrichArchive(manifest.archive || null),
-    dataset: enrichDatasetMeta(manifest.dataset || null),
-    history: enrichHistory(manifest.history || null),
-    summary: manifest.summary ? deepClean(manifest.summary) : null,
-  })
-}
-
-function buildFlagSections(bans) {
-  if (!bans || typeof bans !== 'object') return []
-  const listConfigs = [
+function toKpis(meta) {
+  const totals = meta?.totals || {}
+  return [
     {
-      key: 'candidates',
-      title: 'Primary ban candidates',
-      description: 'Hosts flagged for exclusion in this crawl.',
-      tone: 'warn',
+      id: 'images',
+      label: 'Images discovered',
+      value: totals.images || totals.items || 0,
     },
     {
-      key: 'zeroContentSitemaps',
-      title: 'Zero-content sitemaps',
-      description: 'Sitemaps that returned no URLs or empty payloads.',
-      tone: 'warn',
+      id: 'products',
+      label: 'Products mapped',
+      value: totals.products || 0,
     },
     {
-      key: 'skippedDueToErrors',
-      title: 'Skipped hosts — fetch errors',
-      description: 'Endpoints skipped after repeated failures during sitemap or robots fetches.',
-      tone: 'error',
+      id: 'hosts',
+      label: 'Hosts tracked',
+      value: totals.summaryHosts || totals.hosts || 0,
     },
     {
-      key: 'preservedDueToHistory',
-      title: 'Preserved for historical coverage',
-      description: 'Hosts retained because previous snapshots still reference them.',
-      tone: 'info',
-    },
-    {
-      key: 'massRemovalSafeguardHosts',
-      title: 'Safeguarded removals',
-      description: 'Hosts protected by mass-removal safeguards.',
-      tone: 'warn',
-    },
-    {
-      key: 'skippedDueToUnknownHistory',
-      title: 'Skipped — unknown history',
-      description: 'Hosts deferred because historical context was unavailable.',
-      tone: 'info',
+      id: 'documents',
+      label: 'Cached documents',
+      value: totals.documents || 0,
     },
   ]
-  const MAX_ITEMS = 60
-  const sections = []
-  for (const config of listConfigs) {
-    const items = Array.isArray(bans[config.key])
-      ? bans[config.key].map((item) => cleanText(item)).filter(Boolean)
-      : []
-    if (!items.length) continue
-    const trimmed = items.slice(0, MAX_ITEMS)
-    const overflow = Math.max(0, items.length - trimmed.length)
-    sections.push({
-      key: config.key,
-      title: config.title,
-      description: config.description,
-      tone: config.tone,
-      count: items.length,
-      items: trimmed,
-      overflow,
-    })
-  }
-  if (bans.massRemovalSafeguardTriggered) {
-    sections.push({
-      key: 'massRemovalSafeguardTriggered',
-      title: 'Mass-removal safeguard triggered',
-      description: 'Bulk deletions were blocked to avoid regressions — review before purging.',
-      tone: 'warn',
-      count: 1,
-      items: [],
-    })
-  }
-  if (bans.skippedRewrite) {
-    sections.push({
-      key: 'skippedRewrite',
-      title: 'Rewrite phase skipped',
-      description: 'Rewrite operations were deferred; rebuilt URLs may require manual review.',
-      tone: 'info',
-      count: 1,
-      items: [],
-    })
-  }
-  return sections
 }
 
-function truncatePreview(text, max = 320) {
-  if (!text) return ''
-  const trimmed = text.trim()
-  if (trimmed.length <= max) return trimmed
-  return `${trimmed.slice(0, max).trim()}…`
-}
-
-function cleanText(value) {
-  if (value == null) return ''
-  let text = String(value).replace(/\s+/g, ' ').trim()
-  if ((text.startsWith('"') && text.endsWith('"')) || (text.startsWith("'") && text.endsWith("'"))) {
-    text = text.slice(1, -1).trim()
-  }
-  if (text.startsWith('"') && text.includes('://')) {
-    text = text.replace(/^"+/, '')
-  }
-  if (text.endsWith('"') && text.includes('://')) {
-    text = text.replace(/"+$/, '')
-  }
-  return text
-}
-
-function deepClean(value) {
-  if (Array.isArray(value)) {
-    return value
-      .map((entry) => deepClean(entry))
-      .filter((entry) => entry !== undefined && entry !== null && entry !== '')
-  }
-  if (value && typeof value === 'object') {
-    const next = {}
-    for (const [key, entry] of Object.entries(value)) {
-      const cleaned = deepClean(entry)
-      if (cleaned === undefined || cleaned === null) continue
-      if (typeof cleaned === 'string' && cleaned.length === 0) continue
-      next[key] = cleaned
-    }
-    return next
-  }
-  if (typeof value === 'string') return cleanText(value)
-  return value
-}
-
-function pushSearchDoc(list, doc) {
-  if (!list) return
-  if (!doc || !doc.id) return
-  list.push({
-    id: doc.id,
-    section: doc.section || 'general',
-    title: cleanText(doc.title || ''),
-    description: cleanText(doc.description || ''),
-    href: doc.href || '',
-    badge: doc.badge || '',
-    tags: Array.isArray(doc.tags) ? doc.tags.filter(Boolean) : [],
-    meta: doc.meta ? deepClean(doc.meta) : {},
-  })
-}
-
-function upsertImage(map, entry) {
-  const id = cleanText(entry?.id || '')
-  if (!id) return null
-  const existing = map.get(id) || {
-    id,
-    src: '',
-    basename: '',
-    pageUrl: '',
-    title: '',
-    host: '',
-    firstSeen: '',
-    lastSeen: '',
-    duplicateOf: null,
-  }
-
-  const updated = {
-    ...existing,
-    src: entry?.src ? cleanText(entry.src) : existing.src,
-    basename: entry?.basename ? cleanText(entry.basename) : existing.basename,
-    pageUrl: entry?.pageUrl ? cleanText(entry.pageUrl) : existing.pageUrl,
-    title: entry?.title ? cleanText(entry.title) : existing.title,
-    host: entry?.host ? cleanText(entry.host) : existing.host,
-    firstSeen: entry?.firstSeen && (!existing.firstSeen || entry.firstSeen < existing.firstSeen)
-      ? entry.firstSeen
-      : existing.firstSeen,
-    lastSeen: entry?.lastSeen && (!existing.lastSeen || entry.lastSeen > existing.lastSeen)
-      ? entry.lastSeen
-      : existing.lastSeen,
-    duplicateOf: entry?.duplicateOf ?? existing.duplicateOf ?? null,
-  }
-
-  if (!updated.basename && updated.src) {
-    const withoutQuery = updated.src.split(/[#?]/)[0] || updated.src
-    updated.basename = cleanText(path.basename(withoutQuery))
-  }
-
-  map.set(id, updated)
-  return updated
-}
-
-function upsertProduct(map, pageUrl) {
-  const key = cleanText(pageUrl) || `__product-${map.size + 1}`
-  if (!map.has(key)) {
-    map.set(key, {
-      pageUrl: cleanText(pageUrl || ''),
-      title: '',
-      images: [],
-      firstSeen: '',
-      lastSeen: '',
-      cache: null,
-      urls: null,
-    })
-  }
-  return map.get(key)
-}
-
-function mergeProducts(product, image, meta) {
-  if (!product || !image) return
-  if (!product.images.some((item) => item.id === image.id)) {
-    product.images.push({ id: image.id, src: image.src, duplicateOf: image.duplicateOf })
-  }
-  if (!product.title && image.title) product.title = image.title
-  if (!product.pageUrl && image.pageUrl) product.pageUrl = image.pageUrl
-  if (meta?.firstSeen && (!product.firstSeen || meta.firstSeen < product.firstSeen)) {
-    product.firstSeen = meta.firstSeen
-  }
-  if (meta?.lastSeen && (!product.lastSeen || meta.lastSeen > product.lastSeen)) {
-    product.lastSeen = meta.lastSeen
-  }
-}
-
-function buildAggregates({ itemsMeta, legacyImages, legacyProducts, summaryItems = {} }) {
-  const imageMap = new Map()
-  const productMap = new Map()
-  const summaryItemsSafe = summaryItems && typeof summaryItems === 'object' ? summaryItems : {}
-
-  const addFromMeta = (metaEntries) => {
-    if (!metaEntries) return
-    for (const [id, meta] of Object.entries(metaEntries)) {
-      if (!meta || meta.removedAt) continue
-      const image = upsertImage(imageMap, { ...meta, id })
-      if (!image) continue
-      const product = upsertProduct(productMap, meta.pageUrl || '')
-      mergeProducts(product, image, meta)
-    }
-  }
-
-  addFromMeta(itemsMeta || {})
-
-  if (Array.isArray(legacyImages)) {
-    for (const entry of legacyImages) {
-      const image = upsertImage(imageMap, entry)
-      if (!image) continue
-      const product = upsertProduct(productMap, entry?.pageUrl || '')
-      mergeProducts(product, image, entry)
-    }
-  }
-
-  if (Array.isArray(legacyProducts)) {
-    for (const legacy of legacyProducts) {
-      const product = upsertProduct(productMap, legacy?.pageUrl || '')
-      if (!product) continue
-      if (!product.title && legacy?.title) product.title = cleanText(legacy.title)
-      if (!product.firstSeen || (legacy?.firstSeen && legacy.firstSeen < product.firstSeen)) {
-        product.firstSeen = legacy.firstSeen || product.firstSeen
-      }
-      if (!product.lastSeen || (legacy?.lastSeen && legacy.lastSeen > product.lastSeen)) {
-        product.lastSeen = legacy.lastSeen || product.lastSeen
-      }
-      if (Array.isArray(legacy?.images)) {
-        for (const img of legacy.images) {
-          const normalized = upsertImage(imageMap, { ...img, pageUrl: legacy.pageUrl })
-          if (!normalized) continue
-          mergeProducts(product, normalized, img)
-        }
-      }
-      if (legacy?.cache && !product.cache) product.cache = deepClean(legacy.cache)
-      if (Array.isArray(legacy?.urls) && !product.urls) {
-        product.urls = legacy.urls.slice(0, 8).map(cleanText)
-      }
-    }
-  }
-
-  const allImages = Array.from(imageMap.values()).sort((a, b) => a.id.localeCompare(b.id))
-  const allProducts = Array.from(productMap.values()).map((product) => ({
-    ...product,
-    images: product.images.sort((a, b) => a.id.localeCompare(b.id)),
-  })).sort((a, b) => (b.images.length - a.images.length) || a.pageUrl.localeCompare(b.pageUrl))
-
-  const duplicatesMap = new Map()
-  for (const image of allImages) {
-    if (!image.duplicateOf) continue
-    const key = image.duplicateOf
-    if (!duplicatesMap.has(key)) duplicatesMap.set(key, [])
-    duplicatesMap.get(key).push(image)
-  }
-
-  const duplicates = Array.from(duplicatesMap.entries())
-    .map(([canonicalId, duplicatesList]) => ({
-      canonicalId,
-      canonical: imageMap.get(canonicalId) || null,
-      duplicates: duplicatesList.sort((a, b) => a.id.localeCompare(b.id)),
-    }))
-    .sort((a, b) => b.duplicates.length - a.duplicates.length)
-
-  const hostStats = (() => {
-    const map = new Map()
-    const ensure = (host) => {
-      if (!map.has(host)) {
-        map.set(host, {
-          host,
-          images: 0,
-          uniqueImages: 0,
-          duplicates: 0,
-          products: 0,
-          pages: new Set(),
-        })
-      }
-      return map.get(host)
-    }
-    const hostOfUrl = (value) => {
-      try {
-        return new URL(value).host
-      } catch {
-        return ''
-      }
-    }
-    for (const image of allImages) {
-      const host = image.host || hostOfUrl(image.pageUrl)
-      if (!host) continue
-      const stats = ensure(host)
-      stats.images++
-      if (image.duplicateOf) stats.duplicates++
-      else stats.uniqueImages++
-      if (image.pageUrl) stats.pages.add(image.pageUrl)
-    }
-    for (const product of allProducts) {
-      const host = hostOfUrl(product.pageUrl)
-      if (!host) continue
-      const stats = ensure(host)
-      stats.products++
-      if (product.pageUrl) stats.pages.add(product.pageUrl)
-    }
-    for (const meta of Object.values(itemsMeta || {})) {
-      const host = hostOfUrl(meta?.pageUrl)
-      if (!host) continue
-      const stats = ensure(host)
-      if (meta?.pageUrl) stats.pages.add(meta.pageUrl)
-    }
-    return Array.from(map.values())
-      .map((entry) => ({
-        id: entry.host,
-        host: entry.host,
-        images: entry.images,
-        uniqueImages: entry.uniqueImages,
-        duplicates: entry.duplicates,
-        products: entry.products,
-        pages: entry.pages.size,
-      }))
-      .sort((a, b) => b.images - a.images || a.host.localeCompare(b.host))
-  })()
-
-  const topProducts = allProducts.slice(0, 25)
-
-  const totals = {
-    images: allImages.length,
-    uniqueImages: allImages.filter((img) => !img.duplicateOf).length,
-    duplicateImages: allImages.filter((img) => !!img.duplicateOf).length,
-    products: allProducts.length,
-    hosts: hostStats.length,
-  }
-
-  const itemsMetrics = (() => {
-    let total = 0
-    let active = 0
-    let removed = 0
-    let duplicatesCount = 0
-    for (const meta of Object.values(itemsMeta || {})) {
-      if (!meta) continue
-      total++
-      if (meta.removedAt) removed++
-      else active++
-      if (meta.duplicateOf) duplicatesCount++
-    }
-    return {
-      total: summaryItemsSafe.total ?? total,
-      active: summaryItemsSafe.active ?? active,
-      removed: summaryItemsSafe.removed ?? removed,
-      duplicates: summaryItemsSafe.duplicatesThisRun
-        ?? summaryItemsSafe.duplicates
-        ?? duplicatesCount,
-      added: summaryItemsSafe.added ?? null,
-      purged: summaryItemsSafe.purged ?? null,
-      processed: summaryItemsSafe.processed ?? null,
-      discovered: summaryItemsSafe.discovered ?? null,
-      duplicatesThisRun: summaryItemsSafe.duplicatesThisRun ?? null,
-      newItems: summaryItemsSafe.newItems ?? summaryItemsSafe.discovered ?? null,
-    }
-  })()
-
-  return { allImages, allProducts, duplicates, hostStats, topProducts, totals, itemsMetrics }
-}
-
-function paginateItems(items, size = 60) {
-  const list = Array.isArray(items) ? items : []
-  const pageSize = Math.max(1, size)
-  const totalItems = list.length
-  const pageCount = totalItems === 0 ? 1 : Math.ceil(totalItems / pageSize)
-  const pages = []
-  for (let pageNumber = 0; pageNumber < pageCount; pageNumber++) {
-    const start = pageNumber * pageSize
-    const slice = list.slice(start, start + pageSize)
-    const from = totalItems === 0 ? 0 : start + 1
-    const to = totalItems === 0 ? 0 : start + slice.length
-    pages.push({
-      pageNumber,
-      pageCount,
-      totalItems,
-      from,
-      to,
-      size: pageSize,
-      items: slice,
-    })
-  }
-  if (pages.length === 0) {
-    pages.push({
-      pageNumber: 0,
-      pageCount: 1,
-      totalItems: 0,
-      from: 0,
-      to: 0,
-      size: pageSize,
-      items: [],
-    })
-  }
-  return { size: pageSize, totalItems, pageCount: pages.length, pages }
-}
-
-function buildPagination(sectionMap) {
-  const entries = Object.entries(sectionMap || {})
-  if (entries.length === 0) {
-    return { sections: {}, pages: [{ pageNumber: 0, pageCount: 1, sections: {} }] }
-  }
-
-  const sectionMeta = {}
-  let globalPageCount = 0
-
-  for (const [key, config] of entries) {
-    const { title = key, items = [], size = 60 } = config || {}
-    const data = paginateItems(items, size)
-    sectionMeta[key] = { title, ...data }
-    globalPageCount = Math.max(globalPageCount, data.pageCount)
-  }
-
-  if (globalPageCount === 0) globalPageCount = 1
-
-  const pages = []
-  for (let pageNumber = 0; pageNumber < globalPageCount; pageNumber++) {
-    const sections = {}
-    for (const [key, meta] of Object.entries(sectionMeta)) {
-      const pageEntry = meta.pages[pageNumber] || meta.pages[meta.pages.length - 1] || {
-        pageNumber,
-        pageCount: meta.pageCount,
-        totalItems: meta.totalItems,
-        from: 0,
-        to: 0,
-        size: meta.size,
-        items: [],
-      }
-      sections[key] = {
-        title: meta.title,
-        pageNumber: pageEntry.pageNumber,
-        pageCount: pageEntry.pageCount,
-        totalItems: pageEntry.totalItems,
-        from: pageEntry.from,
-        to: pageEntry.to,
-        size: pageEntry.size,
-        items: pageEntry.items,
-      }
-    }
-    pages.push({ pageNumber, pageCount: globalPageCount, sections })
-  }
-
-  const sections = {}
-  for (const [key, meta] of Object.entries(sectionMeta)) {
-    sections[key] = {
-      title: meta.title,
-      size: meta.size,
-      totalItems: meta.totalItems,
-      pageCount: meta.pageCount,
-    }
-  }
-
-  return { sections, pages }
-}
-
-function makeBreakdown(counts, meta, total) {
-  return Object.entries(counts).map(([key, count]) => {
-    const m = meta[key] || { label: key, tone: 'info', issue: false }
-    const pct = total ? (count / total) * 100 : 0
-    return {
-      key,
-      label: m.label,
-      tone: m.tone,
-      issue: m.issue,
-      count,
-      pct: Math.round(pct * 10) / 10,
-    }
-  }).sort((a, b) => {
-    const toneRank = { error: 0, warn: 1, info: 2, ok: 3 }
-    const td = (toneRank[a.tone] ?? 4) - (toneRank[b.tone] ?? 4)
-    if (td !== 0) return td
-    return b.count - a.count
-  })
-}
-
-function classifyDocContent(filePath, previewText) {
-  const ext = path.extname(filePath).toLowerCase()
-  if (ext === '.gz') {
-    return {
-      category: 'gzip',
-      label: 'Compressed (.gz)',
-      tone: 'warn',
-      isIssue: true,
-      httpStatus: null,
-      httpLabel: '',
-    }
-  }
-  const text = (previewText || '').trim()
-  if (!text) {
-    return {
-      category: 'empty',
-      label: 'Empty response',
-      tone: 'error',
-      isIssue: true,
-      httpStatus: null,
-      httpLabel: '',
-    }
-  }
-  if (/<!doctype html|<html/i.test(text.substring(0, 200))) {
-    const status = extractHttpStatus(text)
-    return {
-      category: 'html-error',
-      label: status ? `${status.code ?? ''} ${status.reason ?? ''}`.trim() : 'HTML error page',
-      tone: 'error',
-      isIssue: true,
-      httpStatus: status?.code ?? null,
-      httpLabel: status ? `${status.code ?? ''} ${status.reason ?? ''}`.trim() : 'HTML error page',
-    }
-  }
-  if (text.startsWith('{') || text.startsWith('[')) {
-    const status = extractHttpStatus(text)
-    const isError = !!status && typeof status.code === 'number' && status.code >= 400
-    const label = status ? `${status.code ?? ''} ${status.reason ?? ''}`.trim() : 'JSON payload'
-    return {
-      category: isError ? 'json-error' : 'json',
-      label,
-      tone: isError ? 'error' : 'info',
-      isIssue: !!isError,
-      httpStatus: status?.code ?? null,
-      httpLabel: label,
-    }
-  }
-  if (/^<\?xml/i.test(text) || /^<(urlset|sitemapindex|feed|rss)\b/i.test(text)) {
-    return {
-      category: 'xml',
-      label: 'XML document',
-      tone: 'ok',
-      isIssue: false,
-      httpStatus: null,
-      httpLabel: '',
-    }
-  }
-  if (/user-agent|disallow|allow/i.test(text)) {
-    return {
-      category: 'robots-txt',
-      label: 'Robots/text directives',
-      tone: 'info',
-      isIssue: false,
-      httpStatus: null,
-      httpLabel: '',
-    }
-  }
-  if (/[a-z]/i.test(text)) {
-    return {
-      category: 'text',
-      label: 'Plain text',
-      tone: 'info',
-      isIssue: false,
-      httpStatus: null,
-      httpLabel: '',
-    }
-  }
-  return {
-    category: 'unknown',
-    label: 'Unclassified',
-    tone: 'warn',
-    isIssue: true,
-    httpStatus: null,
-    httpLabel: '',
-  }
-}
-
-async function generateReport() {
-  await ensureDatasetReady()
-  const [
-    summary,
-    urlmeta,
-    itemsMeta,
-    legacyAllImages,
-    legacyAllProducts,
-    runsHistory,
-    bundleManifest,
-    datasetReport,
-  ] = await Promise.all([
-    loadJSON(SUMMARY_JSON, {}),
-    loadJSON(URLMETA_JSON, {}),
-    loadJSON(ITEMS_META_JSON, {}),
-    loadJSON(ALL_IMAGES_JSON, []),
-    loadJSON(ALL_PRODUCTS_JSON, []),
-    loadJSON(RUNS_HISTORY_JSON, []),
-    loadJSON(BUNDLE_MANIFEST_JSON, null),
-    loadJSON(DATASET_REPORT_FILE, null),
-  ])
-
-  const baseHref = '/content/projects/lv-images/generated/lv/'
-  const rev = buildReverseUrlmeta(urlmeta)
-  const searchDocuments = []
-
-  // Sitemaps table rows (summary.sitemaps now contains {host,url,itemCount})
-  const sitemapsLog = Array.isArray(summary?.sitemaps) ? summary.sitemaps : []
-  const sitemaps = sitemapsLog.map((s, index) => {
-    const url = cleanText(s.url || '')
-    const um = urlmeta[url] || {}
-    const savedPath = um.path
-      ? path.relative(LV_BASE, path.resolve(um.path)).split(path.sep).join('/')
-      : ''
-    const id = `sitemap-${index}`
-    pushSearchDoc(searchDocuments, {
-      id,
-      section: 'sitemaps',
-      title: cleanText(s.host || url || 'Sitemap'),
-      description: url,
-      href: savedPath ? `${baseHref}${savedPath}` : url,
-      badge: classifySitemap(url),
-      tags: ['sitemap', classifySitemap(url)].filter(Boolean),
-      meta: { status: um.status ?? '', itemCount: s.itemCount || 0 },
-    })
-    return {
-      id,
-      host: s.host || '',
-      url,
-      type: classifySitemap(url),
-      imageCount: s.itemCount || 0,
-      status: um.status ?? '',
-      savedPath,
-    }
-  })
-
-  // All cached XML/TXT docs under cache/sitemaps/
-  const docs = []
-  const docCounts = Object.create(null)
-  let docIndex = 0
-  for await (const absPath of walk(SITEMAPS_DIR)) {
-    if (!/\.(xml|txt|gz)$/i.test(absPath)) continue
-    const meta = rev.get(path.resolve(absPath)) || {}
-    const url = meta.url || ''
-    const host = (() => {
-      try {
-        return new URL(url).host
-      } catch {
-        return path.basename(path.dirname(absPath))
-      }
-    })()
-    const relPath = path.relative(LV_BASE, path.resolve(absPath)).split(path.sep).join('/')
-    const kind = /\.xml(\.gz)?$/i.test(absPath) ? 'xml' : /\.txt$/i.test(absPath) ? 'txt' : 'bin'
-
-    let sizeBytes = 0, previewSource = ''
-    if (relPath.endsWith('.gz')) {
-      try {
-        const stat = await fs.stat(absPath)
-        sizeBytes = stat.size
-      } catch {}
-    } else {
-      try {
-        const fh = await fs.open(absPath, 'r')
-        const stat = await fh.stat()
-        const len = Math.min(stat.size, 4096)
-        const buf = Buffer.alloc(len)
-        await fh.read(buf, 0, len, 0)
-        await fh.close()
-        previewSource = buf.toString('utf8')
-        sizeBytes = stat.size
-      } catch {
-        try {
-          const statFallback = await fs.stat(absPath)
-          sizeBytes = statFallback.size
-        } catch {}
-      }
-    }
-
-    const classification = classifyDocContent(relPath, previewSource)
-    docCounts[classification.category] = (docCounts[classification.category] || 0) + 1
-
-    const preview = ((t, m = 360) => {
-      const trimmed = (t || '').trim()
-      if (trimmed.length <= m) return trimmed
-      return `${trimmed.slice(0, m).trim()}…`
-    })(previewSource, 360)
-
-    const record = {
-      id: `doc-${docIndex++}`,
-      host,
-      kind,
-      url,
-      status: meta.status ?? '',
-      contentType: meta.contentType || '',
-      savedPath: relPath,
-      fileName: path.basename(absPath),
-      sizeBytes,
-      sizeLabel: formatBytes(sizeBytes),
-      statusCategory: classification.category,
-      statusLabel: classification.label,
-      statusTone: classification.tone,
-      httpStatus: classification.httpStatus ?? null,
-      httpLabel: classification.httpLabel || '',
-      isIssue: classification.isIssue,
-      preview,
-    }
-    docs.push(record)
-    pushSearchDoc(searchDocuments, {
-      id: record.id,
-      section: 'docs',
-      title: cleanText(
-        `${record.host} ${record.fileName}`.trim() || record.fileName || 'Cached doc',
-      ),
-      description: record.url,
-      href: record.savedPath ? `${baseHref}${record.savedPath}` : record.url,
-      badge: record.kind,
-      tags: [record.kind, record.statusCategory].filter(Boolean),
-      meta: { status: record.status, contentType: record.contentType, size: record.sizeLabel },
-    })
-  }
-  docs.sort((a, b) => a.host.localeCompare(b.host) || a.savedPath.localeCompare(b.savedPath))
-
-  // Robots explorer: union of hosts we know about
-  const robotsHosts = new Set()
-  try {
-    const files = await fs.readdir(ROBOTS_DIR)
-    for (const n of files) if (n.endsWith('.txt')) robotsHosts.add(n.replace(/\.txt$/i, ''))
-  } catch {}
-  for (const r of sitemaps) robotsHosts.add(r.host)
-  for (const d of docs) robotsHosts.add(d.host)
-  const allHosts = Array.from(robotsHosts).filter(Boolean).sort()
-
-  const robots = []
-  const robotsCounts = Object.create(null)
-  let robotIndex = 0
-  for (const host of allHosts) {
-    const robotsPath = path.join(ROBOTS_DIR, `${host}.txt`)
-    let rawText = null
-    try {
-      rawText = await fs.readFile(robotsPath, 'utf8')
-    } catch {}
-
-    const decoded = await loadDecodedRobots(host)
-
-    let parsed
-    if (decoded) {
-      const allow = [], disallow = [], noindex = []
-      const sitemaps = decoded.summary?.sitemaps || []
-      let crawlDelay = decoded.summary?.crawlDelay ?? null
-
-      for (const g of decoded.groups || []) {
-        for (const r of g.rules || []) {
-          if (r.type === 'allow') allow.push(r.value)
-          else if (r.type === 'disallow') disallow.push(r.value)
-          else if (r.type === 'noindex') noindex.push(r.value)
-          else if (r.type === 'crawl-delay') {
-            const n = Number(r.value)
-            if (!Number.isNaN(n)) crawlDelay = crawlDelay == null ? n : Math.min(crawlDelay, n)
-          }
-        }
-      }
-
-      // unknown directives
-      const other = {}
-      for (const line of decoded.lines || []) {
-        if (line.type !== 'directive') continue
-        const k = (line.directive || '').toLowerCase()
-        if (
-          !k || ['user-agent', 'allow', 'disallow', 'noindex', 'sitemap', 'crawl-delay'].includes(k)
-        ) continue
-        ;(other[k] ||= []).push(line.value || '')
-      }
-
-      parsed = {
-        groups: decoded.groups || [],
-        merged: { allow, disallow, noindex, crawlDelay, sitemaps },
-        other,
-        hasRules: (allow.length + disallow.length + noindex.length + sitemaps.length) > 0,
-      }
-    } else {
-      parsed = rawText
-        ? parseRobots(rawText)
-        : {
-          groups: [],
-          merged: { allow: [], disallow: [], noindex: [], crawlDelay: null, sitemaps: [] },
-          other: {},
-          hasRules: false,
-        }
-    }
-
-    const classification = classifyRobotsResponse(rawText || '', !!rawText)
-
-    robotsCounts[classification.category] = (robotsCounts[classification.category] || 0) + 1
-
-    const sizeBytes = rawText ? Buffer.byteLength(rawText, 'utf8') : 0
-    const record = {
-      id: `robot-${robotIndex++}`,
-      host,
-      hasCached: !!rawText,
-      robotsTxtPath: rawText ? path.relative(LV_BASE, robotsPath).split(path.sep).join('/') : '',
-      rawText: rawText || '',
-      linesTotal: decoded
-        ? (decoded.lines?.length || 0)
-        : (rawText ? rawText.split(/\r?\n/).length : 0),
-      parsed,
-      blacklisted: !!(summary?.blacklist?.[host]),
-      blacklistUntil: summary?.blacklist?.[host]?.untilISO || '',
-      blacklistReason: summary?.blacklist?.[host]?.reason || '',
-      fileName: rawText ? path.basename(robotsPath) : '',
-      sizeBytes,
-      sizeLabel: formatBytes(sizeBytes),
-      statusCategory: classification.category,
-      statusLabel: classification.label,
-      statusTone: classification.tone,
-      httpStatus: classification.httpStatus ?? null,
-      httpLabel: classification.httpLabel || '',
-      isIssue: classification.isIssue,
-      preview: truncatePreview(rawText, 360),
-    }
-    robots.push(record)
-    pushSearchDoc(searchDocuments, {
-      id: record.id,
-      section: 'robots',
-      title: cleanText(`${host} robots.txt`),
-      description: classification.httpLabel || classification.label,
-      href: record.robotsTxtPath ? `${baseHref}${record.robotsTxtPath}` : '',
-      badge: classification.category,
-      tags: [classification.category, classification.tone].filter(Boolean),
-      meta: { hasCached: record.hasCached, lines: record.linesTotal, isIssue: record.isIssue },
-    })
-  }
-
-  const aggregates = buildAggregates({
-    itemsMeta,
-    legacyImages: Array.isArray(legacyAllImages) ? legacyAllImages : [],
-    legacyProducts: Array.isArray(legacyAllProducts) ? legacyAllProducts : [],
-    summaryItems: summary?.items || {},
-  })
-
-  const { sections: paginationSections, pages } = buildPagination({
-    sitemaps: { title: 'Sitemaps', items: sitemaps, size: 60 },
-    docs: { title: 'Cached documents', items: docs, size: 40 },
-    robots: { title: 'Robots.txt', items: robots, size: 50 },
-    duplicates: { title: 'Duplicate images', items: aggregates.duplicates, size: 40 },
-    topProducts: { title: 'Top products', items: aggregates.topProducts, size: 30 },
-    hostStats: { title: 'Host statistics', items: aggregates.hostStats, size: 40 },
-  })
-
-  for (const [index, image] of aggregates.allImages.slice(0, 400).entries()) {
-    pushSearchDoc(searchDocuments, {
-      id: `image-${index}`,
-      section: 'images',
-      title: image.title || image.basename || image.src || image.id,
-      description: image.pageUrl || image.src,
-      href: image.pageUrl || image.src,
-      badge: image.duplicateOf ? 'duplicate' : 'image',
-      tags: [image.host, image.duplicateOf ? 'duplicate' : 'unique'].filter(Boolean),
-      meta: { firstSeen: image.firstSeen, lastSeen: image.lastSeen },
-    })
-  }
-
-  for (const duplicate of aggregates.duplicates.slice(0, 120)) {
-    pushSearchDoc(searchDocuments, {
-      id: `duplicate-${duplicate.canonicalId}`,
-      section: 'duplicates',
-      title: duplicate.canonical?.title || duplicate.canonical?.basename || duplicate.canonicalId,
-      description: duplicate.canonical?.pageUrl || duplicate.canonical?.src
-        || duplicate.canonicalId,
-      href: duplicate.canonical?.pageUrl || duplicate.canonical?.src || '',
-      badge: `×${duplicate.duplicates.length + 1}`,
-      tags: ['duplicate'],
-      meta: { duplicateCount: duplicate.duplicates.length },
-    })
-  }
-
-  for (const [index, product] of aggregates.topProducts.entries()) {
-    pushSearchDoc(searchDocuments, {
-      id: `product-${index}`,
-      section: 'products',
-      title: product.title || product.pageUrl || `Product ${index + 1}`,
-      description: product.pageUrl,
-      href: product.pageUrl && /^https?:/i.test(product.pageUrl) ? product.pageUrl : '',
-      badge: 'product',
-      tags: [String(product.images.length), 'images'],
-      meta: {
-        imageCount: product.images.length,
-        firstSeen: product.firstSeen,
-        lastSeen: product.lastSeen,
-      },
-    })
-  }
-
-  for (const [index, host] of aggregates.hostStats.slice(0, 40).entries()) {
-    pushSearchDoc(searchDocuments, {
-      id: `host-${index}`,
-      section: 'hosts',
-      title: host.host,
-      description: `${host.images} images`,
-      href: '',
-      badge: 'host',
-      tags: ['host'],
-      meta: {
-        imageCount: host.images,
-        duplicateCount: host.duplicates,
-        productCount: host.products,
-        pages: host.pages,
-      },
-    })
-  }
-
-  const robotsMetrics = {
-    total: robots.length,
-    issues: robots.filter((r) => r.isIssue).length,
-    breakdown: makeBreakdown(robotsCounts, ROBOTS_CATEGORY_META, robots.length),
-  }
-  robotsMetrics.issuePct = robotsMetrics.total
-    ? (robotsMetrics.issues / robotsMetrics.total) * 100
-    : 0
-
-  const docsMetrics = {
-    total: docs.length,
-    issues: docs.filter((d) => d.isIssue).length,
-    breakdown: makeBreakdown(
-      (() => {
-        const counts = Object.create(null)
-        for (const d of docs) counts[d.statusCategory] = (counts[d.statusCategory] || 0) + 1
-        return counts
-      })(),
-      DOC_CATEGORY_META,
-      docs.length,
-    ),
-  }
-  docsMetrics.issuePct = docsMetrics.total
-    ? (docsMetrics.issues / docsMetrics.total) * 100
-    : 0
-
-  const bundleExists = await pathExists(BUNDLE_ARCHIVE_PATH)
-  const manifestEnriched = enrichManifest(bundleManifest)
-  const dataset = {
-    manifest: manifestEnriched,
-    manifestHref: '/content/projects/lv-images/generated/lv.bundle.json',
-    archiveHref: '/content/projects/lv-images/generated/lv.bundle.tgz',
-    archiveExists: bundleExists,
-    totals: {
-      images: aggregates.totals.images,
-      uniqueImages: aggregates.totals.uniqueImages,
-      duplicateImages: aggregates.totals.duplicateImages,
-      products: aggregates.totals.products,
-      hosts: aggregates.totals.hosts,
+function buildSearchIndex(rows) {
+  const engine = new MiniSearch({
+    fields: ['title', 'sku', 'locale', 'productType', 'tags'],
+    storeFields: ['id', 'title', 'sku', 'locale', 'productType', 'pageUrl', 'imageUrl', 'hasHero', 'imageCount', 'updatedAt'],
+    searchOptions: {
+      boost: { title: 2, sku: 2 },
+      prefix: true,
+      fuzzy: 0.2,
     },
-    flags: buildFlagSections(summary?.bans || {}),
-    capture: summary?.capture && typeof summary.capture === 'object'
-      ? Object.entries(summary.capture).map(([key, enabled]) => ({
-        key,
-        enabled: Boolean(enabled),
-      }))
-      : [],
-    summaryTotals: summary?.totals ? deepClean(summary.totals) : null,
-    bundleLabel: summary?.bundleLabel || null,
-    runMode: summary?.runMode || null,
-  }
-  if (manifestEnriched?.history) {
-    dataset.history = manifestEnriched.history
-  }
-  if (manifestEnriched?.dataset?.fileCount != null) {
-    dataset.totals.fileCount = manifestEnriched.dataset.fileCount
-  }
-  if (manifestEnriched?.dataset?.totalBytes != null) {
-    dataset.totals.totalBytes = manifestEnriched.dataset.totalBytes
-  }
-  if (manifestEnriched?.dataset?.sizeLabel) {
-    dataset.totals.sizeLabel = manifestEnriched.dataset.sizeLabel
-  }
-  if (manifestEnriched?.archive?.sizeLabel) {
-    dataset.totals.bundleSizeLabel = manifestEnriched.archive.sizeLabel
-  }
-  if (manifestEnriched?.archive?.shaPreview) {
-    dataset.totals.shaPreview = manifestEnriched.archive.shaPreview
-  }
-  if (summary?.totals) {
-    if (summary.totals.pages != null) dataset.totals.pages = summary.totals.pages
-    if (summary.totals.sitemapsProcessed != null) {
-      dataset.totals.sitemapsProcessed = summary.totals.sitemapsProcessed
-    }
-    if (summary.totals.itemsFound != null) dataset.totals.itemsFound = summary.totals.itemsFound
-    if (summary.totals.newItems != null) dataset.totals.newItems = summary.totals.newItems
-    if (summary.totals.pageSnapshots != null) {
-      dataset.totals.pageSnapshots = summary.totals.pageSnapshots
-    }
-    if (summary.totals.imageSnapshots != null) {
-      dataset.totals.imageSnapshots = summary.totals.imageSnapshots
-    }
-  }
-  if (datasetReport?.payload?.totals) {
-    dataset.totals = { ...dataset.totals, ...deepClean(datasetReport.payload.totals) }
-  }
+  })
+  const documents = rows.map((row) => ({
+    id: row.id,
+    title: row.title || row.pageUrl || row.sku || 'Untitled',
+    sku: row.sku || '',
+    locale: row.locale || 'unknown',
+    productType: row.productType || 'other',
+    pageUrl: row.pageUrl || '',
+    imageUrl: row.imageUrl || '',
+    hasHero: row.hasHero,
+    imageCount: row.imageCount ?? 0,
+    updatedAt: row.updatedAt || row.lastMod || '',
+    tags: Array.isArray(row.tags) ? row.tags.join(' ') : '',
+  }))
+  engine.addAll(documents)
+  return { engine, documents }
+}
 
-  const runsHistoryClean = Array.isArray(runsHistory)
-    ? runsHistory.map((entry) => deepClean(entry)).slice(0, 10)
-    : []
-
-  let searchIndex = null
-  let searchError = null
-  try {
-    const engine = new MiniSearch(MINI_SEARCH_OPTIONS)
-    engine.addAll(searchDocuments)
-    searchIndex = engine.toJSON()
-  } catch (error) {
-    searchError = error?.message || String(error)
-  }
-
-  const search = {
-    documents: searchDocuments,
-    index: searchIndex,
-    options: MINI_SEARCH_OPTIONS,
-    datasetHref: `${baseHref}lvreport.dataset.json`,
-    documentCount: searchDocuments.length,
-    error: searchError,
-  }
-
+function buildSections(meta, rows) {
+  const summary = meta?.summary || {}
   return {
-    baseHref,
-    summary: summary || {},
-    sitemaps,
-    docs,
-    robots,
-    sample: await sampleItems(ITEMS_DIR, 60),
-    metrics: { robots: robotsMetrics, docs: docsMetrics, items: aggregates.itemsMetrics },
-    allImages: aggregates.allImages,
-    allProducts: aggregates.allProducts,
-    duplicates: aggregates.duplicates,
-    hostStats: aggregates.hostStats,
-    topProducts: aggregates.topProducts,
-    totals: aggregates.totals,
-    dataset,
-    runsHistory: runsHistoryClean,
-    pagination: deepClean(paginationSections),
-    pages: pages.map((page) => ({
-      pageNumber: page.pageNumber,
-      pageCount: page.pageCount,
-      sections: deepClean(page.sections),
-    })),
-    search,
+    datasetMap: {
+      hosts: summary?.hosts || [],
+      locales: summary?.locales || [],
+    },
+    sitemaps: summary?.sitemaps || [],
+    duplicates: meta?.images?.filter((img) => img?.duplicateOf).slice(0, 50) || [],
+    topProducts: meta?.products?.slice(0, 50) || [],
+    runsHistory: meta?.runsHistory || [],
+    robots: meta?.robots || [],
+    docs: meta?.docs || [],
+    sample: Array.isArray(rows) ? rows.slice(0, 60) : [],
   }
 }
 
-export async function buildAndPersistReport({ log = null } = {}) {
-  const payload = await generateReport()
-  const generatedAt = new Date().toISOString()
-  const record = { generatedAt, payload }
-  try {
-    await fs.mkdir(path.dirname(DATASET_REPORT_FILE), { recursive: true })
-    await fs.writeFile(DATASET_REPORT_FILE, `${JSON.stringify(record, null, 2)}\n`, 'utf8')
-    if (typeof log === 'function') {
-      const rel = path.relative(path.resolve(__dirname, '..'), DATASET_REPORT_FILE)
-      const totals = payload?.totals || {}
-      log(
-        `lvreport dataset saved → ${rel || DATASET_REPORT_FILE} (images=${
-          totals.images ?? '?'
-        }, pages=${totals.pages ?? '?'})`,
-      )
-    }
-  } catch (error) {
-    if (typeof log === 'function') {
-      log(`Failed to persist lvreport dataset: ${error?.message || error}`)
-    }
-    throw error
+async function writeClientPayload({
+  indexHref,
+  metaHref,
+  metricsHref,
+  searchHref,
+  facets,
+  totals,
+  kpis,
+}) {
+  await mkdir(PUBLIC_DATA_DIR, { recursive: true })
+  const payload = {
+    indexHref,
+    metaHref,
+    metricsHref,
+    searchHref,
+    facets,
+    totals,
+    kpis,
   }
-  return { file: DATASET_REPORT_FILE, payload, generatedAt }
+  await writeFile(CLIENT_PAYLOAD_FILE, `${JSON.stringify(payload)}\n`, 'utf8')
+  return payload
+}
+
+async function buildReport() {
+  await ensureBundleAvailable()
+  const { meta, rows } = await buildIndex()
+  const { engine, documents } = buildSearchIndex(rows)
+  const searchIndex = engine.toJSON()
+  const facets = meta?.facets || {}
+  const totals = meta?.totals || {}
+  const kpis = toKpis(meta)
+  const sections = buildSections(meta, rows)
+
+  await mkdir(PUBLIC_DATA_DIR, { recursive: true })
+  await writeFile(DATASET_FILE, `${JSON.stringify({ meta, rows, sections })}\n`, 'utf8')
+  await writeFile(SEARCH_INDEX_FILE, `${JSON.stringify({ documents, index: searchIndex })}\n`, 'utf8')
+  const clientPayload = await writeClientPayload({
+    indexHref: '/assets/data/lvreport/index.json',
+    metaHref: '/assets/data/lvreport/meta.json',
+    metricsHref: '/assets/data/lvreport/ingest-metrics.json',
+    searchHref: '/assets/data/lvreport/search-index.json',
+    facets,
+    totals,
+    kpis,
+  })
+
+  return {
+    generatedAt: meta?.generatedAt || new Date().toISOString(),
+    totals,
+    facets,
+    kpis,
+    sections,
+    meta,
+    rows,
+    search: {
+      documents,
+      index: searchIndex,
+      count: documents.length,
+    },
+    clientPayload,
+  }
+}
+
+export async function buildAndPersistReport({ log } = {}) {
+  const report = await getReport()
+  if (typeof log === 'function') {
+    log(
+      `lvreport dataset cached → ${path.relative(projectRoot, DATASET_FILE)} (items=${
+        report?.search?.count ?? '?'
+      })`,
+    )
+  }
+  return { file: DATASET_FILE, payload: report }
+}
+
+async function getReport() {
+  if (memoized) return memoized
+  memoized = await buildReport()
+  return memoized
 }
 
 export default async function() {
-  return generateReport()
+  return getReport()
+}
+
+export async function loadClientPayload() {
+  try {
+    const raw = await readFile(CLIENT_PAYLOAD_FILE, 'utf8')
+    return raw ? JSON.parse(raw) : null
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null
+    throw error
+  }
 }

--- a/src/assets/js/lvreport-app.js
+++ b/src/assets/js/lvreport-app.js
@@ -1,483 +1,864 @@
-import Alpine from 'alpinejs'
-import Fuse from 'fuse.js'
 import MiniSearch from 'minisearch'
+import Fuse from 'fuse.js'
 
 const datasetEl = document.getElementById('lvreport-data')
-const payloadSource = (() => {
-  if (!datasetEl) return null
-  if (datasetEl.tagName === 'TEMPLATE') return datasetEl.innerHTML
-  return datasetEl.textContent
-})()
-const payload = payloadSource ? JSON.parse(payloadSource) : {}
-const baseHref = payload.baseHref || ''
-const sections = payload.page?.sections || {}
-const sectionKeys = Object.keys(sections)
+const payload = datasetEl ? JSON.parse(datasetEl.textContent || '{}') : {}
 
-const fuseConfigs = {
-  sitemaps: { keys: ['host', 'url', 'type', 'status'], threshold: 0.35, ignoreLocation: true },
-  robots: {
-    keys: ['host', 'statusLabel', 'httpLabel', 'preview'],
-    threshold: 0.35,
-    ignoreLocation: true,
+const MINI_SEARCH_OPTIONS = {
+  fields: ['title', 'sku', 'locale', 'productType', 'tags'],
+  storeFields: ['id', 'title', 'sku', 'locale', 'productType', 'pageUrl', 'imageUrl', 'hasHero', 'imageCount', 'updatedAt'],
+  searchOptions: {
+    boost: { title: 2, sku: 2 },
+    prefix: true,
+    fuzzy: 0.2,
   },
-  docs: {
-    keys: ['host', 'fileName', 'statusLabel', 'contentType', 'preview'],
-    threshold: 0.3,
-    ignoreLocation: true,
-  },
-  duplicates: { keys: ['basename', 'title', 'pageUrl'], threshold: 0.3, ignoreLocation: true },
-  topProducts: { keys: ['title', 'pageUrl'], threshold: 0.3, ignoreLocation: true },
-  hosts: { keys: ['host'], threshold: 0.2, ignoreLocation: true },
 }
 
-const fuseInstances = new Map()
-const filters = {}
-const originalSummary = {}
+const BANNED_HOSTS = new Set(['www.olyv.co.in', 'app.urlgeni.us'])
 
-function initFuseEngines() {
-  for (const key of sectionKeys) {
-    const items = sections[key]?.items || []
-    const config = fuseConfigs[key]
-    if (!config || !items.length) continue
-    fuseInstances.set(key, new Fuse(items, { includeScore: true, ...config }))
+const getHostname = (value) => {
+  if (!value) return ''
+  try {
+    const url = new URL(value)
+    return (url.hostname || '').toLowerCase()
+  } catch (error) {
+    return String(value).toLowerCase()
   }
 }
 
-function ensureSummaryCache(section) {
-  const el = document.querySelector(`[data-filter-summary="${section}"]`)
-  if (el && !originalSummary[section]) {
-    originalSummary[section] = el.textContent.trim()
-  }
+const isBannedUrl = (value) => {
+  const host = getHostname(value)
+  return host ? BANNED_HOSTS.has(host) : false
 }
 
-function updateSummary(section, total, visible) {
-  const el = document.querySelector(`[data-filter-summary="${section}"]`)
-  if (!el) return
-  ensureSummaryCache(section)
-  if (!originalSummary[section]) return
-  if (visible === total) {
-    el.textContent = originalSummary[section]
-  } else {
-    el.textContent = `${originalSummary[section]} • Filtered ${visible} of ${total}`
-  }
-}
+const escapeHtml = (value) =>
+  String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 
-function updateRowVisibility(section, visibleIds) {
-  const rows = document.querySelectorAll(`[data-section-row="${section}"]`)
-  rows.forEach(row => {
-    const id = row.dataset.entryId
-    row.hidden = !visibleIds.has(id)
-  })
-}
-
-function applyFilters(section) {
-  const data = sections[section]
-  if (!data) return
-  const items = data.items || []
-  const filterState = filters[section]
-  let results = items
-
-  const query = (filterState.query || '').trim()
-  if (query.length) {
-    const fuse = fuseInstances.get(section)
-    if (fuse) {
-      results = fuse.search(query).map(hit => hit.item)
-    } else {
-      const lower = query.toLowerCase()
-      results = items.filter(item => JSON.stringify(item).toLowerCase().includes(lower))
-    }
+class ImageRequestQueue {
+  constructor(limit = 4) {
+    this.limit = limit
+    this.queue = []
+    this.active = 0
   }
 
-  if (section === 'sitemaps' && filterState.types) {
-    results = results.filter(item => filterState.types.has(item.type || 'other'))
-  }
-  if ((section === 'robots' || section === 'docs') && filterState.statuses) {
-    results = results.filter(item => filterState.statuses.has(item.statusCategory || ''))
-  }
-  if ((section === 'robots' || section === 'docs') && filterState.issuesOnly) {
-    results = results.filter(item => item.isIssue)
+  enqueue(src, element) {
+    if (!src || !element) return
+    if (isBannedUrl(src)) return
+    this.queue.push({ src, element })
+    this.flush()
   }
 
-  filters[section].last = results
-  const visibleIds = new Set(results.map(item => item.id))
-  updateRowVisibility(section, visibleIds)
-  updateSummary(section, items.length, visibleIds.size)
-}
-
-function hookSearchInputs() {
-  const inputs = document.querySelectorAll('[data-search-input]')
-  inputs.forEach(input => {
-    const section = input.dataset.searchInput
-    if (!sectionKeys.includes(section)) return
-    input.addEventListener('input', event => {
-      filters[section].query = event.target.value
-      applyFilters(section)
-    })
-  })
-}
-
-function hookIssueToggles() {
-  const toggles = document.querySelectorAll('[data-issues-toggle]')
-  toggles.forEach(toggle => {
-    const section = toggle.dataset.issuesToggle
-    if (!sectionKeys.includes(section)) return
-    toggle.addEventListener('change', () => {
-      filters[section].issuesOnly = toggle.checked
-      applyFilters(section)
-    })
-  })
-}
-
-function hookStatusChips() {
-  const chips = document.querySelectorAll('.status-chip[data-section][data-status]')
-  chips.forEach(chip => {
-    const section = chip.dataset.section
-    if (!sectionKeys.includes(section)) return
-    chip.addEventListener('click', () => {
-      const status = chip.dataset.status
-      const set = filters[section].statuses
-      if (!set) return
-      if (set.has(status)) {
-        set.delete(status)
-        chip.classList.remove('btn-active')
-      } else {
-        set.add(status)
-        chip.classList.add('btn-active')
+  flush() {
+    while (this.active < this.limit && this.queue.length) {
+      const job = this.queue.shift()
+      if (!job) return
+      this.active++
+      const loader = new Image()
+      loader.decoding = 'async'
+      loader.loading = 'lazy'
+      loader.referrerPolicy = 'no-referrer'
+      const cleanup = () => {
+        this.active = Math.max(0, this.active - 1)
+        this.flush()
       }
-      if (!set.size) {
-        // ensure at least one status remains active
-        const related = document.querySelectorAll(`.status-chip[data-section="${section}"]`)
-        related.forEach(btn => {
-          btn.classList.add('btn-active')
-          set.add(btn.dataset.status)
+      loader.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+          job.element.src = job.src
+          job.element.classList.remove('opacity-0')
+          job.element.classList.add('opacity-100')
+          job.element.dataset.loaded = 'true'
+          cleanup()
         })
-      }
-      applyFilters(section)
-    })
-  })
-}
-
-function hookTypeChips() {
-  const groups = document.querySelectorAll('[data-filter-chips]')
-  groups.forEach(group => {
-    const section = group.dataset.filterChips
-    if (!sectionKeys.includes(section)) return
-    group.querySelectorAll('[data-type]').forEach(button => {
-      button.addEventListener('click', () => {
-        const type = button.dataset.type || 'other'
-        const active = filters[section].types
-        if (!active) return
-        if (active.has(type) && active.size > 1) {
-          active.delete(type)
-          button.classList.remove('btn-primary')
-          button.classList.add('btn-outline')
-        } else {
-          active.add(type)
-          button.classList.add('btn-primary')
-          button.classList.remove('btn-outline')
-        }
-        applyFilters(section)
       })
-    })
-  })
+      loader.addEventListener('error', () => {
+        job.element.dataset.error = 'true'
+        job.element.classList.add('opacity-30')
+        cleanup()
+      })
+      loader.src = job.src
+    }
+  }
 }
 
-function csvEscape(value = '') {
-  const str = String(value ?? '')
-  const needsQuote = /[\n",]/.test(str)
-  const escaped = str.replace(/"/g, '""')
-  return needsQuote ? `"${escaped}"` : escaped
+const fuseOptions = {
+  keys: ['title', 'sku', 'locale', 'productType', 'tags'],
+  includeScore: true,
+  threshold: 0.32,
 }
 
-function downloadCsv(filename, rows) {
-  const csv = rows.map(row => row.map(csvEscape).join(',')).join('\n')
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-  const link = document.createElement('a')
-  link.href = URL.createObjectURL(blob)
-  link.download = filename
-  document.body.append(link)
-  link.click()
-  setTimeout(() => {
-    URL.revokeObjectURL(link.href)
-    link.remove()
-  }, 300)
+const formatNumber = (value) => new Intl.NumberFormat('en-US').format(Number(value || 0))
+
+const formatDate = (value) => {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toISOString().slice(0, 10)
 }
 
-const exportSchemas = {
-  sitemaps: {
-    name: 'lv-sitemaps.csv',
-    headers: ['Host', 'Type', 'Images', 'Status', 'URL', 'Cached'],
-    map: item => [
-      item.host || '',
-      item.type || '',
-      item.imageCount ?? 0,
-      item.status || '',
-      item.url || '',
-      item.savedPath ? `${baseHref}${item.savedPath}` : '',
-    ],
-  },
-  robots: {
-    name: 'lv-robots.csv',
-    headers: ['Host', 'Status', 'HTTP', 'Cached', 'Preview'],
-    map: item => [
-      item.host || '',
-      item.statusLabel || '',
-      item.httpLabel || '',
-      item.robotsTxtPath ? `${baseHref}${item.robotsTxtPath}` : '',
-      (item.preview || '').replace(/\s+/g, ' ').slice(0, 180),
-    ],
-  },
-  docs: {
-    name: 'lv-documents.csv',
-    headers: ['Host', 'File', 'Status', 'Content Type', 'Cached'],
-    map: item => [
-      item.host || '',
-      item.fileName || '',
-      item.statusLabel || '',
-      item.contentType || '',
-      item.savedPath ? `${baseHref}${item.savedPath}` : '',
-    ],
-  },
-  duplicates: {
-    name: 'lv-duplicates.csv',
-    headers: ['Image', 'Duplicates', 'Basename', 'Page URL', 'First Seen', 'Last Seen'],
-    map: item => [
-      item.src || '',
-      Math.max(0, (item.count || 1) - 1),
-      item.basename || '',
-      item.pageUrl || '',
-      item.firstSeen || '',
-      item.lastSeen || '',
-    ],
-  },
-  topProducts: {
-    name: 'lv-products.csv',
-    headers: ['Title', 'Page URL', 'Total Images', 'Unique Images', 'First Seen', 'Last Seen'],
-    map: item => [
-      item.title || '',
-      item.pageUrl || '',
-      item.totalImages ?? 0,
-      item.uniqueImages ?? 0,
-      item.firstSeen || '',
-      item.lastSeen || '',
-    ],
-  },
-  hosts: {
-    name: 'lv-hosts.csv',
-    headers: ['Host', 'Images', 'Unique', 'Duplicates', 'Pages'],
-    map: item => [
-      item.host || '',
-      item.images ?? 0,
-      item.uniqueImages ?? 0,
-      item.duplicates ?? 0,
-      item.pages ?? 0,
-    ],
-  },
-}
-
-function hookExports() {
-  const buttons = document.querySelectorAll('[data-export-section]')
-  buttons.forEach(button => {
-    const section = button.dataset.exportSection
-    const schema = exportSchemas[section]
-    if (!schema) return
-    button.addEventListener('click', () => {
-      const rows = [schema.headers]
-      const items = filters[section]?.last || []
-      if (!items.length) return
-      items.forEach(item => rows.push(schema.map(item)))
-      downloadCsv(schema.name, rows)
-    })
-  })
-}
-
-function initialiseFilters() {
-  for (const key of sectionKeys) {
-    const items = sections[key]?.items || []
-    filters[key] = {
+class LvReportApp {
+  constructor(root) {
+    this.root = root
+    this.state = {
       query: '',
-      issuesOnly: false,
-      types: null,
-      statuses: null,
-      last: items,
+      page: 1,
+      pageSize: 25,
+      facetLocales: new Set(),
+      facetTypes: new Set(),
+      facetMonths: new Set(),
+      heroOnly: false,
     }
-    if (key === 'sitemaps') {
-      const allTypes = new Set(items.map(item => item.type || 'other'))
-      filters[key].types = allTypes
-      const chipButtons = document.querySelectorAll('[data-filter-chips="sitemaps"] [data-type]')
-      chipButtons.forEach(btn => {
-        btn.classList.add('btn-primary')
-        btn.classList.remove('btn-outline')
-      })
+    this.rows = []
+    this.filteredRows = []
+    this.searchEngine = null
+    this.searchDocuments = []
+    this.fuse = null
+    this.bundleMeta = null
+    this.metrics = null
+
+    this.bindings = {
+      tableBody: root.querySelector('[data-lvreport="table-body"]'),
+      tableSummary: root.querySelector('[data-lvreport="table-summary"]'),
+      pageStatus: root.querySelector('[data-lvreport="page-status"]'),
+      pagePrev: root.querySelector('[data-lvreport="page-prev"]'),
+      pageNext: root.querySelector('[data-lvreport="page-next"]'),
+      pageSize: root.querySelector('[data-lvreport="page-size"]'),
+      tableSearch: root.querySelector('[data-lvreport="table-search"]'),
+      facetPanel: root.querySelector('[data-lvreport="facet-panel"]'),
+      facetLocale: root.querySelector('[data-lvreport="facet-locale"]'),
+      facetType: root.querySelector('[data-lvreport="facet-type"]'),
+      facetMonth: root.querySelector('[data-lvreport="facet-month"]'),
+      facetHero: root.querySelector('[data-lvreport="facet-hero"]'),
+      facetApply: root.querySelector('[data-lvreport="facet-apply"]'),
+      facetReset: root.querySelector('[data-lvreport="facet-reset"]'),
+      openDrawer: root.querySelector('[data-lvreport="open-drawer"]'),
+      toggleFacets: root.querySelector('[data-lvreport="toggle-facets"]'),
+      bundleMeta: root.querySelector('[data-lvreport="bundle-meta"]'),
+      mapCount: root.querySelector('[data-lvreport="map-count"]'),
+      hostsList: root.querySelector('[data-lvreport="hosts-list"]'),
+      robotsList: root.querySelector('[data-lvreport="robots-list"]'),
+      docsList: root.querySelector('[data-lvreport="docs-list"]'),
+      duplicateList: root.querySelector('[data-lvreport="duplicate-list"]'),
+      productList: root.querySelector('[data-lvreport="product-list"]'),
+      sampleGrid: root.querySelector('[data-lvreport="sample-grid"]'),
+      openSearch: root.querySelector('[data-lvreport="open-search"]'),
+      searchInput: root.querySelector('[data-lvreport="global-search"]'),
+      searchButton: root.querySelector('[data-lvreport="search-open"]'),
+      detailContent: root.querySelector('[data-lvreport="detail-content"]'),
+      detailPanel: root.querySelector('[data-lvreport="detail-panel"]'),
     }
-    if (key === 'robots' || key === 'docs') {
-      const statuses = new Set(items.map(item => item.statusCategory || ''))
-      filters[key].statuses = statuses
-      document
-        .querySelectorAll(`.status-chip[data-section="${key}"]`)
-        .forEach(btn => btn.classList.add('btn-active'))
-    }
-    updateSummary(key, items.length, items.length)
+
+    this.detailToggle = document.getElementById('lvreport-drawer-toggle')
+    this.filterToggle = document.getElementById('lvreport-filters-toggle')
+
+    this.commandPalette = null
+    this.commandInput = null
+    this.commandResults = null
+    this.imageQueue = new ImageRequestQueue(4)
+    this.galleryObserver = null
   }
-}
 
-function initLocalFiltering() {
-  initialiseFilters()
-  initFuseEngines()
-  hookSearchInputs()
-  hookIssueToggles()
-  hookStatusChips()
-  hookTypeChips()
-  hookExports()
-  sectionKeys.forEach(applyFilters)
-}
-
-/* --------------------
-   Global search (MiniSearch + Alpine)
--------------------- */
-const searchPayload = payload.search || {}
-let globalSearchEngine = null
-let documentsById = new Map()
-
-if (Array.isArray(searchPayload.documents)) {
-  documentsById = new Map(searchPayload.documents.map(doc => [doc.id, doc]))
-}
-let indexLoaded = false
-if (searchPayload.index && searchPayload.options) {
-  try {
-    const indexSource = typeof searchPayload.index === 'string'
-      ? JSON.parse(searchPayload.index)
-      : searchPayload.index
-    globalSearchEngine = MiniSearch.loadJSON(indexSource, searchPayload.options)
-    indexLoaded = true
-  } catch (error) {
-    console.warn('[lvreport-app] Failed to load search index:', error)
-    globalSearchEngine = null
+  async init() {
+    await this.fetchData()
+    this.syncControls()
+    this.bindEvents()
+    this.renderMeta()
+    this.renderFacets()
+    this.applyFilters()
+    this.renderAncillary()
+    this.installKeyboardShortcuts()
   }
-}
-if (!globalSearchEngine) {
-  const options = searchPayload.options || {
-    fields: ['title', 'description', 'section', 'tags'],
-    storeFields: ['id', 'title', 'description', 'href', 'section', 'badge', 'tags'],
-    searchOptions: { prefix: true, fuzzy: 0.2 },
-  }
-  try {
-    globalSearchEngine = new MiniSearch(options)
-    if (documentsById.size) {
-      globalSearchEngine.addAll(Array.from(documentsById.values()))
+
+  syncControls() {
+    if (this.bindings.pageSize) {
+      this.bindings.pageSize.value = String(this.state.pageSize)
     }
-    if (!indexLoaded && searchPayload.documentCount) {
-      console.warn('[lvreport-app] Rebuilt search index in-memory from dataset snapshot.')
-    }
-  } catch (error) {
-    console.warn('[lvreport-app] Search index unavailable:', error)
-    globalSearchEngine = null
   }
-}
-if (!globalSearchEngine && searchPayload.documentCount && !indexLoaded) {
-  console.warn('[lvreport-app] Search index missing; global dataset search disabled.')
-}
 
-function formatSectionLabel(section) {
-  if (!section) return 'Result'
-  return section.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/^./, c => c.toUpperCase())
-}
+  sanitizeRows(rows = []) {
+    if (!Array.isArray(rows)) return []
+    return rows.filter((row) => row && !isBannedUrl(row.pageUrl) && !isBannedUrl(row.imageUrl))
+  }
 
-Alpine.data('globalSearch', () => ({
-  open: false,
-  query: '',
-  results: [],
-  activeIndex: 0,
-  init() {
-    this.handleShortcut = event => {
+  sanitizeMeta(meta = {}, rowsCount = 0) {
+    if (!meta || typeof meta !== 'object') return {}
+    const summary = meta.summary && typeof meta.summary === 'object' ? { ...meta.summary } : {}
+    if (Array.isArray(summary.hosts)) {
+      summary.hosts = summary.hosts.filter((entry) => !isBannedUrl(entry?.host || entry?.id || entry))
+    }
+    if (Array.isArray(summary.sitemaps)) {
+      summary.sitemaps = summary.sitemaps.filter((entry) => !isBannedUrl(entry?.url || entry?.loc || entry))
+    }
+
+    const next = { ...meta, summary }
+    if (Array.isArray(meta.products)) {
+      next.products = meta.products.filter((product) => !isBannedUrl(product?.pageUrl || product?.url))
+    }
+    if (Array.isArray(meta.images)) {
+      next.images = meta.images.filter((image) => !isBannedUrl(image?.pageUrl || image?.url || image?.src))
+    }
+    if (Array.isArray(meta.docs)) {
+      next.docs = meta.docs.filter((doc) => !isBannedUrl(doc?.url || doc?.path || doc?.host))
+    }
+    if (Array.isArray(meta.robots)) {
+      next.robots = meta.robots.filter((robot) => !isBannedUrl(robot?.host))
+    }
+
+    const totals = { ...(meta.totals || {}) }
+    if (Array.isArray(next.products)) totals.products = next.products.length
+    if (Array.isArray(next.docs)) totals.documents = next.docs.length
+    if (Array.isArray(next.robots)) totals.robots = next.robots.length
+    if (Array.isArray(next.images)) totals.images = next.images.length
+    if (Array.isArray(next.summary?.hosts)) totals.summaryHosts = next.summary.hosts.length
+    if (Array.isArray(next.summary?.locales)) totals.locales = next.summary.locales.length
+    totals.items = typeof totals.items === 'number' ? totals.items : rowsCount
+    next.totals = totals
+    return next
+  }
+
+  async fetchData() {
+    const indexUrl = payload.indexHref || '/assets/data/lvreport/index.json'
+    const metaUrl = payload.metaHref || '/assets/data/lvreport/meta.json'
+    const metricsUrl = payload.metricsHref || '/assets/data/lvreport/ingest-metrics.json'
+    const searchUrl = payload.searchHref || '/assets/data/lvreport/search-index.json'
+
+    const [indexData, metaData, metricsData, searchData] = await Promise.all([
+      fetch(indexUrl).then((res) => res.json()),
+      fetch(metaUrl).then((res) => res.json()),
+      fetch(metricsUrl).then((res) => res.json()).catch(() => null),
+      fetch(searchUrl).then((res) => res.json()).catch(() => null),
+    ])
+
+    const rawRows = Array.isArray(indexData?.rows) ? indexData.rows : []
+    this.rows = this.sanitizeRows(rawRows)
+    this.meta = this.sanitizeMeta(indexData?.meta || metaData || {}, this.rows.length)
+    this.metrics = metricsData || this.meta?.metrics || {}
+
+    const allowedIds = new Set(this.rows.map((row) => row.id))
+    if (searchData?.index) {
+      this.searchEngine = MiniSearch.loadJSON(searchData.index, MINI_SEARCH_OPTIONS)
+      if (Array.isArray(searchData.documents)) {
+        this.searchDocuments = searchData.documents.filter((doc) => allowedIds.has(doc.id))
+      }
+    } else {
+      this.searchEngine = new MiniSearch(MINI_SEARCH_OPTIONS)
+      this.searchDocuments = this.rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        sku: row.sku,
+        locale: row.locale,
+        productType: row.productType,
+        pageUrl: row.pageUrl,
+        imageUrl: row.imageUrl,
+        hasHero: row.hasHero,
+        imageCount: row.imageCount,
+        updatedAt: row.updatedAt,
+        tags: Array.isArray(row.tags) ? row.tags.join(' ') : '',
+      }))
+      this.searchEngine.addAll(this.searchDocuments)
+    }
+
+    this.fuse = new Fuse(this.rows, fuseOptions)
+  }
+
+  bindEvents() {
+    this.bindings.tableSearch?.addEventListener('input', (event) => {
+      this.state.query = event.target.value.trim()
+      this.state.page = 1
+      this.applyFilters()
+    })
+
+    this.bindings.pagePrev?.addEventListener('click', () => {
+      if (this.state.page > 1) {
+        this.state.page--
+        this.renderTable()
+      }
+    })
+
+    this.bindings.pageNext?.addEventListener('click', () => {
+      const pageCount = this.getPageCount()
+      if (this.state.page < pageCount) {
+        this.state.page++
+        this.renderTable()
+      }
+    })
+
+    this.bindings.pageSize?.addEventListener('change', (event) => {
+      this.state.pageSize = Number(event.target.value) || 25
+      this.state.page = 1
+      this.renderTable()
+    })
+
+    this.bindings.openDrawer?.addEventListener('click', () => this.openFacetDrawer())
+    this.bindings.toggleFacets?.addEventListener('click', () => this.openFacetDrawer())
+    this.bindings.facetApply?.addEventListener('click', () => {
+      this.filterToggle.checked = false
+      this.state.page = 1
+      this.applyFilters()
+    })
+    this.bindings.facetReset?.addEventListener('click', () => {
+      this.state.facetLocales.clear()
+      this.state.facetTypes.clear()
+      this.state.facetMonths.clear()
+      this.state.heroOnly = false
+      if (this.bindings.facetHero) this.bindings.facetHero.checked = false
+      this.renderFacetSelection()
+      this.state.page = 1
+      this.applyFilters()
+    })
+    this.bindings.facetHero?.addEventListener('change', (event) => {
+      this.state.heroOnly = event.target.checked
+    })
+
+    this.bindings.openSearch?.addEventListener('click', () => this.showCommandPalette())
+    this.bindings.searchButton?.addEventListener('click', () => this.showCommandPalette())
+    this.bindings.searchInput?.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        this.showCommandPalette(this.bindings.searchInput.value)
+      }
+    })
+  }
+
+  installKeyboardShortcuts() {
+    document.addEventListener('keydown', (event) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
         event.preventDefault()
-        this.openPanel()
-      }
-    }
-    document.addEventListener('keydown', this.handleShortcut)
-  },
-  destroy() {
-    document.removeEventListener('keydown', this.handleShortcut)
-  },
-  openPanel() {
-    this.open = true
-    this.$nextTick(() => {
-      const input = this.$el.querySelector('input[type="search"]')
-      input?.focus()
-    })
-  },
-  closePanel() {
-    this.open = false
-    this.query = ''
-    this.results = []
-    this.activeIndex = 0
-  },
-  search() {
-    const term = this.query.trim()
-    if (!term) {
-      this.results = []
-      this.activeIndex = 0
-      return
-    }
-    if (!globalSearchEngine) {
-      this.results = []
-      this.activeIndex = 0
-      return
-    }
-    const hits = globalSearchEngine.search(term, { boost: { title: 2 }, prefix: true, fuzzy: 0.2 })
-    this.results = hits.slice(0, 20).map(hit => {
-      const doc = documentsById.get(hit.id) || hit
-      return {
-        id: doc.id,
-        title: doc.title || 'Result',
-        description: doc.description || '',
-        href: doc.href || '',
-        section: doc.section || '',
-        badge: formatSectionLabel(doc.section),
+        this.showCommandPalette()
       }
     })
-    this.activeIndex = 0
-  },
-  move(delta) {
-    if (!this.results.length) return
-    this.activeIndex = (this.activeIndex + delta + this.results.length) % this.results.length
-  },
-  setActive(index) {
-    this.activeIndex = index
-  },
-  selectActive() {
-    if (!this.results.length) return
-    const result = this.results[this.activeIndex]
-    this.openResult(result)
-  },
-  openResult(result) {
-    if (!result) return
-    if (result.href?.startsWith('#')) {
-      this.closePanel()
-      const target = document.querySelector(result.href)
-      target?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  renderMeta() {
+    if (this.bindings.bundleMeta) {
+      const sha = this.meta?.bundle?.sha256 ? String(this.meta.bundle.sha256).slice(0, 12) : 'unknown'
+      const size = this.meta?.bundle?.size
+        ? `${formatNumber(Math.round(this.meta.bundle.size / 1024 / 1024))} MB`
+        : '—'
+      const parseMs = this.metrics?.parseMs ? `${formatNumber(this.metrics.parseMs)} ms` : '—'
+      this.bindings.bundleMeta.innerHTML = `
+        <span class="badge badge-outline">SHA ${sha}</span>
+        <span class="badge badge-outline">${size}</span>
+        <span class="badge badge-outline">Parsed in ${parseMs}</span>
+      `
+    }
+    if (this.bindings.mapCount && Array.isArray(this.rows)) {
+      this.bindings.mapCount.textContent = `${formatNumber(this.rows.length)} items`
+    }
+  }
+
+  renderFacets() {
+    const facets = payload.facets || this.meta?.facets || {}
+    this.renderFacetGroup(this.bindings.facetLocale, facets.locales, this.state.facetLocales)
+    this.renderFacetGroup(this.bindings.facetType, facets.productTypes, this.state.facetTypes)
+    this.renderFacetGroup(this.bindings.facetMonth, facets.updatedMonths, this.state.facetMonths, {
+      asPills: false,
+      labelFormatter: (entry) => entry.value,
+    })
+    this.renderFacetSelection()
+  }
+
+  renderFacetGroup(container, entries, selection, { asPills = true, labelFormatter } = {}) {
+    if (!container) return
+    container.innerHTML = ''
+    if (!Array.isArray(entries) || !entries.length) {
+      container.innerHTML = '<p class="text-xs opacity-60">No data</p>'
       return
     }
-    if (result.href) {
-      window.open(result.href, '_blank', 'noopener')
+    for (const entry of entries) {
+      const value = entry?.value ?? entry
+      const count = entry?.count ?? 0
+      const node = document.createElement(asPills ? 'button' : 'label')
+      node.className = asPills
+        ? 'btn btn-xs btn-outline'
+        : 'flex cursor-pointer items-center justify-between rounded-lg border border-base-200 bg-base-100 px-2 py-1 text-xs'
+      node.dataset.value = value
+      node.textContent = labelFormatter ? labelFormatter(entry) : value
+      if (asPills) {
+        node.appendChild(document.createElement('span')).textContent = ` ${formatNumber(count)}`
+      } else {
+        const countEl = document.createElement('span')
+        countEl.className = 'text-[0.7rem] opacity-60'
+        countEl.textContent = formatNumber(count)
+        node.appendChild(countEl)
+      }
+      node.addEventListener('click', () => {
+        if (selection.has(value)) {
+          selection.delete(value)
+        } else {
+          selection.add(value)
+        }
+        this.renderFacetSelection()
+      })
+      container.appendChild(node)
     }
-    this.closePanel()
-  },
-}))
+  }
 
-function initialiseGlobalSearch() {
-  // no-op: Alpine handles registration
+  renderFacetSelection() {
+    for (const container of [this.bindings.facetLocale, this.bindings.facetType]) {
+      if (!container) continue
+      container.querySelectorAll('button').forEach((btn) => {
+        const value = btn.dataset.value
+        const selection = container === this.bindings.facetLocale
+          ? this.state.facetLocales
+          : this.state.facetTypes
+        if (selection.has(value)) {
+          btn.classList.add('btn-primary')
+          btn.classList.remove('btn-outline')
+        } else {
+          btn.classList.remove('btn-primary')
+          btn.classList.add('btn-outline')
+        }
+      })
+    }
+    if (this.bindings.facetMonth) {
+      this.bindings.facetMonth.querySelectorAll('label').forEach((label) => {
+        const value = label.dataset.value
+        const active = this.state.facetMonths.has(value)
+        label.classList.toggle('bg-primary/20', active)
+        label.classList.toggle('border-primary/30', active)
+        if (!label.dataset.bound) {
+          label.dataset.bound = '1'
+          label.addEventListener('click', () => {
+            if (this.state.facetMonths.has(value)) this.state.facetMonths.delete(value)
+            else this.state.facetMonths.add(value)
+            this.renderFacetSelection()
+          })
+        }
+      })
+    }
+  }
+
+  applyFilters() {
+    const { query, facetLocales, facetTypes, facetMonths, heroOnly } = this.state
+    let results = this.rows
+
+    if (facetLocales.size) {
+      results = results.filter((row) => facetLocales.has(row.locale || 'unknown'))
+    }
+    if (facetTypes.size) {
+      results = results.filter((row) => facetTypes.has(row.productType || 'other'))
+    }
+    if (facetMonths.size) {
+      results = results.filter((row) => {
+        const month = (row.updatedAt || '').slice(0, 7)
+        return month && facetMonths.has(month)
+      })
+    }
+    if (heroOnly) {
+      results = results.filter((row) => row.hasHero)
+    }
+
+    if (query && query.length >= 2) {
+      if (this.searchEngine) {
+        const hits = this.searchEngine.search(query, MINI_SEARCH_OPTIONS.searchOptions)
+        const ids = new Set(hits.map((hit) => hit.id))
+        results = results.filter((row) => ids.has(row.id))
+      } else if (this.fuse) {
+        results = this.fuse.search(query).map((hit) => hit.item)
+      }
+    }
+
+    this.filteredRows = results
+    this.renderTable()
+    this.renderSamples()
+  }
+
+  getPageCount() {
+    if (!this.filteredRows.length) return 1
+    return Math.max(1, Math.ceil(this.filteredRows.length / this.state.pageSize))
+  }
+
+  renderTable() {
+    if (!this.bindings.tableBody) return
+
+    const pageCount = this.getPageCount()
+    if (this.state.page > pageCount) this.state.page = pageCount
+    const start = (this.state.page - 1) * this.state.pageSize
+    const rows = this.filteredRows.slice(start, start + this.state.pageSize)
+
+    if (!rows.length) {
+      this.bindings.tableBody.innerHTML = '<tr><td colspan="7" class="p-6 text-center text-sm opacity-60">No results match the current filters.</td></tr>'
+    } else {
+      this.bindings.tableBody.innerHTML = rows
+        .map((row) => {
+          const badge = row.hasHero ? '<span class="badge badge-success badge-sm">Hero</span>' : ''
+          const safeId = escapeHtml(row.id || '')
+          const href = row.pageUrl && !isBannedUrl(row.pageUrl) ? row.pageUrl : ''
+          const safeHref = href ? escapeHtml(href) : ''
+          const safeSku = escapeHtml(row.sku || '—')
+          const safeTitle = escapeHtml(row.title || row.pageUrl || 'Untitled')
+          const safeLocale = escapeHtml(row.locale || '—')
+          const safeType = escapeHtml(row.productType || '—')
+          const skuInner = href
+            ? `<a class="link link-primary font-mono" href="${safeHref}" target="_blank" rel="noreferrer">${safeSku}</a>`
+            : `<span class="font-mono">${safeSku}</span>`
+          const titleInner = href
+            ? `<a class="link-hover font-semibold" href="${safeHref}" target="_blank" rel="noreferrer">${safeTitle}</a>`
+            : `<span class="font-semibold">${safeTitle}</span>`
+          return `
+            <tr data-id="${safeId}">
+              <td class="text-xs">${skuInner}</td>
+              <td class="max-w-[320px] truncate">
+                ${titleInner}
+                ${badge}
+              </td>
+              <td>${safeLocale}</td>
+              <td>${safeType}</td>
+              <td class="text-right">${formatNumber(row.imageCount || 0)}</td>
+              <td>${formatDate(row.updatedAt)}</td>
+              <td class="text-right">
+                <button class="btn btn-xs" data-detail="${safeId}">View</button>
+              </td>
+            </tr>
+          `
+        })
+        .join('')
+    }
+
+    this.bindings.tableBody.querySelectorAll('[data-detail]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const id = button.dataset.detail
+        const row = this.rows.find((entry) => entry.id === id)
+        if (row) this.showDetail(row)
+      })
+    })
+
+    this.bindings.tableSummary.textContent = `${formatNumber(this.filteredRows.length)} items • page ${this.state.page} of ${pageCount}`
+    this.bindings.pageStatus.textContent = `${this.state.page} / ${pageCount}`
+  }
+
+  openFacetDrawer() {
+    if (this.filterToggle) this.filterToggle.checked = true
+  }
+
+  showDetail(row) {
+    if (!this.detailContent) return
+    const safeSku = escapeHtml(row.sku || '—')
+    const safeTitle = escapeHtml(row.title || row.pageUrl || 'Untitled')
+    const safeLocale = escapeHtml(row.locale || '—')
+    const safeType = escapeHtml(row.productType || '—')
+    const safePageUrl = row.pageUrl && !isBannedUrl(row.pageUrl) ? escapeHtml(row.pageUrl) : ''
+    const heroUrl = row.imageUrl && !isBannedUrl(row.imageUrl) ? row.imageUrl : ''
+    const safeHeroUrl = heroUrl ? escapeHtml(heroUrl) : ''
+
+    const actionLinks = [
+      safePageUrl
+        ? `<a class="btn btn-xs btn-primary" href="${safePageUrl}" target="_blank" rel="noreferrer">Open product</a>`
+        : '',
+      safeHeroUrl ? `<a class="btn btn-xs btn-outline" href="${safeHeroUrl}" target="_blank" rel="noreferrer">Open hero</a>` : '',
+    ].filter(Boolean)
+
+    const linkRow = actionLinks.length
+      ? `<div class="flex flex-wrap gap-2">${actionLinks.join('')}</div>`
+      : ''
+
+    this.detailContent.innerHTML = `
+      <div>
+        <p class="text-xs uppercase tracking-wide opacity-60">SKU</p>
+        <p class="font-semibold">${safeSku}</p>
+      </div>
+      <div>
+        <p class="text-xs uppercase tracking-wide opacity-60">Title</p>
+        <p class="font-semibold">${safeTitle}</p>
+      </div>
+      <div class="grid grid-cols-2 gap-2 text-sm">
+        <div><span class="opacity-60">Locale</span><p>${safeLocale}</p></div>
+        <div><span class="opacity-60">Type</span><p>${safeType}</p></div>
+        <div><span class="opacity-60">Images</span><p>${formatNumber(row.imageCount || 0)}</p></div>
+        <div><span class="opacity-60">Updated</span><p>${formatDate(row.updatedAt)}</p></div>
+      </div>
+      <div class="space-y-2 text-sm">
+        <p class="opacity-60">URL</p>
+        ${
+          safePageUrl
+            ? `<a class="link link-primary break-all" href="${safePageUrl}" target="_blank" rel="noreferrer">${safePageUrl}</a>`
+            : '<span class="break-all opacity-60">Unavailable</span>'
+        }
+      </div>
+      ${linkRow}
+    `
+
+    if (heroUrl) {
+      const wrapper = document.createElement('a')
+      wrapper.href = heroUrl
+      wrapper.target = '_blank'
+      wrapper.rel = 'noreferrer'
+      wrapper.className = 'mt-4 block overflow-hidden rounded-xl border border-base-300/70 bg-base-200/50'
+      const img = document.createElement('img')
+      img.alt = row.title || 'Image preview'
+      img.loading = 'lazy'
+      img.decoding = 'async'
+      img.dataset.src = heroUrl
+      img.className = 'h-full w-full object-cover opacity-0 transition-opacity duration-500'
+      wrapper.appendChild(img)
+      this.detailContent.appendChild(wrapper)
+      this.imageQueue.enqueue(heroUrl, img)
+    }
+    if (this.detailToggle) this.detailToggle.checked = true
+  }
+
+  renderAncillary() {
+    const duplicatesSource = Array.isArray(this.meta?.images)
+      ? this.meta.images.filter((img) => img.duplicateOf)
+      : []
+    this.renderList(this.bindings.duplicateList, duplicatesSource.slice(0, 20), (item) => ({
+      title: item.canonical?.title || item.canonicalId || 'Cluster',
+      meta: `${item.duplicates?.length || 0} duplicates`,
+      href: item.canonical?.pageUrl || item.canonical?.url || item.canonical?.href,
+    }))
+    this.renderList(this.bindings.productList, (this.meta?.products || []).slice(0, 20), (item) => ({
+      title: item.title || item.pageUrl || 'Product',
+      meta: `${formatNumber(item.images?.length || 0)} images`,
+      href: item.pageUrl,
+    }))
+    const hostStats = this.meta?.summary?.hosts || []
+    this.renderList(this.bindings.hostsList, hostStats.slice(0, 10), (item) => ({
+      title: item.host || item.id,
+      meta: `${formatNumber(item.images || item.count || 0)} images • ${formatNumber(item.pages || 0)} pages`,
+      href: item.host ? `https://${String(item.host).replace(/^https?:\/\//i, '')}` : '',
+    }))
+    this.renderList(this.bindings.robotsList, (this.meta?.robots || []).slice(0, 10), (item) => ({
+      title: item.host,
+      meta: `${item.issue ? 'Issues present' : 'OK'} • ${item.agents?.length || 0} agents`,
+      href: item.host ? `https://${String(item.host).replace(/^https?:\/\//i, '')}/robots.txt` : '',
+    }))
+    this.renderList(this.bindings.docsList, (this.meta?.docs || []).slice(0, 10), (item) => ({
+      title: item.path || item.url,
+      meta: `${item.contentType || 'unknown'} • ${formatNumber(item.size || 0)} bytes`,
+      href: item.url,
+    }))
+    this.renderSamples()
+  }
+
+  renderList(container, items, mapper) {
+    if (!container) return
+    if (!Array.isArray(items) || !items.length) {
+      container.innerHTML = '<p class="text-xs opacity-60">No data available.</p>'
+      return
+    }
+    container.innerHTML = items
+      .map((item) => {
+        const mapped = mapper(item)
+        const safeTitle = escapeHtml(mapped.title || '')
+        const safeMeta = escapeHtml(mapped.meta || '')
+        const safeHref = mapped.href && !isBannedUrl(mapped.href) ? escapeHtml(mapped.href) : ''
+        const href = safeHref
+          ? `<a class="link link-primary break-all" href="${safeHref}" target="_blank" rel="noreferrer">${safeTitle}</a>`
+          : safeTitle
+        return `
+          <div class="rounded-lg border border-base-300/40 bg-base-100/80 p-3">
+            <p class="font-semibold text-sm">${href}</p>
+            <p class="text-xs opacity-70">${safeMeta}</p>
+          </div>
+        `
+      })
+      .join('')
+  }
+
+  renderSamples() {
+    const container = this.bindings.sampleGrid
+    if (!container) return
+    if (!this.filteredRows.length) {
+      container.innerHTML = '<p class="text-xs opacity-60">No items match current filters.</p>'
+      return
+    }
+
+    const sorted = [...this.filteredRows].sort((a, b) => {
+      const aDate = (a.updatedAt || a.createdAt || '').slice(0, 19)
+      const bDate = (b.updatedAt || b.createdAt || '').slice(0, 19)
+      return bDate.localeCompare(aDate)
+    })
+
+    const sample = sorted.slice(0, 12)
+    if (!sample.length) {
+      container.innerHTML = '<p class="text-xs opacity-60">No recent arrivals with imagery available.</p>'
+      return
+    }
+
+    container.innerHTML = sample.map((row) => this.renderSampleCard(row)).join('')
+    this.prepareGalleryImages(container)
+  }
+
+  renderSampleCard(row) {
+    const heroUrl = row.imageUrl && !isBannedUrl(row.imageUrl) ? row.imageUrl : ''
+    const linkTarget = row.pageUrl && !isBannedUrl(row.pageUrl) ? row.pageUrl : heroUrl
+    const safeLink = linkTarget ? escapeHtml(linkTarget) : ''
+    const safeTitle = escapeHtml(row.title || row.pageUrl || row.sku || 'Item')
+    const safeLocale = escapeHtml(row.locale || 'unknown')
+    const safeType = escapeHtml(row.productType || '—')
+    const updatedLabel = escapeHtml(formatDate(row.updatedAt || row.createdAt))
+    const heroBadge = row.hasHero
+      ? '<span class="absolute left-3 top-3 rounded-full bg-primary px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-primary-content shadow">Hero</span>'
+      : ''
+    const outerStart = safeLink
+      ? `<a class="group flex flex-col overflow-hidden rounded-3xl border border-base-300/40 bg-base-100/80 shadow-lg transition-transform duration-300 hover:-translate-y-1 hover:shadow-2xl" href="${safeLink}" target="_blank" rel="noreferrer">`
+      : '<div class="group flex flex-col overflow-hidden rounded-3xl border border-base-300/40 bg-base-100/80 shadow-lg">'
+    const outerEnd = safeLink ? '</a>' : '</div>'
+
+    const figure = heroUrl
+      ? `
+          <div class="relative aspect-[4/5] overflow-hidden">
+            ${heroBadge}
+            <img data-src="${escapeHtml(heroUrl)}" alt="${safeTitle}" class="h-full w-full object-cover opacity-0 transition-transform duration-500 group-hover:scale-[1.02]" />
+            <div class="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col gap-1 bg-gradient-to-t from-black/80 via-black/20 to-transparent p-4 text-white">
+              <p class="font-semibold text-sm leading-tight text-white">${safeTitle}</p>
+              <p class="text-[11px] uppercase tracking-wide text-white/70">${safeLocale} • ${safeType}</p>
+            </div>
+          </div>
+        `
+      : `
+          <div class="relative aspect-[4/5] rounded-3xl border border-dashed border-base-300/60 bg-base-200/70 p-4">
+            ${heroBadge}
+            <div class="flex h-full flex-col justify-end gap-2">
+              <span class="badge badge-outline badge-sm">No hero</span>
+              <p class="font-semibold text-sm">${safeTitle}</p>
+              <p class="text-xs opacity-70">${safeLocale} • ${safeType}</p>
+            </div>
+          </div>
+        `
+
+    const imageCountLabel = escapeHtml(formatNumber(row.imageCount || 0))
+
+    return `
+      ${outerStart}
+        ${figure}
+        <div class="flex items-center justify-between gap-3 px-4 py-3 text-xs">
+          <span class="opacity-70">Updated ${updatedLabel}</span>
+          <span class="badge badge-ghost badge-sm">${imageCountLabel} img</span>
+        </div>
+      ${outerEnd}
+    `
+  }
+
+  prepareGalleryImages(container) {
+    if (!container) return
+    const images = Array.from(container.querySelectorAll('img[data-src]'))
+    if (!images.length) return
+
+    if (this.galleryObserver) {
+      this.galleryObserver.disconnect()
+    }
+
+    if ('IntersectionObserver' in window) {
+      if (!this.galleryObserver) {
+        this.galleryObserver = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (!entry.isIntersecting) return
+              const target = entry.target
+              this.galleryObserver.unobserve(target)
+              const src = target.dataset.src
+              if (src) {
+                this.imageQueue.enqueue(src, target)
+              }
+            })
+          },
+          { rootMargin: '200px 0px', threshold: 0.1 },
+        )
+      }
+      images.forEach((img) => {
+        img.loading = 'lazy'
+        img.decoding = 'async'
+        img.classList.add('opacity-0')
+        this.galleryObserver.observe(img)
+      })
+    } else {
+      images.forEach((img) => {
+        img.loading = 'lazy'
+        img.decoding = 'async'
+        this.imageQueue.enqueue(img.dataset.src, img)
+      })
+    }
+  }
+
+  createCommandPalette() {
+    const container = document.createElement('div')
+    container.className = 'fixed inset-0 z-[120] hidden items-start justify-center bg-base-200/80 backdrop-blur'
+    container.innerHTML = `
+      <div class="mt-24 w-full max-w-2xl rounded-2xl border border-base-300 bg-base-100 shadow-2xl">
+        <div class="border-b border-base-300 px-4 py-3">
+          <input type="search" class="input input-bordered input-sm w-full" placeholder="Search LV inventory" />
+        </div>
+        <div class="max-h-80 overflow-auto" data-results></div>
+      </div>
+    `
+    document.body.appendChild(container)
+    this.commandPalette = container
+    this.commandInput = container.querySelector('input')
+    this.commandResults = container.querySelector('[data-results]')
+
+    this.commandInput.addEventListener('input', () => this.renderCommandResults(this.commandInput.value))
+    container.addEventListener('click', (event) => {
+      if (event.target === container) this.hideCommandPalette()
+    })
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !container.classList.contains('hidden')) {
+        this.hideCommandPalette()
+      }
+    })
+  }
+
+  showCommandPalette(initialQuery = '') {
+    if (!this.commandPalette) this.createCommandPalette()
+    this.commandPalette.classList.remove('hidden')
+    this.commandInput.value = initialQuery
+    this.commandInput.focus()
+    this.renderCommandResults(initialQuery)
+  }
+
+  hideCommandPalette() {
+    if (!this.commandPalette) return
+    this.commandPalette.classList.add('hidden')
+  }
+
+  renderCommandResults(query) {
+    if (!this.commandResults) return
+    const trimmed = (query || '').trim()
+    let hits = []
+    if (trimmed.length >= 2 && this.searchEngine) {
+      hits = this.searchEngine.search(trimmed, MINI_SEARCH_OPTIONS.searchOptions)
+    } else if (!trimmed) {
+      hits = this.searchDocuments.slice(0, 20).map((doc) => ({ id: doc.id, score: 0 }))
+    }
+
+    if (!hits.length) {
+      this.commandResults.innerHTML = '<p class="px-4 py-6 text-sm opacity-60">No results yet — start typing to search.</p>'
+      return
+    }
+
+    this.commandResults.innerHTML = hits.slice(0, 40)
+      .map((hit) => {
+        const doc = this.searchDocuments.find((item) => item.id === hit.id) || {}
+        return `
+          <button class="flex w-full flex-col items-start gap-1 border-b border-base-200 px-4 py-3 text-left text-sm hover:bg-base-200" data-hit="${hit.id}">
+            <span class="font-semibold">${doc.title || doc.pageUrl || doc.sku || 'Result'}</span>
+            <span class="text-xs opacity-60">${doc.locale || 'unknown'} • ${doc.productType || '—'} • SKU ${doc.sku || '—'}</span>
+          </button>
+        `
+      })
+      .join('')
+
+    this.commandResults.querySelectorAll('[data-hit]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const id = button.dataset.hit
+        const row = this.rows.find((entry) => entry.id === id)
+        if (row) {
+          this.showDetail(row)
+          this.hideCommandPalette()
+        }
+      })
+    })
+  }
 }
 
-function bootstrap() {
-  initLocalFiltering()
-  initialiseGlobalSearch()
+if (datasetEl) {
+  document.addEventListener('DOMContentLoaded', () => {
+    const app = new LvReportApp(document.body)
+    app.init().catch((error) => console.error('[lvreport-app] init failed', error))
+  })
 }
-
-if (sectionKeys.length) {
-  bootstrap()
-}
-
-window.Alpine = Alpine
-Alpine.start()

--- a/src/content/projects/lv-images/report.11tydata.js
+++ b/src/content/projects/lv-images/report.11tydata.js
@@ -3,78 +3,52 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const here = fileURLToPath(import.meta.url)
 const projectRoot = path.resolve(here, '../../../..')
-const lvreportModuleUrl = pathToFileURL(path.join(projectRoot, '_data', 'lvreport.js')).href
+const lvreportModuleUrl = pathToFileURL(path.join(projectRoot, 'src', '_data', 'lvreport.js')).href
 
-let memoizedReport = null
+let memoized = null
 
-async function loadReport() {
-  if (memoizedReport) return memoizedReport
-  const module = await import(lvreportModuleUrl)
-  if (typeof module.default !== 'function') {
-    throw new Error('lvreport data module missing default export')
+async function loadReportModule() {
+  if (!memoized) {
+    const module = await import(lvreportModuleUrl)
+    if (typeof module.default !== 'function') {
+      throw new Error('lvreport data module missing default export')
+    }
+    memoized = module
   }
-  const report = await module.default()
-  memoizedReport = report
-  return report
+  return memoized
+}
+
+function sanitizeForInline(value) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
 }
 
 export default async function() {
-  const report = await loadReport()
-  const pages = report?.pages
-  if (!Array.isArray(pages) || pages.length === 0) {
-    const reason = report?.__lvreportFallbackReason || 'missing lvreport.pages'
-    const detail = Array.isArray(pages) ? `length=${pages.length}` : typeof pages
-    throw new Error(`lvreport pagination unavailable (${reason}, pages:${detail})`)
+  const module = await loadReportModule()
+  const report = await module.default()
+  const clientPayload = report?.clientPayload
+    || (typeof module.loadClientPayload === 'function' ? await module.loadClientPayload() : null)
+
+  const payload = clientPayload || {
+    indexHref: '/assets/data/lvreport/index.json',
+    metaHref: '/assets/data/lvreport/meta.json',
+    metricsHref: '/assets/data/lvreport/ingest-metrics.json',
+    searchHref: '/assets/data/lvreport/search-index.json',
+    facets: report?.facets || {},
+    totals: report?.totals || {},
+    kpis: report?.kpis || [],
   }
 
   return {
     lvreport: report,
-    lvreportPages: pages,
-    pagination: {
-      data: 'lvreportPages',
-      size: 1,
-      alias: 'lvReportPage',
-    },
     eleventyComputed: {
-      permalink(context) {
-        const pageNumber = context.pagination?.pageNumber ?? 0
-        return pageNumber === 0 ? '/lv/report/' : `/lv/report/page/${pageNumber + 1}/`
-      },
-      title(context) {
-        const base = 'LV Image Atlas — Report'
-        const pageNumber = context.lvReportPage?.pageNumber ?? 0
-        const total = context.lvReportPage?.pageCount ?? 1
-        return pageNumber === 0 ? base : `${base} (Page ${pageNumber + 1} of ${total})`
-      },
-      clientPayloadJson(context) {
-        const payload = {
-          baseHref: context.lvreport?.baseHref || '/content/projects/lv-images/generated/lv/',
-          totals: context.lvreport?.totals || {},
-          dataset: {
-            ndjson: context.lvreport?.dataset?.ndjson || {},
-            cache: context.lvreport?.dataset?.cache || {},
-            warnings: context.lvreport?.dataset?.warnings || [],
-            history: context.lvreport?.dataset?.history || null,
-            flags: context.lvreport?.dataset?.flags || [],
-            capture: context.lvreport?.dataset?.capture || [],
-            summaryTotals: context.lvreport?.dataset?.summaryTotals || null,
-            bundleLabel: context.lvreport?.dataset?.bundleLabel || null,
-            runMode: context.lvreport?.dataset?.runMode || null,
-          },
-          page: {
-            number: context.lvReportPage?.pageNumber ?? 0,
-            count: context.lvReportPage?.pageCount ?? 1,
-            sections: context.lvReportPage?.sections || {},
-          },
-          search: context.lvreport?.search || {},
-        }
-        return JSON.stringify(payload)
-          .replace(/</g, '\\u003c')
-          .replace(/>/g, '\\u003e')
-          .replace(/&/g, '\\u0026')
-          .replace(/\u2028/g, '\\u2028')
-          .replace(/\u2029/g, '\\u2029')
-      },
+      permalink: () => '/lv/report/',
+      title: () => 'LV Image Atlas — Report',
+      clientPayloadJson: () => sanitizeForInline(payload),
     },
   }
 }

--- a/src/content/projects/lv-images/report.njk
+++ b/src/content/projects/lv-images/report.njk
@@ -4,1476 +4,271 @@ fullBleed: true
 metaDisable: true
 ---
 # dprint-ignore-file
-{#
-  This template renders a comprehensive, data‑driven report for the LV image atlas
-  crawl.  It takes the summarized crawl information provided via the `lvreport`
-  data file and presents it with modern daisyUI v5 components.  The layout
-  emphasises key metrics using the Stats and Radial Progress components, while
-  retaining interactive filtering for each table.  Sections are clearly
-  delineated with headings and concise descriptions.  Feel free to adjust
-  colours via themes (see base.njk) or customise individual elements further.
-#}
+{% set report = lvreport or {} %}
+{% set sections = report.sections or {} %}
+{% set kpis = report.kpis or [] %}
+{% set runsHistory = sections.runsHistory or [] %}
+{% set sitemaps = sections.sitemaps or [] %}
+{% set duplicates = sections.duplicates or [] %}
+{% set topProducts = sections.topProducts or [] %}
+{% set robots = sections.robots or [] %}
+{% set docs = sections.docs or [] %}
+{% set sample = sections.sample or [] %}
+{% set datasetMap = sections.datasetMap or {} %}
 
-{% set lv       = lvreport.lvreport or lvreport or {} %}
-{% set baseHref = lv.baseHref or '/content/projects/lv-images/generated/lv/' %}
-{% set summary  = lv.summary  or {} %}
-{# Pull global totals from the top level (lv.totals) first, falling back to summary.totals if not present.  The crawler exposes unique image and page counts via lv.totals. #}
-{% set totals   = lv.totals or summary.totals or {} %}
-{% set paginationSections = lv.pagination or {} %}
-{% set pageSections = lvReportPage and lvReportPage.sections or {} %}
-{% set sitemapsPage = pageSections.sitemaps or {} %}
-{% set docsPage = pageSections.docs or {} %}
-{% set robotsPage = pageSections.robots or {} %}
-{% set duplicatesPage = pageSections.duplicates or {} %}
-{% set topProductsPage = pageSections.topProducts or {} %}
-{% set hostStatsPage = pageSections.hostStats or {} %}
-{% set sitemaps = sitemapsPage.items or [] %}
-{% set docs     = docsPage.items or [] %}
-{% set robots   = robotsPage.items or [] %}
-{% set duplicates = duplicatesPage.items or [] %}
-{% set topProducts = topProductsPage.items or [] %}
-{% set hostStats = hostStatsPage.items or [] %}
-{% set sample   = lv.sample   or [] %}
-{% set metrics  = lv.metrics  or {} %}
-{% set robotsMetrics = metrics.robots or {} %}
-{% set docsMetrics   = metrics.docs   or {} %}
-{% set itemsMetrics  = metrics.items or {} %}
-{% set dataset = lv.dataset or {} %}
-{% set datasetTotals = dataset.totals or {} %}
-{% set manifest = dataset.manifest or {} %}
-{% set manifestDataset = manifest.dataset or {} %}
-{% set manifestArchive = manifest.archive or {} %}
-{% set manifestSummary = manifest.summary or {} %}
-{% set datasetWarnings = dataset.warnings or [] %}
-{% set datasetHistory = dataset.history or {} %}
-{% set historyEntries = datasetHistory.entries or [] %}
-{% set datasetFlags = dataset.flags or [] %}
-{% set datasetCapture = dataset.capture or [] %}
-{% set summaryTotals = dataset.summaryTotals or summary.totals or {} %}
-<script type="application/json" id="lvreport-data">{{ clientPayloadJson | safe }}</script>
-<script type="module" src="/assets/js/lvreport-app.js"></script>
-{%
-  set warningCopy = {
-    "missing-archive": "Bundle archive missing — run <code>npm run lv-images:sync</code> before shipping.",
-    "missing-manifest": "Bundle manifest missing — rebuild via <code>npm run lv-images:bundle</code>.",
-    "empty-dataset": "Dataset is empty — crawl with <code>npm run lv-images:sync</code> to populate generated/lv/. "
-  }
-%}
-{%
-  set toneBadge = {
-    "error": "badge-error",
-    "warn": "badge-warning",
-    "ok": "badge-success",
-    "info": "badge-info"
-  }
-%}
-{%
-  set toneChip = {
-    "error": "bg-error/15 text-error",
-    "warn": "bg-warning/20 text-warning-content",
-    "ok": "bg-success/15 text-success",
-    "info": "bg-info/15 text-info"
-  }
-%}
-
-{# Compute flagged percentages for radial progress indicators.  The logical
-   short‑circuit ensures we avoid division by zero when there are no items. #}
-
-<section class="relative overflow-hidden rounded-box bg-gradient-to-br from-primary via-secondary to-accent p-8 text-primary-content shadow-xl">
-  <div class="absolute inset-0 pointer-events-none opacity-30 mix-blend-screen bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.45),_transparent_60%)]">
-  </div>
-  <div class="relative grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,360px)] items-start">
+<section class="relative overflow-hidden rounded-box bg-gradient-to-br from-primary via-secondary to-accent p-10 text-primary-content shadow-xl">
+  <div class="absolute inset-0 pointer-events-none opacity-30 mix-blend-screen bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.5),_transparent_65%)]"></div>
+  <div class="relative grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,360px)] items-start">
     <div>
       <h1 class="text-4xl font-bold tracking-tight">{{ title }}</h1>
-      <p class="mt-3 max-w-2xl text-sm md:text-base opacity-80">
-        Atlas of {{ totals.hosts or 0 }} hosts capturing sitemaps, robots directives, cached
-        payloads, and NDJSON shards ready for offline builds.
+      <p class="mt-3 max-w-2xl text-sm md:text-base opacity-85">
+        Unified LV image intelligence — hydrated from the build-time bundle and rendered as a single hyper-responsive dashboard.
       </p>
+      <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4" id="lvreport-kpis">
+        {% for stat in kpis %}
+          <div class="glass rounded-box border border-white/10 bg-white/10 p-4 text-left shadow-lg">
+            <p class="text-xs uppercase tracking-widest opacity-80">{{ stat.label }}</p>
+            <p class="mt-3 text-3xl font-black tabular-nums">{{ stat.value | number }}</p>
+          </div>
+        {% endfor %}
+      </div>
       <div class="mt-6 flex flex-wrap gap-3">
-        {% if baseHref %}
-          <a
-            href="{{ baseHref }}"
-            class="btn btn-sm md:btn-md btn-primary shadow-md"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Browse generated/lv
-          </a>
-        {% endif %}
-        {% if dataset.archiveHref %}
-          <a
-            href="{{ dataset.archiveHref }}"
-            class="btn btn-sm md:btn-md btn-outline border-primary/50 text-primary-content/90"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Download bundle
-          </a>
-        {% endif %}
-        {% if dataset.manifestHref %}
-          <a
-            href="{{ dataset.manifestHref }}"
-            class="btn btn-sm md:btn-md btn-outline border-primary/30 text-primary-content/80"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Manifest JSON
-          </a>
-        {% endif %}
-        {% if dataset.history.manifestHref %}
-          <a
-            href="{{ dataset.history.manifestHref }}"
-            class="btn btn-sm md:btn-md btn-outline border-primary/20 text-primary-content/70"
-            target="_blank"
-            rel="noreferrer"
-          >
-            History manifest
-          </a>
-        {% endif %}
+        <button class="btn btn-sm md:btn-md btn-outline border-white/30 text-primary-content/80" data-lvreport="open-search">
+          <span class="font-semibold">Global dataset search</span>
+          <span class="hidden sm:inline opacity-70">⌘K / Ctrl K</span>
+        </button>
+        <button class="btn btn-sm md:btn-md btn-outline border-white/20 text-primary-content/70" data-lvreport="toggle-facets">
+          Facet filters
+        </button>
       </div>
-      {% if datasetWarnings | length %}
-        <div class="alert alert-warning mt-6 max-w-xl shadow-lg">
-          <span class="font-semibold text-sm uppercase tracking-wide">Snapshot warnings</span>
-          <ul class="mt-2 space-y-1 text-xs text-warning-content/80">
-            {% for code in datasetWarnings %}
-              <li>{{ warningCopy[code] | safe }}</li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endif %}
-      <div
-        x-data="globalSearch()"
-        x-init="init()"
-        class="mt-6 space-y-3"
-      >
-        <div class="flex flex-wrap items-center gap-3">
-          <button type="button" class="btn btn-sm md:btn-md btn-outline" @click="openPanel()">
-            <span class="font-semibold">Global dataset search</span>
-            <span class="hidden sm:inline opacity-70">⌘K / Ctrl K</span>
-          </button>
-          <p class="text-xs opacity-70">
-            Search across sitemaps, cached documents, robots, hosts, duplicates, and products.
+    </div>
+    <aside class="grid gap-4 text-sm" id="lvreport-meta">
+      <div class="rounded-box bg-black/20 p-4 shadow-md">
+        <p class="font-semibold uppercase tracking-wide text-xs opacity-80">Bundle integrity</p>
+        <p class="mt-2 text-sm opacity-75">Hydrated once at build time. Runtime reads the baked index — no live LFS access.</p>
+        <div class="mt-4 flex items-center gap-2 text-xs opacity-70" data-lvreport="bundle-meta"></div>
+      </div>
+      <div class="rounded-box bg-black/10 p-4 shadow-md">
+        <p class="font-semibold uppercase tracking-wide text-xs opacity-80">Latest run</p>
+        {% if runsHistory | length %}
+          <p class="mt-2 text-sm opacity-75">
+            {{ runsHistory[0].label or 'Run' }} • {{ runsHistory[0].finishedAt or runsHistory[0].startedAt }}
           </p>
-        </div>
-        <template x-if="open">
-          <div
-            class="fixed inset-0 z-[90] flex items-start justify-center bg-base-100/90 backdrop-blur"
-            @keydown.window.escape="closePanel()"
-            @click.self="closePanel()"
-          >
-            <div class="mt-16 w-full max-w-3xl rounded-box border border-base-content/10 bg-base-200/95 shadow-2xl">
-              <div class="flex items-center gap-3 border-b border-base-content/10 px-4 py-3">
-                <input
-                  x-model="query"
-                  @input.debounce.120ms="search()"
-                  @keydown.down.prevent="move(1)"
-                  @keydown.up.prevent="move(-1)"
-                  @keydown.enter.prevent="selectActive"
-                  autofocus
-                  type="search"
-                  class="input input-bordered input-sm md:input-md flex-1"
-                  placeholder="Search the LV dataset…"
-                />
-                <button type="button" class="btn btn-sm btn-ghost" @click="closePanel()">
-                  Esc
-                </button>
-              </div>
-              <div
-                class="max-h-80 overflow-y-auto divide-y divide-base-content/10"
-                x-show="results.length"
-                x-transition
-              >
-                <template x-for="(result, idx) in results" :key="result.id">
-                  <button
-                    type="button"
-                    class="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-base-300/40 focus:bg-base-300/50"
-                    :class="{ 'bg-base-300/50': activeIndex === idx }"
-                    @mouseenter="setActive(idx)"
-                    @click="openResult(result)"
-                  >
-                    <div class="mt-1">
-                      <span class="badge badge-sm" x-text="result.badge"></span>
-                    </div>
-                    <div class="flex-1 space-y-1">
-                      <p class="font-semibold" x-text="result.title"></p>
-                      <p class="text-xs opacity-70" x-text="result.description"></p>
-                    </div>
-                  </button>
-                </template>
-              </div>
-              <div class="px-4 py-3 text-xs opacity-60" x-show="!results.length">
-                Start typing to surface sitemaps, cached XML, robots directives, duplicate clusters,
-                hosts, and high-volume products.
-              </div>
-            </div>
-          </div>
-        </template>
-      </div>
-    </div>
-    <div class="space-y-4">
-      {% set shaPreview = manifestArchive.shaPreview or manifestArchive.sha256 %}
-      <div class="card glass border border-white/30 bg-base-100/10 shadow-lg backdrop-blur">
-        <div class="card-body space-y-3">
-          <h2 class="card-title text-sm uppercase tracking-[0.2em] text-primary-content/80">
-            Snapshot digest
-          </h2>
-          <dl class="grid grid-cols-1 gap-3 text-sm">
-            <div>
-              <dt class="text-xs uppercase opacity-60">Generated</dt>
-              <dd class="font-semibold">
-                {{ summary.generatedAt or manifest.generatedAt or '—' }}
-              </dd>
-            </div>
-            <div class="grid grid-cols-2 gap-3">
-              <div>
-                <dt class="text-xs uppercase opacity-60">Version</dt>
-                <dd class="font-semibold">
-                  {{ summary.version or manifestSummary.version or '—' }}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-xs uppercase opacity-60">Hosts</dt>
-                <dd class="font-semibold">{{ totals.hosts or 0 }}</dd>
-              </div>
-            </div>
-            <div class="grid grid-cols-2 gap-3">
-              <div>
-                <dt class="text-xs uppercase opacity-60">Mode</dt>
-                <dd class="font-semibold">
-                  {{ manifest.mode or (summary.capture and summary.capture.pages and 'pages' or 'metadata') }}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-xs uppercase opacity-60">Bundle label</dt>
-                <dd class="font-semibold">{{ manifest.runLabel or '—' }}</dd>
-              </div>
-            </div>
-            <div class="grid grid-cols-2 gap-3">
-              <div>
-                <dt class="text-xs uppercase opacity-60">Files</dt>
-                <dd class="font-semibold">
-                  {{ datasetTotals.fileCount or manifestDataset.fileCount or 0 }}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-xs uppercase opacity-60">Payload</dt>
-                <dd class="font-semibold">
-                  {{
-                    datasetTotals.sizeLabel or manifestDataset.sizeLabel or manifestArchive.sizeLabel or '—'
-                  }}
-                </dd>
-              </div>
-            </div>
-            <div>
-              <dt class="text-xs uppercase opacity-60">Bundle SHA (16)</dt>
-              <dd class="font-mono text-xs">{{ shaPreview or '—' }}</dd>
-            </div>
-          </dl>
-        </div>
-      </div>
-      {% if historyEntries | length %}
-        <div class="card border border-base-content/10 bg-base-100/30 shadow-md backdrop-blur">
-          <div class="card-body space-y-4">
-            <h2 class="card-title text-sm uppercase tracking-[0.18em] text-primary-content/80">
-              Archive history
-            </h2>
-            <ul class="space-y-3 text-sm">
-              {% for entry in historyEntries | slice(0, 3) %}
-                <li class="flex items-start justify-between gap-3">
-                  <div class="space-y-1">
-                    <p class="font-semibold leading-tight">
-                      {{ entry.generatedAt or entry.name or 'Snapshot' }}
-                    </p>
-                    <p class="text-xs opacity-70">
-                      {{ entry.label or entry.mode or '—' }}
-                    </p>
-                  </div>
-                  <div class="text-right text-xs space-y-1">
-                    {% if entry.sizeLabel %}<span class="font-semibold">{{ entry.sizeLabel }}</span>{% endif %}
-                    {% if entry.shaPreview %}<span class="font-mono text-[11px] opacity-70">{{ entry.shaPreview }}</span>{% endif %}
-                    {% if entry.href %}
-                      <a
-                        class="link link-hover"
-                        href="{{ entry.href }}"
-                        target="_blank"
-                        rel="noreferrer"
-                      >Download</a>
-                    {% endif %}
-                  </div>
-                </li>
-              {% endfor %}
-            </ul>
-            <div class="flex items-center justify-between text-[11px] opacity-70">
-              {% if historyEntries | length > 3 %}
-                <span>+{{ historyEntries | length - 3 }} more snapshots preserved.</span>
-              {% endif %}
-              <div class="space-x-3">
-                {% if datasetHistory.directoryHref %}
-                  <a
-                    class="link link-hover"
-                    href="{{ datasetHistory.directoryHref }}"
-                    target="_blank"
-                    rel="noreferrer"
-                  >Browse archives</a>
-                {% endif %}
-                {% if datasetHistory.manifestHref %}
-                  <a
-                    class="link link-hover"
-                    href="{{ datasetHistory.manifestHref }}"
-                    target="_blank"
-                    rel="noreferrer"
-                  >Manifest JSON</a>
-                {% endif %}
-              </div>
-            </div>
-          </div>
-        </div>
-      {% endif %}
-    </div>
-  </div>
-</section>
-
-{% if pagination and pagination.hrefs and (pagination.hrefs | length) > 1 %}
-  <nav class="mt-6 flex flex-wrap items-center justify-center gap-2">
-    {% for href in pagination.hrefs %}
-      {% set pageIndex = loop.index0 %}
-      {% set isCurrent = pageIndex == pagination.pageNumber %}
-      <a
-        href="{{ href }}"
-        class="btn btn-sm md:btn-md {{ 'btn-primary' if isCurrent else 'btn-outline' }}"
-      >
-        Page {{ pageIndex + 1 }}
-      </a>
-    {% endfor %}
-  </nav>
-{% endif %}
-
-{% if (datasetFlags | length) or (datasetCapture | length) %}
-  {% set captureCount = datasetCapture | length %}
-  <section id="dataset-intel" class="mt-10 space-y-4">
-    <h2 class="text-3xl font-semibold">Dataset intelligence</h2>
-    <p class="text-sm opacity-70">
-      Run metadata, safeguards, and capture switches surfaced directly from the bundle manifest.
-    </p>
-    <div
-      class="grid gap-6 {{ 'lg:grid-cols-[minmax(0,260px)_minmax(0,1fr)]' if captureCount else 'lg:grid-cols-1' }}"
-    >
-      {% if captureCount %}
-        <div class="card border border-base-content/15 bg-base-200/80 shadow-sm">
-          <div class="card-body space-y-4">
-            <h3 class="card-title text-lg">Capture profile</h3>
-            <ul class="space-y-2 text-sm">
-              {% for capture in datasetCapture %}
-                <li class="flex items-center justify-between gap-3">
-                  <span class="capitalize">{{ capture.key }}</span>
-                  <span
-                    class="badge {{ 'badge-success' if capture.enabled else 'badge-outline' }}"
-                  >{{ 'enabled' if capture.enabled else 'off' }}</span>
-                </li>
-              {% endfor %}
-            </ul>
-            <div class="text-xs opacity-70 space-y-1">
-              {% if dataset.bundleLabel %}
-                <p>Bundle label: <span class="font-semibold">{{ dataset.bundleLabel }}</span></p>
-              {% endif %}
-              {% if dataset.runMode %}
-                <p>Mode: <span class="font-semibold capitalize">{{ dataset.runMode }}</span></p>
-              {% endif %}
-              {% if summaryTotals.itemsFound %}
-                <p>Total items discovered: {{ summaryTotals.itemsFound }}</p>
-              {% endif %}
-            </div>
-          </div>
-        </div>
-      {% endif %}
-      <div class="space-y-4">
-        {% if datasetFlags | length %}
-          <div class="grid gap-4 md:grid-cols-2">
-            {% for flag in datasetFlags %}
-              <div class="card border border-base-content/15 bg-base-200/80 shadow-sm">
-                <div class="card-body space-y-3">
-                  <div class="flex items-start justify-between gap-3">
-                    <h3 class="card-title text-base leading-tight">{{ flag.title }}</h3>
-                    <span class="badge {{ toneBadge[flag.tone] or 'badge-outline' }}">
-                      {{ flag.count }}
-                    </span>
-                  </div>
-                  <p class="text-xs opacity-70">{{ flag.description }}</p>
-                  {% if flag.items and (flag.items | length) %}
-                    <details class="collapse collapse-arrow bg-base-300/30 rounded-box text-xs">
-                      <summary class="collapse-title font-semibold">
-                        View {{ flag.items | length }} host{% if flag.items | length != 1 %}s{% endif %}
-                        {% if flag.overflow %} ({{ flag.overflow }} more){% endif %}
-                      </summary>
-                      <div class="collapse-content">
-                        <ul class="max-h-40 overflow-y-auto space-y-1">
-                          {% for host in flag.items %}
-                            <li class="truncate">{{ host }}</li>
-                          {% endfor %}
-                          {% if flag.overflow %}
-                            <li class="text-[11px] opacity-60">
-                              … {{ flag.overflow }} additional entries omitted for brevity.
-                            </li>
-                          {% endif %}
-                        </ul>
-                      </div>
-                    </details>
-                  {% endif %}
-                </div>
-              </div>
-            {% endfor %}
-          </div>
         {% else %}
-          <div class="alert alert-success shadow-sm">
-            <span>No ban candidates or safeguards triggered in this snapshot.</span>
-          </div>
+          <p class="mt-2 text-sm opacity-75">Awaiting first ingest.</p>
         {% endif %}
       </div>
-    </div>
-  </section>
-{% endif %}
+    </aside>
+  </div>
+</section>
 
-<section class="mt-12 space-y-10">
-  <div class="grid gap-6 lg:grid-cols-3">
-    <div class="card border border-base-content/15 bg-base-200/70 shadow-sm">
-      <div class="card-body space-y-4">
-        <h2 class="card-title text-lg">Atlas totals</h2>
-        <div class="grid grid-cols-2 gap-3 text-sm">
-          <div>
-            <p class="text-xs uppercase opacity-60">Unique images</p>
-            <p class="text-2xl font-semibold">{{ totals.images or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Unique pages</p>
-            <p class="text-2xl font-semibold">{{ totals.pages or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">NDJSON shards</p>
-            <p class="text-xl font-semibold">{{ dataset.ndjson and dataset.ndjson.count or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Sample tiles</p>
-            <p class="text-xl font-semibold">{{ sample | length }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Sitemaps processed</p>
-            <p class="text-xl font-semibold">{{ totals.sitemapsProcessed or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Items ingested</p>
-            <p class="text-xl font-semibold">{{ totals.itemsFound or totals.images or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Cached page snapshots</p>
-            <p class="text-xl font-semibold">{{ dataset.cache.pages.totalSnapshots or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Cached image snapshots</p>
-            <p class="text-xl font-semibold">{{ dataset.cache.images.totalSnapshots or 0 }}</p>
-          </div>
-        </div>
-        {% if dataset.ndjson and dataset.ndjson.latestShard %}
-          <p class="text-xs opacity-70">
-            Latest shard: <a
-              class="link link-hover"
-              href="{{ baseHref }}{{ dataset.ndjson.latestShard }}"
-              target="_blank"
-              rel="noreferrer"
-            >{{ dataset.ndjson.latestShard }}</a>
-          </p>
-        {% endif %}
-      </div>
+<section class="mt-12 grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+  <div class="rounded-box bg-base-200/70 p-6 shadow-inner">
+    <div class="flex items-center justify-between">
+      <h2 class="text-xl font-semibold">Dataset map</h2>
+      <span class="badge badge-outline" data-lvreport="map-count"></span>
     </div>
-    <div class="card border border-base-content/15 bg-base-200/70 shadow-sm">
-      <div class="card-body space-y-4">
-        <h2 class="card-title text-lg">Lifecycle (current run)</h2>
-        <div class="grid grid-cols-2 gap-3 text-sm">
-          <div>
-            <p class="text-xs uppercase opacity-60">New</p>
-            <p class="text-2xl font-semibold">{{ itemsMetrics.added or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Removed</p>
-            <p class="text-2xl font-semibold">{{ itemsMetrics.removed or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Active</p>
-            <p class="text-2xl font-semibold">
-              {{ itemsMetrics.active or summary.items and summary.items.active or 0 }}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Total tracked</p>
-            <p class="text-2xl font-semibold">
-              {{ itemsMetrics.total or summary.items and summary.items.total or 0 }}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Duplicates</p>
-            <p class="text-2xl font-semibold">{{ itemsMetrics.duplicates or 0 }}</p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Purged</p>
-            <p class="text-2xl font-semibold">{{ itemsMetrics.purged or 0 }}</p>
-          </div>
-        </div>
+    <div class="mt-4 grid gap-4 lg:grid-cols-2" id="lvreport-map">
+      <div>
+        <h3 class="text-sm font-semibold uppercase tracking-wide opacity-70">Hosts</h3>
+        <ul class="mt-2 max-h-40 space-y-1 overflow-auto text-sm">
+          {% for host in (datasetMap.hosts or []) | slice(0, 20) %}
+            <li class="truncate text-primary">{{ host.host or host }}</li>
+          {% endfor %}
+        </ul>
       </div>
-    </div>
-    <div class="card border border-base-content/15 bg-base-200/70 shadow-sm">
-      <div class="card-body space-y-4">
-        <h2 class="card-title text-lg">Cache & transport</h2>
-        <div class="grid grid-cols-2 gap-3 text-sm">
-          <div>
-            <p class="text-xs uppercase opacity-60">Robots cached</p>
-            <p class="text-xl font-semibold">
-              {{ dataset.cache and dataset.cache.robotsFiles or 0 }}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Sitemaps cached</p>
-            <p class="text-xl font-semibold">
-              {{ dataset.cache and dataset.cache.sitemapFiles or 0 }}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">URL meta entries</p>
-            <p class="text-xl font-semibold">
-              {{ dataset.cache and dataset.cache.urlmetaEntries or 0 }}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Bundle files</p>
-            <p class="text-xl font-semibold">
-              {{ datasetTotals.fileCount or manifestDataset.fileCount or 0 }}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Robots issues</p>
-            <p class="text-sm font-semibold">
-              {{ robotsMetrics.issues or 0 }} / {{ robotsMetrics.total or 0 }}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs uppercase opacity-60">Docs issues</p>
-            <p class="text-sm font-semibold">
-              {{ docsMetrics.issues or 0 }} / {{ docsMetrics.total or 0 }}
-            </p>
-          </div>
-        </div>
-        <p class="text-xs opacity-70">
-          Use <code>npm run lv-images:verify</code> before CI to confirm archive integrity.
-        </p>
+      <div>
+        <h3 class="text-sm font-semibold uppercase tracking-wide opacity-70">Locales</h3>
+        <ul class="mt-2 max-h-40 space-y-1 overflow-auto text-sm">
+          {% for locale in (datasetMap.locales or []) | slice(0, 20) %}
+            <li class="truncate text-primary">{{ locale.locale or locale.code or locale }}</li>
+          {% endfor %}
+        </ul>
       </div>
     </div>
   </div>
+  <div class="rounded-box bg-base-200/50 p-6 shadow-inner">
+    <h2 class="text-xl font-semibold">Runs history</h2>
+    <div class="mt-4 space-y-2 text-sm" id="lvreport-runs">
+      {% for entry in runsHistory | slice(0, 6) %}
+        <div class="rounded-lg border border-base-300/50 bg-base-100/70 p-3">
+          <p class="font-semibold">{{ entry.label or entry.mode or 'Run' }}</p>
+          <p class="mt-1 text-xs opacity-70">{{ entry.finishedAt or entry.startedAt }}</p>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-    <div class="card shadow bg-base-200/80 border border-base-content/10">
-      <div class="card-body">
-        <h2 class="card-title">Robots Health</h2>
-        <p class="text-sm opacity-70">{{ robotsMetrics.total or 0 }} hosts analysed</p>
-        <div class="flex items-center gap-6 mt-4">
-          <div
-            class="radial-progress text-error"
-            style="--value: {{ robotsMetrics.issuePct | round(1) }}; --size: 4rem; --thickness: 4px"
-          >
-            {{ robotsMetrics.issuePct | round(1) }}%
-          </div>
-          <div>
-            <p class="text-2xl font-bold">{{ robotsMetrics.issues or 0 }}</p>
-            <p class="text-sm opacity-70">Flagged</p>
-          </div>
-        </div>
-        <div class="mt-4 flex flex-wrap gap-2">
-          {% for seg in robotsMetrics.breakdown or [] %}
-            {% set c = toneChip[seg.tone] or 'bg-base-300/20 text-base-content' %}
-            <span class="badge {{ c }}">{{ seg.label }} • {{ seg.count }} ({{ seg.pct }}%)</span>
-          {% endfor %}
-        </div>
+<section class="mt-12" id="lvreport-table">
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h2 class="text-2xl font-semibold">Global inventory</h2>
+      <p class="text-sm opacity-70">Searchable, paginated, facet-aware listing of every captured LV record.</p>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <input type="search" class="input input-bordered input-sm w-48 md:w-64" placeholder="Search SKU, title, locale" data-lvreport="table-search" />
+      <select class="select select-bordered select-sm" data-lvreport="page-size">
+        <option value="25" selected>25 / page</option>
+        <option value="50">50 / page</option>
+        <option value="100">100 / page</option>
+        <option value="200">200 / page</option>
+      </select>
+      <button class="btn btn-sm" data-lvreport="open-drawer">Filters</button>
+    </div>
+  </div>
+  <div class="mt-4 overflow-hidden rounded-xl border border-base-300/60 bg-base-100 shadow-xl">
+    <table class="table table-zebra w-full text-sm">
+      <thead class="bg-base-200/80 text-xs uppercase tracking-wide">
+        <tr>
+          <th class="w-24">SKU</th>
+          <th>Title</th>
+          <th class="w-24">Locale</th>
+          <th class="w-28">Type</th>
+          <th class="w-20 text-right">Images</th>
+          <th class="w-36">Updated</th>
+          <th class="w-12"></th>
+        </tr>
+      </thead>
+      <tbody data-lvreport="table-body">
+        <tr>
+          <td colspan="7" class="p-8 text-center text-sm opacity-60">Loading inventory…</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm" data-lvreport="table-footer">
+    <div data-lvreport="table-summary">Awaiting data…</div>
+    <div class="join">
+      <button class="btn btn-sm join-item" data-lvreport="page-prev">Prev</button>
+      <span class="join-item px-4 py-2 text-xs" data-lvreport="page-status">1 / 1</span>
+      <button class="btn btn-sm join-item" data-lvreport="page-next">Next</button>
+    </div>
+  </div>
+</section>
+
+<section class="mt-12 grid gap-6 lg:grid-cols-2" id="lvreport-duplicates">
+  <div class="rounded-box bg-base-200/50 p-6 shadow-inner">
+    <h2 class="text-xl font-semibold">Duplicate clusters</h2>
+    <ul class="mt-4 space-y-3 text-sm" data-lvreport="duplicate-list">
+      {% for cluster in duplicates | slice(0, 5) %}
+        <li class="rounded-lg border border-base-300/50 bg-base-100/70 p-3">
+          <p class="font-semibold">{{ cluster.canonical?.title or cluster.canonicalId }}</p>
+          <p class="mt-1 text-xs opacity-70">{{ cluster.duplicates | length }} duplicates</p>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="rounded-box bg-base-200/50 p-6 shadow-inner" id="lvreport-top-products">
+    <h2 class="text-xl font-semibold">Top products</h2>
+    <ul class="mt-4 space-y-3 text-sm" data-lvreport="product-list">
+      {% for product in topProducts | slice(0, 5) %}
+        <li class="rounded-lg border border-base-300/50 bg-base-100/70 p-3">
+          <p class="font-semibold">{{ product.title or product.pageUrl }}</p>
+          <p class="mt-1 text-xs opacity-70">{{ product.images | length }} images</p>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+
+<section class="mt-12 grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)]">
+  <div class="rounded-box bg-base-200/50 p-6 shadow-inner" id="lvreport-hosts">
+    <h2 class="text-xl font-semibold">Hosts overview</h2>
+    <div class="mt-4 space-y-3 text-sm" data-lvreport="hosts-list"></div>
+  </div>
+  <div class="rounded-box bg-base-200/50 p-6 shadow-inner" id="lvreport-robots">
+    <h2 class="text-xl font-semibold">Robots explorer</h2>
+    <div class="mt-4 space-y-3 text-sm" data-lvreport="robots-list"></div>
+  </div>
+  <div class="rounded-box bg-base-200/50 p-6 shadow-inner" id="lvreport-docs">
+    <h2 class="text-xl font-semibold">Cached documents</h2>
+    <div class="mt-4 space-y-3 text-sm" data-lvreport="docs-list"></div>
+  </div>
+</section>
+
+<section class="mt-12" id="lvreport-samples">
+  <div class="rounded-box bg-base-200/60 p-6 shadow-inner">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div class="max-w-2xl space-y-2">
+        <h2 class="text-2xl font-semibold">Fresh arrivals</h2>
+        <p class="text-sm opacity-70">Latest LV captures hydrate from the baked index with a throttled image queue — no bursty fetches.</p>
+        <p class="text-xs font-semibold uppercase tracking-wide text-primary">Scroll to reveal thumbnails; loading stays under rate limits.</p>
+      </div>
+      <div class="flex flex-wrap gap-2 text-xs opacity-70">
+        <span class="badge badge-outline badge-sm">Lazy</span>
+        <span class="badge badge-outline badge-sm">Queued</span>
+        <span class="badge badge-outline badge-sm">Hypebrüt gallery</span>
       </div>
     </div>
-    <div class="card shadow bg-base-200/80 border border-base-content/10">
-      <div class="card-body">
-        <h2 class="card-title">Documents Health</h2>
-        <p class="text-sm opacity-70">{{ docsMetrics.total or 0 }} files analysed</p>
-        <div class="flex items-center gap-6 mt-4">
-          <div
-            class="radial-progress text-error"
-            style="--value: {{ docsMetrics.issuePct | round(1) }}; --size: 4rem; --thickness: 4px"
-          >
-            {{ docsMetrics.issuePct | round(1) }}%
-          </div>
-          <div>
-            <p class="text-2xl font-bold">{{ docsMetrics.issues or 0 }}</p>
-            <p class="text-sm opacity-70">Flagged</p>
-          </div>
-        </div>
-        <div class="mt-4 flex flex-wrap gap-2">
-          {% for seg in docsMetrics.breakdown or [] %}
-            {% set c = toneChip[seg.tone] or 'bg-base-300/20 text-base-content' %}
-            <span class="badge {{ c }}">{{ seg.label }} • {{ seg.count }} ({{ seg.pct }}%)</span>
-          {% endfor %}
-        </div>
+    <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" data-lvreport="sample-grid">
+      <div class="flex aspect-[4/5] animate-pulse flex-col justify-end rounded-3xl bg-gradient-to-br from-base-300 via-base-200 to-base-100 p-4 text-xs text-base-content/60">
+        <span>Hydrating arrivals…</span>
+        <span class="opacity-50">Queue primed</span>
       </div>
     </div>
   </div>
 </section>
 
-{% if dataset.directories and (dataset.directories | length) %}
-  <section id="snapshot-map" class="mt-12 space-y-4">
-    <h2 class="text-3xl font-semibold">Generated snapshot map</h2>
-    <p class="text-sm opacity-70">
-      Top level directories inside <code>generated/lv/</code> with quick links into cached assets.
-    </p>
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-      {% for dir in dataset.directories %}
-        <div class="card border border-base-content/10 bg-base-200/70 hover:border-secondary/60 hover:shadow-lg transition">
-          <div class="card-body space-y-3">
-            <div class="flex items-center justify-between gap-4">
-              <h3 class="card-title text-lg">{{ dir.label }}</h3>
-              <span class="badge badge-outline badge-primary">{{ dir.fileCount }} files</span>
-            </div>
-            <p class="text-xs font-mono opacity-70 break-all">{{ dir.pathLabel }}</p>
-            <dl class="grid grid-cols-2 gap-3 text-sm">
-              <div>
-                <dt class="text-xs uppercase opacity-60">Bytes</dt>
-                <dd class="font-semibold">{{ dir.sizeLabel }}</dd>
-              </div>
-              <div>
-                <dt class="text-xs uppercase opacity-60">Browse</dt>
-                <dd>
-                  <a class="link link-hover" href="{{ dir.href }}" target="_blank" rel="noreferrer"
-                  >Open</a>
-                </dd>
-              </div>
-            </dl>
-            {% if dir.examples and (dir.examples | length) %}
-              <div>
-                <p class="text-xs uppercase opacity-60">Examples</p>
-                <ul class="mt-1 space-y-1 text-xs font-mono">
-                  {% for example in dir.examples %}
-                    <li class="truncate">
-                      <a
-                        class="link link-hover"
-                        href="{{ baseHref }}{{ example }}"
-                        target="_blank"
-                        rel="noreferrer"
-                      >{{ example }}</a>
-                    </li>
-                  {% endfor %}
-                </ul>
-              </div>
-            {% endif %}
-          </div>
+<section class="mt-12" id="lvreport-search">
+  <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div>
+      <h2 class="text-2xl font-semibold">Global search</h2>
+      <p class="text-sm opacity-70">Command palette powering fuzzy lookup across the index.</p>
+    </div>
+    <div class="join">
+      <input type="search" class="input input-bordered join-item w-64" placeholder="Try “Neverfull MM”" data-lvreport="global-search" />
+      <button class="btn btn-primary join-item" data-lvreport="search-open">Open</button>
+    </div>
+  </div>
+</section>
+
+<div id="lvreport-filters" class="drawer drawer-end">
+  <input id="lvreport-filters-toggle" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-side z-[80]">
+    <label for="lvreport-filters-toggle" aria-label="Close filters" class="drawer-overlay"></label>
+    <div class="min-h-full w-80 max-w-md bg-base-100 p-6">
+      <h2 class="text-lg font-semibold">Facet filters</h2>
+      <div class="mt-4 space-y-6" data-lvreport="facet-panel">
+        <div>
+          <h3 class="text-xs font-semibold uppercase tracking-wide opacity-70">Locale</h3>
+          <div class="mt-2 flex flex-wrap gap-2" data-lvreport="facet-locale"></div>
         </div>
-      {% endfor %}
+        <div>
+          <h3 class="text-xs font-semibold uppercase tracking-wide opacity-70">Product type</h3>
+          <div class="mt-2 flex flex-wrap gap-2" data-lvreport="facet-type"></div>
+        </div>
+        <div>
+          <h3 class="text-xs font-semibold uppercase tracking-wide opacity-70">Updated month</h3>
+          <div class="mt-2 flex flex-col gap-1" data-lvreport="facet-month"></div>
+        </div>
+        <div class="form-control">
+          <label class="cursor-pointer label">
+            <span class="label-text">Only hero imagery</span>
+            <input type="checkbox" class="toggle" data-lvreport="facet-hero" />
+          </label>
+        </div>
+      </div>
+      <div class="mt-6 flex gap-2">
+        <button class="btn btn-sm btn-primary flex-1" data-lvreport="facet-apply">Apply</button>
+        <button class="btn btn-sm btn-ghost" data-lvreport="facet-reset">Reset</button>
+      </div>
     </div>
-  </section>
-{% endif %}
-
-{# Sitemaps Section #}
-<section id="sitemaps" class="space-y-4 mt-12">
-  <h2 class="text-3xl font-semibold">Sitemaps</h2>
-  <p class="text-sm opacity-70">Every sitemap crawl attempt with cached artifacts.</p>
-  <div class="flex flex-wrap gap-3 items-center mt-4">
-    <label class="input input-bordered flex items-center gap-2 w-full sm:w-72">
-      <span class="opacity-60">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="m21 21-3.5-3.5"></path>
-        </svg>
-      </span>
-      <input
-        id="sitemapFilter"
-        type="search"
-        class="grow"
-        placeholder="Filter host or URL…"
-        autocomplete="off"
-        data-search-input="sitemaps"
-      />
-    </label>
-    <div id="typeChips" class="join" data-filter-chips="sitemaps">
-      {% for type in ['image', 'product', 'catalog', 'content', 'index', 'other'] %}
-        <button
-          type="button"
-          class="btn btn-xs btn-outline"
-          data-section="sitemaps"
-          data-type="{{ type }}"
-        >
-          {{ type }}
-        </button>
-      {% endfor %}
-    </div>
-    <button
-      class="btn btn-sm btn-outline"
-      id="exportSitemaps"
-      type="button"
-      data-export-section="sitemaps"
-    >
-      Export CSV
-    </button>
   </div>
-  {% if sitemapsPage.totalItems %}
-    <p class="text-xs opacity-60 mt-2" data-filter-summary="sitemaps">
-      Showing {{ sitemapsPage.from }}–{{ sitemapsPage.to }} of {{ sitemapsPage.totalItems }}
-      sitemaps (page {{ (pagination.pageNumber or 0) + 1 }} of {{
-        paginationSections.sitemaps.pageCount or 1
-      }}).
-    </p>
-  {% endif %}
-  {% if sitemaps | length %}
-    <div class="overflow-x-auto rounded-box border border-base-content/10 mt-4">
-      <table class="table table-zebra table-sm" id="sitemapsTable">
-        <thead>
-          <tr>
-            <th>Host</th>
-            <th>Type</th>
-            <th>Images</th>
-            <th>Status</th>
-            <th>Live</th>
-            <th>Cached</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for r in sitemaps %}
-            <tr data-section-row="sitemaps" data-entry-id="{{ r.id }}" data-type="{{ r.type }}">
-              <td class="font-medium">{{ r.host or '—' }}</td>
-              <td><span class="badge badge-outline capitalize">{{ r.type or 'other' }}</span></td>
-              <td>{{ r.imageCount or 0 }}</td>
-              <td>{{ r.status or '—' }}</td>
-              <td>
-                {% if r.url %}<a
-                    href="{{ r.url }}"
-                    class="link link-primary"
-                    target="_blank"
-                    rel="noreferrer"
-                  >{{ r.url }}</a>{% else %}—{% endif %}
-              </td>
-              <td>
-                {% if r.savedPath %}<a
-                    href="{{ baseHref }}{{ r.savedPath }}"
-                    class="link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >open</a>{% else %}—{% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% else %}
-    <div class="alert alert-info mt-4">
-      <span>No sitemap activity yet. Run the crawler to populate this section.</span>
-    </div>
-  {% endif %}
-</section>
+</div>
 
-{# Runs history timeline #}
-<section id="history" class="space-y-4 mt-12">
-  <h2 class="text-3xl font-semibold">Runs History</h2>
-  <p class="text-sm opacity-70">
-    Overview of the last {{ lv.runsHistory and lv.runsHistory | length or 0 }} runs with lifecycle
-    metrics.
-  </p>
-  {% if lv.runsHistory and (lv.runsHistory | length) %}
-    <div class="overflow-x-auto rounded-box border border-base-content/10 mt-4">
-      <table class="table table-zebra table-xs" id="historyTable">
-        <thead>
-          <tr>
-            <th>Date</th>
-            <th>Added</th>
-            <th>Removed</th>
-            <th>Active</th>
-            <th>Total</th>
-            <th>Duplicates</th>
-            <th>Purged</th>
-            <th>Images</th>
-            <th>Pages</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for run in lv.runsHistory | reverse %}
-            <tr>
-              <td>{{ run.timestamp }}</td>
-              <td>{{ run.metrics.added or 0 }}</td>
-              <td>{{ run.metrics.removed or 0 }}</td>
-              <td>{{ run.metrics.active or 0 }}</td>
-              <td>{{ run.metrics.total or 0 }}</td>
-              <td>{{ run.metrics.duplicates or 0 }}</td>
-              <td>{{ run.metrics.purged or 0 }}</td>
-              <td>{{ run.totals.images or 0 }}</td>
-              <td>{{ run.totals.pages or 0 }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+<div id="lvreport-drawer" class="drawer drawer-end">
+  <input id="lvreport-drawer-toggle" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-side z-[90]">
+    <label for="lvreport-drawer-toggle" aria-label="Close details" class="drawer-overlay"></label>
+    <div class="min-h-full w-[28rem] max-w-full bg-base-100 p-6" data-lvreport="detail-panel">
+      <h2 class="text-lg font-semibold">Item details</h2>
+      <div class="mt-4 space-y-4" data-lvreport="detail-content">
+        <p class="text-sm opacity-70">Select a row to inspect metadata.</p>
+      </div>
     </div>
-  {% else %}
-    <div class="alert alert-info mt-4"><span>No run history available.</span></div>
-  {% endif %}
-</section>
-
-{# Duplicate images section #}
-<section id="duplicates-section" class="space-y-4 mt-12">
-  <h2 class="text-3xl font-semibold">Duplicate Images</h2>
-  <p class="text-sm opacity-70">
-    Canonical images with one or more duplicates. The count reflects duplicate occurrences beyond
-    the canonical image.
-  </p>
-  <div class="flex flex-wrap gap-3 items-end mt-4">
-    <label class="input input-bordered flex items-center gap-2 w-full sm:w-72">
-      <span class="opacity-60">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="m21 21-3.5-3.5"></path>
-        </svg>
-      </span>
-      <input
-        id="duplicatesFilter"
-        type="search"
-        class="grow"
-        placeholder="Search basename, title or page…"
-        autocomplete="off"
-        data-search-input="duplicates"
-      />
-    </label>
-    <button
-      class="btn btn-sm btn-outline"
-      id="exportDuplicates"
-      type="button"
-      data-export-section="duplicates"
-    >
-      Export CSV
-    </button>
   </div>
-  {% if duplicatesPage.totalItems %}
-    <p class="text-xs opacity-60 mt-2" data-filter-summary="duplicates">
-      Showing {{ duplicatesPage.from }}–{{ duplicatesPage.to }} of {{ duplicatesPage.totalItems }}
-      duplicate groups.
-    </p>
-  {% endif %}
-  {% if duplicates and (duplicates | length) %}
-    <div class="overflow-x-auto rounded-box border border-base-content/10 mt-4">
-      <table class="table table-zebra table-xs" id="duplicatesTable">
-        <thead>
-          <tr>
-            <th class="min-w-[80px]">Image</th>
-            <th class="min-w-[80px]">Dupes</th>
-            <th>Basename</th>
-            <th class="min-w-[260px]">Page</th>
-            <th>First Seen</th>
-            <th>Last Seen</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for d in duplicates %}
-            <tr data-section-row="duplicates" data-entry-id="{{ d.id }}">
-              <td>
-                <a href="{{ d.src }}" target="_blank" rel="noreferrer"><img
-                    src="{{ d.src }}"
-                    alt=""
-                    class="w-12 h-12 object-cover rounded-box border border-base-content/10"
-                  /></a>
-              </td>
-              <td>{{ d.count - 1 }}</td>
-              <td>{{ d.basename or '' }}</td>
-              <td>
-                {% if d.pageUrl %}<a
-                    class="link link-primary"
-                    href="{{ d.pageUrl }}"
-                    target="_blank"
-                    rel="noreferrer"
-                  >{{ d.pageUrl }}</a>{% else %}—{% endif %}
-              </td>
-              <td>{{ d.firstSeen }}</td>
-              <td>{{ d.lastSeen }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% else %}
-    <div class="alert alert-info mt-4"><span>No duplicates found.</span></div>
-  {% endif %}
-</section>
+</div>
 
-{# Top products section #}
-<section id="products-section" class="space-y-4 mt-12">
-  <h2 class="text-3xl font-semibold">Top Products</h2>
-  <p class="text-sm opacity-70">
-    Pages with the most cached images. Review {{ topProductsPage.totalItems or 0 }} products, paged
-    for easier browsing.
-  </p>
-  <div class="flex flex-wrap gap-3 items-end mt-4">
-    <label class="input input-bordered flex items-center gap-2 w-full sm:w-72">
-      <span class="opacity-60">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-        >
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="m21 21-3.5-3.5"></path>
-        </svg>
-      </span>
-      <input
-        id="productsFilter"
-        type="search"
-        class="grow"
-        placeholder="Search page or title…"
-        autocomplete="off"
-        data-search-input="topProducts"
-      />
-    </label>
-    <button
-      class="btn btn-sm btn-outline"
-      id="exportProducts"
-      type="button"
-      data-export-section="topProducts"
-    >
-      Export CSV
-    </button>
-  </div>
-  {% if topProductsPage.totalItems %}
-    <p class="text-xs opacity-60 mt-2" data-filter-summary="topProducts">
-      Showing {{ topProductsPage.from }}–{{ topProductsPage.to }} of {{
-        topProductsPage.totalItems
-      }} products.
-    </p>
-  {% endif %}
-  {% if topProducts and (topProducts | length) %}
-    <div class="overflow-x-auto rounded-box border border-base-content/10 mt-4">
-      <table class="table table-zebra table-xs" id="productsTable">
-        <thead>
-          <tr>
-            <th class="min-w-[240px]">Page</th>
-            <th>Total Images</th>
-            <th>Unique Images</th>
-            <th>First Seen</th>
-            <th>Last Seen</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for p in topProducts %}
-            <tr data-section-row="topProducts" data-entry-id="{{ p.id }}">
-              <td>
-                {% if p.pageUrl %}<a
-                    href="{{ p.pageUrl }}"
-                    class="link link-primary"
-                    target="_blank"
-                    rel="noreferrer"
-                  >{{ p.title }}</a>{% else %}{{ p.title }}{% endif %}
-              </td>
-              <td>{{ p.totalImages }}</td>
-              <td>{{ p.uniqueImages }}</td>
-              <td>{{ p.firstSeen }}</td>
-              <td>{{ p.lastSeen }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% else %}
-    <div class="alert alert-info mt-4"><span>No products found.</span></div>
-  {% endif %}
-</section>
-
-{# Hosts overview section #}
-<section id="hosts-section" class="space-y-4 mt-12">
-  <h2 class="text-3xl font-semibold">Hosts Overview</h2>
-  <p class="text-sm opacity-70">
-    Summary of total and unique images, duplicates and pages per host.
-  </p>
-  <div class="flex flex-wrap gap-3 items-end mt-4">
-    <label class="input input-bordered flex items-center gap-2 w-full sm:w-72">
-      <span class="opacity-60">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-        >
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="m21 21-3.5-3.5"></path>
-        </svg>
-      </span>
-      <input
-        id="hostsFilter"
-        type="search"
-        class="grow"
-        placeholder="Search host…"
-        autocomplete="off"
-        data-search-input="hosts"
-      />
-    </label>
-    <button
-      class="btn btn-sm btn-outline"
-      id="exportHosts"
-      type="button"
-      data-export-section="hosts"
-    >
-      Export CSV
-    </button>
-  </div>
-  {% if hostStatsPage.totalItems %}
-    <p class="text-xs opacity-60 mt-2" data-filter-summary="hosts">
-      Showing {{ hostStatsPage.from }}–{{ hostStatsPage.to }} of {{ hostStatsPage.totalItems }}
-      hosts.
-    </p>
-  {% endif %}
-  {% if hostStats and (hostStats | length) %}
-    <div class="overflow-x-auto rounded-box border border-base-content/10 mt-4">
-      <table class="table table-zebra table-xs" id="hostsTable">
-        <thead>
-          <tr>
-            <th class="min-w-[200px]">Host</th>
-            <th>Total Images</th>
-            <th>Unique Images</th>
-            <th>Duplicates</th>
-            <th>Products</th>
-            <th>Pages</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for h in hostStats %}
-            <tr data-section-row="hosts" data-entry-id="{{ h.id }}">
-              <td>{{ h.host or '—' }}</td>
-              <td>{{ h.images }}</td>
-              <td>{{ h.uniqueImages }}</td>
-              <td>{{ h.duplicates }}</td>
-              <td>{{ h.products }}</td>
-              <td>{{ h.pages }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% else %}
-    <div class="alert alert-info mt-4"><span>No host data available.</span></div>
-  {% endif %}
-</section>
-
-{# Robots Section #}
-<section id="robots" class="space-y-4 mt-12">
-  <h2 class="text-3xl font-semibold">Robots Explorer</h2>
-  <p class="text-sm opacity-70">
-    Classified view of cached <code>robots.txt</code> responses with live mirrors, cached filenames,
-    and directive counts.
-  </p>
-  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:flex-wrap mt-4">
-    <label class="input input-bordered flex items-center gap-2 w-full sm:w-72">
-      <span class="opacity-60">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-        >
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="m21 21-3.5-3.5"></path>
-        </svg>
-      </span>
-      <input
-        id="robotsFilter"
-        type="search"
-        class="grow"
-        placeholder="Search host, directive, or status…"
-        autocomplete="off"
-        data-search-input="robots"
-      />
-    </label>
-    <div id="robotsStatusFilters" class="flex flex-wrap gap-2">
-      {% for seg in robotsMetrics.breakdown or [] %}
-        {% set badgeClass = toneBadge[seg.tone] or 'badge-outline' %}
-        <button
-          type="button"
-          class="btn btn-xs btn-ghost status-chip"
-          data-section="robots"
-          data-status="{{ seg.key }}"
-        >
-          <span class="badge {{ badgeClass }} badge-xs">{{ seg.label }}</span>
-          <span class="text-xs opacity-60">{{ seg.count }}</span>
-        </button>
-      {% endfor %}
-    </div>
-    <label class="flex items-center gap-2 text-sm mt-2 sm:mt-0">
-      <input
-        id="robotsIssuesOnly"
-        type="checkbox"
-        class="checkbox checkbox-sm"
-        data-issues-toggle="robots"
-      />
-      <span>Show issues only</span>
-    </label>
-  </div>
-  {% if robotsPage.totalItems %}
-    <p class="text-xs opacity-60 mt-2" data-filter-summary="robots">
-      Showing {{ robotsPage.from }}–{{ robotsPage.to }} of {{ robotsPage.totalItems }} robots
-      snapshots.
-    </p>
-  {% endif %}
-  {% if robots | length %}
-    <div class="overflow-x-auto rounded-box border border-base-content/10 mt-4">
-      <table class="table table-zebra table-xs" id="robotsTable">
-        <thead>
-          <tr>
-            <th class="min-w-[220px]">Host</th>
-            <th class="min-w-[160px]">Status</th>
-            <th class="min-w-[160px]">Cache</th>
-            <th class="min-w-[200px]">Directives</th>
-            <th class="min-w-[260px]">Preview</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for r in robots %}
-            <tr
-              data-section-row="robots"
-              data-entry-id="{{ r.id }}"
-              data-host="{{ r.host }}"
-              data-status="{{ r.statusCategory }}"
-              data-issue="{% if r.isIssue %}1{% else %}0{% endif %}"
-            >
-              <td class="align-top">
-                <div class="flex flex-col gap-1">
-                  <span class="font-medium">{{ r.host }}</span>
-                  <div class="flex flex-wrap items-center gap-2 text-xs">
-                    <a
-                      class="link link-primary"
-                      href="https://{{ r.host }}/robots.txt"
-                      target="_blank"
-                      rel="noreferrer"
-                    >Live robots.txt</a>
-                    {% if r.robotsTxtPath %}
-                      <span class="opacity-40">·</span>
-                      <a
-                        class="link"
-                        href="{{ baseHref }}{{ r.robotsTxtPath }}"
-                        target="_blank"
-                        rel="noreferrer"
-                      >Cached</a>
-                    {% endif %}
-                    {% if r.blacklisted %}
-                      <span class="badge badge-error badge-outline">Blacklisted{%
-                          if r.blacklistReason
-                        %}
-                          · {{ r.blacklistReason }}{% endif %}</span>
-                    {% endif %}
-                  </div>
-                  {% if r.blacklisted and r.blacklistUntil %}
-                    <span class="text-[11px] opacity-60">Active until {{ r.blacklistUntil }}</span>
-                  {% endif %}
-                </div>
-              </td>
-              <td class="align-top">
-                <div class="flex flex-col gap-1">
-                  {% set badgeClass = toneBadge[r.statusTone] or 'badge-outline' %}
-                  <span class="badge {{ badgeClass }} badge-sm">{{ r.statusLabel }}</span>
-                  {% if r.httpLabel %}<span class="badge badge-outline badge-xs">{{
-                      r.httpLabel
-                    }}</span>{% endif %}
-                  <span class="text-[11px] opacity-60">{{ r.linesTotal }} lines</span>
-                </div>
-              </td>
-              <td class="align-top">
-                {% if r.robotsTxtPath %}
-                  <div class="flex flex-col gap-1 text-xs">
-                    <a
-                      class="link link-hover"
-                      href="{{ baseHref }}{{ r.robotsTxtPath }}"
-                      target="_blank"
-                      rel="noreferrer"
-                    >{{ r.fileName }}</a>
-                    <span class="opacity-60">{{ r.sizeLabel }} · cached</span>
-                  </div>
-                {% else %}
-                  <span class="text-xs opacity-60">No cache</span>
-                {% endif %}
-              </td>
-              <td class="align-top">
-                {% set allowCount   = r.parsed.merged.allow.length %}
-                {% set disallowCount= r.parsed.merged.disallow.length %}
-                {% set noindexCount = r.parsed.merged.noindex.length %}
-                {% set sitemapCount= r.parsed.merged.sitemaps.length %}
-                <div class="flex flex-wrap gap-1 text-[11px]">
-                  {% if allowCount %}<span class="badge badge-outline badge-xs">Allow {{
-                        allowCount
-                      }}</span>{% endif %}
-                  {% if disallowCount %}<span class="badge badge-outline badge-xs">Disallow {{
-                        disallowCount
-                      }}</span>{% endif %}
-                  {% if noindexCount %}<span class="badge badge-outline badge-xs">Noindex {{
-                        noindexCount
-                      }}</span>{% endif %}
-                  {% if r.parsed.merged.crawlDelay is not none %}<span
-                      class="badge badge-outline badge-xs"
-                    >Delay {{ r.parsed.merged.crawlDelay }}</span>{% endif %}
-                  {% if sitemapCount %}<span class="badge badge-outline badge-xs">Sitemaps {{
-                        sitemapCount
-                      }}</span>{% endif %}
-                </div>
-                {% if sitemapCount %}
-                  <div class="mt-1 space-y-1 text-[11px]">
-                    {% for u in r.parsed.merged.sitemaps | slice(0, 3) %}
-                      <a class="link link-hover" href="{{ u }}" target="_blank" rel="noreferrer">{{
-                        u
-                      }}</a>
-                    {% endfor %}
-                    {% if r.parsed.merged.sitemaps.length > 3 %}<span class="opacity-60"
-                      >+{{ r.parsed.merged.sitemaps.length - 3 }} more…</span>{% endif %}
-                  </div>
-                {% endif %}
-                {% if r.parsed.other and (r.parsed.other | length) %}
-                  <div class="mt-1 flex flex-wrap gap-1 text-[11px]">
-                    {% for key, vals in r.parsed.other %}
-                      <span class="badge badge-outline badge-xs">{{ key }}: {{
-                          vals | join(' · ')
-                        }}</span>
-                    {% endfor %}
-                  </div>
-                {% endif %}
-              </td>
-              <td class="align-top w-80">
-                {% if r.preview %}
-                  <pre class="bg-base-100 border border-base-content/10 rounded-box p-3 text-xs leading-5 whitespace-pre-wrap max-h-36 overflow-auto">{{ r.preview | escape }}</pre>
-                  {% if r.robotsTxtPath %}<a
-                      class="link link-hover text-xs"
-                      href="{{ baseHref }}{{ r.robotsTxtPath }}"
-                      target="_blank"
-                      rel="noreferrer"
-                    >Open full raw</a>{% endif %}
-                {% elif r.hasCached %}
-                  <a
-                    class="link link-hover text-xs"
-                    href="{{ baseHref }}{{ r.robotsTxtPath }}"
-                    target="_blank"
-                    rel="noreferrer"
-                  >Open cached file</a>
-                {% else %}
-                  <span class="text-xs opacity-60">No cache captured</span>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% else %}
-    <div class="alert alert-info mt-4">
-      <span>No robots have been cached yet.</span>
-    </div>
-  {% endif %}
-</section>
-
-{# Docs Section #}
-<section id="docs" class="space-y-4 mt-12">
-  <h2 class="text-3xl font-semibold">Cached Documents</h2>
-  <p class="text-sm opacity-70">Inventory of saved sitemap payloads and text resources.</p>
-  <p class="text-xs opacity-60">
-    Use the status filters to surface errors, HTML payloads and gzip archives.
-  </p>
-  <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end mt-4">
-    <label class="input input-bordered flex items-center gap-2 w-full sm:w-72">
-      <span class="opacity-60">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-        >
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="m21 21-3.5-3.5"></path>
-        </svg>
-      </span>
-      <input
-        id="docsFilter"
-        type="search"
-        class="grow"
-        placeholder="Search host, filename, or status…"
-        autocomplete="off"
-        data-search-input="docs"
-      />
-    </label>
-    <div id="docsStatusFilters" class="flex flex-wrap gap-2">
-      {% for seg in docsMetrics.breakdown or [] %}
-        {% set badgeClass = toneBadge[seg.tone] or 'badge-outline' %}
-        <button
-          type="button"
-          class="btn btn-xs btn-ghost status-chip"
-          data-section="docs"
-          data-status="{{ seg.key }}"
-        >
-          <span class="badge {{ badgeClass }} badge-xs">{{ seg.label }}</span>
-          <span class="text-xs opacity-60">{{ seg.count }}</span>
-        </button>
-      {% endfor %}
-    </div>
-    <label class="flex items-center gap-2 text-sm mt-2 sm:mt-0">
-      <input
-        id="docsIssuesOnly"
-        type="checkbox"
-        class="checkbox checkbox-sm"
-        data-issues-toggle="docs"
-      />
-      <span>Show issues only</span>
-    </label>
-    <button class="btn btn-sm btn-outline" id="exportDocs" type="button" data-export-section="docs">
-      Export CSV
-    </button>
-  </div>
-  {% if docsPage.totalItems %}
-    <p class="text-xs opacity-60 mt-2" data-filter-summary="docs">
-      Showing {{ docsPage.from }}–{{ docsPage.to }} of {{ docsPage.totalItems }} cached documents.
-    </p>
-  {% endif %}
-  {% if docs | length %}
-    <div class="overflow-x-auto rounded-box border border-base-content/10 mt-4">
-      <table class="table table-zebra table-xs" id="docsTable">
-        <thead>
-          <tr>
-            <th class="min-w-[200px]">Host</th>
-            <th class="min-w-[220px]">File</th>
-            <th class="min-w-[160px]">Status</th>
-            <th class="min-w-[160px]">Meta</th>
-            <th class="min-w-[320px]">Preview</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for d in docs %}
-            <tr
-              data-section-row="docs"
-              data-entry-id="{{ d.id }}"
-              data-status="{{ d.statusCategory }}"
-              data-issue="{% if d.isIssue %}1{% else %}0{% endif %}"
-            >
-              <td class="align-top">
-                <div class="flex flex-col gap-1">
-                  <span class="font-medium">{{ d.host or '—' }}</span>
-                  {% if d.url %}<a
-                      class="link link-primary text-xs"
-                      href="{{ d.url }}"
-                      target="_blank"
-                      rel="noreferrer"
-                    >Live document</a>{% endif %}
-                </div>
-              </td>
-              <td class="align-top">
-                <div class="flex flex-col gap-1 text-xs">
-                  {% if d.savedPath %}
-                    <a
-                      class="link link-hover"
-                      href="{{ baseHref }}{{ d.savedPath }}"
-                      target="_blank"
-                      rel="noreferrer"
-                    >{{ d.fileName }}</a>
-                    <span class="opacity-60">{{ d.savedPath }}</span>
-                  {% endif %}
-                  <span class="badge badge-outline badge-xs capitalize">{{ d.kind or '—' }}</span>
-                </div>
-              </td>
-              <td class="align-top">
-                {% set badgeClass = toneBadge[d.statusTone] or 'badge-outline' %}
-                <div class="flex flex-col gap-1">
-                  <span class="badge {{ badgeClass }} badge-sm">{{ d.statusLabel }}</span>
-                  {% if d.httpLabel %}<span class="badge badge-outline badge-xs">{{
-                      d.httpLabel
-                    }}</span>{% endif %}
-                  {% if d.status %}<span class="text-[11px] opacity-60">Fetch status {{
-                        d.status
-                      }}</span>{% endif %}
-                </div>
-              </td>
-              <td class="align-top text-xs">
-                <div class="space-y-1">
-                  <span class="opacity-70">{{ d.sizeLabel }}</span>
-                  {% if d.contentType %}<span class="opacity-60">{{ d.contentType }}</span>{%
-                    endif
-                  %}
-                  {% if d.statusCategory == 'gzip' %}<span class="opacity-60"
-                    >Compressed (.gz)</span>{% endif %}
-                </div>
-              </td>
-              <td class="align-top w-[360px]">
-                {% if d.preview %}
-                  <pre class="bg-base-100 border border-base-content/10 rounded-box p-3 text-xs leading-5 whitespace-pre-wrap max-h-40 overflow-auto">{{ d.preview | escape }}</pre>
-                {% elif d.statusCategory == 'gzip' %}
-                  <span class="text-xs opacity-60">Gzip archive — download to inspect.</span>
-                {% else %}
-                  <span class="text-xs opacity-60">No preview available.</span>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% else %}
-    <div class="alert alert-info mt-4">
-      <span>No cached documents on disk.</span>
-    </div>
-  {% endif %}
-</section>
-
-{# Sample images grid #}
-<section id="sample" class="space-y-4 mt-12">
-  <h2 class="text-3xl font-semibold">Image Sample</h2>
-  <p class="text-sm opacity-70">
-    A quick glance at NDJSON shards. Click any tile to open the source.
-  </p>
-  {% if sample | length %}
-    <div class="grid gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 mt-4">
-      {% for i in sample %}
-        <a
-          class="relative block aspect-square overflow-hidden rounded-box border border-base-content/10 hover:shadow-md transition"
-          href="{{ i.pageUrl or i.src }}"
-          target="_blank"
-          title="{{ i.title or i.src }}"
-          rel="noreferrer"
-          data-original-image="{{ i.src }}"
-        >
-          <img
-            loading="lazy"
-            src="{{ i.src }}"
-            data-original-src="{{ i.src }}"
-            alt=""
-            class="h-full w-full object-cover"
-          />
-        </a>
-      {% endfor %}
-    </div>
-    <p class="text-sm opacity-70 mt-2">Showing {{ sample | length }} sample images.</p>
-  {% else %}
-    <div class="alert alert-info mt-4">
-      <span>No image samples were found in <code>items/*.ndjson</code>.</span>
-    </div>
-  {% endif %}
-</section>
-
-</section>
+<script type="application/json" id="lvreport-data">{{ clientPayloadJson | safe }}</script>
+<script type="module" src="/assets/js/lvreport-app.js"></script>

--- a/tests/playwright/lv-report.spec.mjs
+++ b/tests/playwright/lv-report.spec.mjs
@@ -8,25 +8,71 @@ async function gotoReport(page, baseURL) {
   await page.goto(urlFrom(baseURL, REPORT_PATH), { waitUntil: 'networkidle' })
 }
 
-test.describe('LV Image Atlas report wiring', () => {
-  test('exposes robots cache entries', async ({ page, baseURL }) => {
+async function waitForInventory(page) {
+  const tableBody = page.locator('[data-lvreport="table-body"]')
+  await expect(tableBody).toBeVisible()
+  await page.waitForTimeout(250)
+}
+
+test.describe('LV report dashboard', () => {
+  test('renders hero KPIs and baked index metadata', async ({ page, baseURL }) => {
     await gotoReport(page, baseURL)
-    const robotsRows = page.locator('#robotsTable tbody tr')
-    await expect(robotsRows.first()).toBeVisible()
-    expect(await robotsRows.count()).toBeGreaterThan(0)
+    const kpiCards = page.locator('#lvreport-kpis .glass')
+    await expect(kpiCards.first()).toBeVisible()
+
+    const bundleMeta = page.locator('[data-lvreport="bundle-meta"] .badge')
+    await expect(bundleMeta.first()).toContainText(/SHA/i)
+    const datasetScript = page.locator('#lvreport-data')
+    const payload = JSON.parse(await datasetScript.textContent())
+    expect(payload.indexHref).toContain('/assets/data/lvreport/index.json')
   })
 
-  test('lists cached XML/TXT docs', async ({ page, baseURL }) => {
+  test('supports pagination and facet toggles', async ({ page, baseURL }) => {
     await gotoReport(page, baseURL)
-    const docRows = page.locator('#docsTable tbody tr')
-    const rowCount = await docRows.count()
-    if (rowCount > 0) {
-      await expect(docRows.first()).toBeVisible()
-      expect(rowCount).toBeGreaterThan(0)
-    } else {
-      const emptyState = page.locator('#docs .alert-info')
-      await expect(emptyState).toBeVisible()
-      await expect(emptyState).toContainText('No cached documents')
+    await waitForInventory(page)
+
+    const summary = page.locator('[data-lvreport="table-summary"]')
+    const initialSummary = await summary.textContent()
+
+    await page.locator('[data-lvreport="toggle-facets"]').click()
+    await expect(page.locator('#lvreport-filters .drawer-side')).toBeVisible()
+
+    const heroToggle = page.locator('[data-lvreport="facet-hero"]')
+    if (await heroToggle.count()) {
+      await heroToggle.check()
     }
+    await page.locator('[data-lvreport="facet-apply"]').click()
+    await page.waitForTimeout(200)
+
+    const updatedSummary = await summary.textContent()
+    expect(updatedSummary?.trim().length).toBeGreaterThan(0)
+    if (initialSummary && updatedSummary) {
+      expect(updatedSummary).not.toBe(initialSummary)
+    }
+  })
+
+  test('opens detail drawer from table row', async ({ page, baseURL }) => {
+    await gotoReport(page, baseURL)
+    await waitForInventory(page)
+    const detailButton = page.locator('[data-lvreport="table-body"] [data-detail]').first()
+    if (await detailButton.count() === 0) {
+      await expect(page.locator('[data-lvreport="table-body"] td')).toContainText(/No results|Loading/i)
+      return
+    }
+    await detailButton.click()
+    await expect(page.locator('#lvreport-drawer .drawer-side')).toBeVisible()
+    await expect(page.locator('[data-lvreport="detail-content"]')).toContainText(/SKU/)
+  })
+
+  test('invokes command palette via keyboard', async ({ page, baseURL }) => {
+    await gotoReport(page, baseURL)
+    await waitForInventory(page)
+    await page.keyboard.press('Control+K')
+    const commandDialog = page.locator('body > div').filter({ hasText: 'Search LV inventory' }).first()
+    await expect(commandDialog).toBeVisible()
+    await commandDialog.locator('input').fill('bag')
+    await page.waitForTimeout(150)
+    const results = commandDialog.locator('[data-results] button')
+    await expect(results.first()).toBeVisible()
   })
 })

--- a/tools/lv-images/index-builder.mjs
+++ b/tools/lv-images/index-builder.mjs
@@ -1,0 +1,421 @@
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { performance } from 'node:perf_hooks'
+import { finished } from 'node:stream/promises'
+
+import tar from 'tar'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const projectRoot = path.resolve(__dirname, '..', '..')
+const DATASET_ROOT = path.join(projectRoot, 'src/content/projects/lv-images')
+const GENERATED_DIR = path.join(DATASET_ROOT, 'generated')
+const BUNDLE_PATH = path.join(GENERATED_DIR, 'lv.bundle.tgz')
+const CACHE_DIR = path.join(projectRoot, '.cache', 'lv-images')
+const INDEX_PATH = path.join(CACHE_DIR, 'index.json')
+const META_PATH = path.join(CACHE_DIR, 'meta.json')
+const METRICS_PATH = path.join(CACHE_DIR, 'ingest-metrics.json')
+
+const BANNED_HOSTS = new Set(['www.olyv.co.in', 'app.urlgeni.us'])
+
+const pointerSignature = Buffer.from('version https://git-lfs.github.com/spec/v1')
+
+function isLikelyPointer(buffer) {
+  if (!buffer || buffer.length < pointerSignature.length) return false
+  return buffer.slice(0, pointerSignature.length).equals(pointerSignature)
+}
+
+async function runGitLfsPull({ logger } = {}) {
+  const { spawn } = await import('node:child_process')
+  return new Promise((resolve, reject) => {
+    const proc = spawn('git', ['lfs', 'pull', `--include="src/content/projects/lv-images/generated/lv.bundle.tgz"`], {
+      cwd: projectRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    proc.stdout.on('data', (chunk) => {
+      if (logger) logger(chunk.toString().trim())
+    })
+    proc.stderr.on('data', (chunk) => {
+      if (logger) logger(chunk.toString().trim())
+    })
+    proc.on('error', reject)
+    proc.on('close', (code) => {
+      if (code === 0) resolve(true)
+      else reject(new Error(`git lfs pull failed with code ${code}`))
+    })
+  })
+}
+
+export async function ensureBundleAvailable({ logger } = {}) {
+  let buffer
+  try {
+    buffer = await readFile(BUNDLE_PATH)
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      if (logger) logger('[lv-images] bundle missing — attempting git lfs pull')
+      await runGitLfsPull({ logger })
+      buffer = await readFile(BUNDLE_PATH)
+    } else {
+      throw error
+    }
+  }
+
+  if (isLikelyPointer(buffer)) {
+    if (logger) logger('[lv-images] bundle is LFS pointer — syncing real artifact')
+    await runGitLfsPull({ logger })
+    buffer = await readFile(BUNDLE_PATH)
+    if (isLikelyPointer(buffer)) {
+      throw new Error('lv.bundle.tgz still resolves to LFS pointer after git lfs pull')
+    }
+  }
+  return { path: BUNDLE_PATH, size: buffer.length }
+}
+
+async function collectEntry(entry) {
+  const chunks = []
+  entry.on('data', (chunk) => chunks.push(chunk))
+  entry.resume()
+  await finished(entry)
+  return Buffer.concat(chunks)
+}
+
+function normalizeRobotEntry(host, payload) {
+  if (!payload || typeof payload !== 'object') return null
+  const groups = Array.isArray(payload.groups) ? payload.groups : []
+  const allow = []
+  const disallow = []
+  const sitemaps = []
+  const userAgents = new Set()
+  for (const group of groups) {
+    const agents = Array.isArray(group.agents) ? group.agents : []
+    for (const agent of agents) userAgents.add(agent)
+    const rules = Array.isArray(group.rules) ? group.rules : []
+    for (const rule of rules) {
+      if (!rule) continue
+      if (rule.type === 'allow') allow.push(rule.path)
+      if (rule.type === 'disallow') disallow.push(rule.path)
+      if (rule.type === 'sitemap') sitemaps.push(rule.path)
+    }
+  }
+  return {
+    host,
+    agents: Array.from(userAgents),
+    allow,
+    disallow,
+    sitemaps,
+    issue: payload.issue ?? false,
+    warnings: Array.isArray(payload.warnings) ? payload.warnings : [],
+    fetchedAt: payload.fetchedAt || null,
+    status: payload.http?.status ?? null,
+    contentType: payload.http?.contentType || '',
+    path: payload.path || '',
+  }
+}
+
+function normalizeDocEntry(relPath, payload) {
+  const host = relPath.split('/')[0] || 'unknown'
+  const status = payload?.http?.status ?? null
+  const size = payload?.size ?? 0
+  return {
+    host,
+    path: relPath,
+    url: payload?.url || '',
+    status,
+    contentType: payload?.http?.contentType || '',
+    size,
+    sizeLabel: size ? formatBytes(size) : '',
+    cachedAt: payload?.fetchedAt || null,
+    issue: Boolean(payload?.issue),
+  }
+}
+
+function formatBytes(bytes) {
+  if (!bytes || Number.isNaN(bytes)) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  let idx = 0
+  let value = bytes
+  while (value >= 1024 && idx < units.length - 1) {
+    value /= 1024
+    idx++
+  }
+  return `${value % 1 ? value.toFixed(1) : value} ${units[idx]}`
+}
+
+function extractHostname(candidate) {
+  if (!candidate) return ''
+  if (typeof candidate === 'string') {
+    try {
+      const url = new URL(candidate)
+      return (url.hostname || '').toLowerCase()
+    } catch (error) {
+      return candidate.toLowerCase()
+    }
+  }
+  if (candidate && typeof candidate === 'object') {
+    const value = candidate.host || candidate.hostname || candidate.url || candidate.pageUrl || ''
+    return extractHostname(value)
+  }
+  return ''
+}
+
+function isBannedHost(candidate) {
+  const host = extractHostname(candidate)
+  return host ? BANNED_HOSTS.has(host) : false
+}
+
+function isBannedUrl(url) {
+  const host = extractHostname(url)
+  return host ? BANNED_HOSTS.has(host) : false
+}
+
+function toIndexRow(meta) {
+  if (!meta || typeof meta !== 'object') return null
+  const locale = meta.locale || meta.market || ''
+  const productType = meta.productType || meta.type || ''
+  const updatedAt = meta.lastSeen || meta.lastUpdated || meta.lastMod || ''
+  const createdAt = meta.firstSeen || meta.createdAt || ''
+  const tags = Array.isArray(meta.tags) ? meta.tags : []
+  return {
+    id: meta.id || meta.hash || '',
+    sku: meta.sku || meta.slug || '',
+    title: meta.title || meta.name || '',
+    locale,
+    productType,
+    pageUrl: meta.pageUrl || meta.url || '',
+    imageUrl: meta.src || meta.heroImage || '',
+    hasHero: Boolean(meta.heroImage || meta.hero || meta.primaryImage),
+    imageCount: typeof meta.imageCount === 'number' ? meta.imageCount : (meta.images?.length || 0),
+    duplicateOf: meta.duplicateOf || null,
+    updatedAt,
+    createdAt,
+    tags,
+    lastMod: meta.lastMod || '',
+    variantCount: typeof meta.variantCount === 'number' ? meta.variantCount : null,
+  }
+}
+
+function enrichIndexRows(itemsMeta = {}) {
+  const rows = []
+  for (const [id, meta] of Object.entries(itemsMeta)) {
+    if (!meta) continue
+    const row = toIndexRow({ ...meta, id })
+    if (!row) continue
+    if (isBannedUrl(row.pageUrl) || isBannedUrl(row.imageUrl)) continue
+    rows.push(row)
+  }
+  return rows
+}
+
+function sanitizeSummary(summary = {}) {
+  const next = { ...summary }
+  if (Array.isArray(summary.hosts)) {
+    next.hosts = summary.hosts.filter((entry) => !isBannedHost(entry?.host || entry?.id || entry))
+  }
+  if (Array.isArray(summary.sitemaps)) {
+    next.sitemaps = summary.sitemaps.filter((entry) => !isBannedUrl(entry?.url || entry?.loc || entry))
+  }
+  if (Array.isArray(summary.issues)) {
+    next.issues = summary.issues.filter((entry) => !isBannedHost(entry?.host || entry))
+  }
+  return next
+}
+
+function computeFacets(rows) {
+  const locales = new Map()
+  const productTypes = new Map()
+  const updatedMonths = new Map()
+  let heroCount = 0
+  for (const row of rows) {
+    if (!row) continue
+    const localeKey = row.locale || 'unknown'
+    locales.set(localeKey, (locales.get(localeKey) || 0) + 1)
+    const typeKey = row.productType || 'other'
+    productTypes.set(typeKey, (productTypes.get(typeKey) || 0) + 1)
+    if (row.hasHero) heroCount++
+    if (row.updatedAt) {
+      const month = row.updatedAt.slice(0, 7)
+      if (month) updatedMonths.set(month, (updatedMonths.get(month) || 0) + 1)
+    }
+  }
+  return {
+    locales: Array.from(locales.entries()).map(([value, count]) => ({ value, count })),
+    productTypes: Array.from(productTypes.entries()).map(([value, count]) => ({ value, count })),
+    updatedMonths: Array.from(updatedMonths.entries())
+      .sort((a, b) => b[0].localeCompare(a[0]))
+      .map(([value, count]) => ({ value, count })),
+    heroCount,
+  }
+}
+
+export async function buildIndex({ logger } = {}) {
+  await ensureBundleAvailable({ logger })
+  await mkdir(CACHE_DIR, { recursive: true })
+
+  const metrics = {
+    startedAt: new Date().toISOString(),
+    bundleBytes: 0,
+    parseMs: 0,
+    entryCount: 0,
+    robotCount: 0,
+    docCount: 0,
+  }
+  const start = performance.now()
+
+  const rawRows = []
+  const robots = []
+  const docs = []
+  let summary = null
+  let runsHistory = []
+  let products = []
+  let allImages = []
+
+  const entryPromises = []
+  await tar.t({
+    file: BUNDLE_PATH,
+    onentry: (entry) => {
+      if (!entry.path.startsWith('lv/')) {
+        entry.resume()
+        return
+      }
+      const relPath = entry.path.slice(3)
+      const task = collectEntry(entry).then((buffer) => {
+        if (relPath === 'summary.json') {
+          summary = JSON.parse(buffer.toString('utf8') || '{}')
+          return
+        }
+        if (relPath === 'runs-history.json') {
+          runsHistory = JSON.parse(buffer.toString('utf8') || '[]')
+          return
+        }
+        if (relPath === 'all-products.json') {
+          products = JSON.parse(buffer.toString('utf8') || '[]')
+          return
+        }
+        if (relPath === 'all-images.json') {
+          allImages = JSON.parse(buffer.toString('utf8') || '[]')
+          return
+        }
+        if (relPath === 'items-meta.json') {
+          const meta = JSON.parse(buffer.toString('utf8') || '{}')
+          rawRows.push(...enrichIndexRows(meta))
+          metrics.entryCount = rawRows.length
+          return
+        }
+        if (relPath.startsWith('cache/robots/') && relPath.endsWith('.json')) {
+          try {
+            const payload = JSON.parse(buffer.toString('utf8') || '{}')
+            const host = path.basename(relPath, '.json')
+            const normalized = normalizeRobotEntry(host, payload)
+            if (normalized) {
+              if (!isBannedHost(host)) {
+                robots.push(normalized)
+                metrics.robotCount = robots.length
+              }
+            }
+          } catch (error) {
+            if (logger) logger(`[lv-images] failed to parse robots entry ${relPath}: ${error?.message || error}`)
+          }
+          return
+        }
+        if (relPath.startsWith('cache/sitemaps/') && relPath.endsWith('.json')) {
+          try {
+            const payload = JSON.parse(buffer.toString('utf8') || '{}')
+            const normalized = normalizeDocEntry(relPath.replace('cache/sitemaps/', ''), payload)
+            if (!isBannedHost(normalized.host)) {
+              docs.push(normalized)
+              metrics.docCount = docs.length
+            }
+          } catch (error) {
+            if (logger) logger(`[lv-images] failed to parse cached doc ${relPath}: ${error?.message || error}`)
+          }
+          return
+        }
+      })
+      entryPromises.push(task)
+    },
+  })
+  await Promise.all(entryPromises)
+
+  metrics.parseMs = Math.round(performance.now() - start)
+  const bundleStats = await stat(BUNDLE_PATH)
+  metrics.bundleBytes = bundleStats.size
+
+  const rows = rawRows.filter((row) => !isBannedUrl(row.pageUrl) && !isBannedUrl(row.imageUrl))
+  metrics.entryCount = rows.length
+  const filteredProducts = Array.isArray(products)
+    ? products.filter((product) => !isBannedUrl(product?.pageUrl || product?.url || product?.href))
+    : []
+  const filteredImages = Array.isArray(allImages)
+    ? allImages.filter((image) => !isBannedUrl(image?.pageUrl || image?.url || image?.src))
+    : []
+  const facets = computeFacets(rows)
+  const totals = {
+    items: rows.length,
+    locales: facets.locales.length,
+    productTypes: facets.productTypes.length,
+    heroItems: facets.heroCount,
+    documents: docs.length,
+    robots: robots.length,
+    products: filteredProducts.length,
+    images: filteredImages.length,
+  }
+
+  const meta = {
+    generatedAt: new Date().toISOString(),
+    bundle: {
+      size: metrics.bundleBytes,
+      sha256: await hashFile(BUNDLE_PATH),
+    },
+    summary: sanitizeSummary(summary) || {},
+    totals,
+    runsHistory,
+    robots,
+    docs,
+    products: filteredProducts,
+    images: filteredImages.slice(0, 1000),
+    facets,
+    metrics,
+  }
+
+  const indexPayload = {
+    meta,
+    rows,
+  }
+
+  await writeFile(INDEX_PATH, `${JSON.stringify(indexPayload)}\n`)
+  await writeFile(META_PATH, `${JSON.stringify(meta)}\n`)
+  await writeFile(METRICS_PATH, `${JSON.stringify(metrics)}\n`)
+
+  return { indexPath: INDEX_PATH, metaPath: META_PATH, metricsPath: METRICS_PATH, meta, rows }
+}
+
+async function hashFile(filePath) {
+  const hash = createHash('sha256')
+  const stream = createReadStream(filePath)
+  return new Promise((resolve, reject) => {
+    stream.on('error', reject)
+    hash.on('error', reject)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => {
+      try {
+        resolve(hash.digest('hex'))
+      } catch (error) {
+        reject(error)
+      }
+    })
+  })
+}
+
+export async function cleanIndexCache() {
+  await rm(CACHE_DIR, { recursive: true, force: true })
+}
+
+export const paths = {
+  bundle: BUNDLE_PATH,
+  cache: CACHE_DIR,
+  index: INDEX_PATH,
+  meta: META_PATH,
+  metrics: METRICS_PATH,
+}


### PR DESCRIPTION
## Summary
- add a build-time LV bundle indexer that pulls the LFS archive, streams entries, emits cached JSON + metrics, and now filters banned hosts
- rebuild the lvreport data source and Eleventy template around the baked index with a single-page dashboard and refreshed fresh-arrivals gallery
- ship a new client-side app for search/facets/pagination with queued lazy thumbnails, clickable links, and a rate-limit-safe detail drawer

## Testing
- npm run lint *(fails: missing @eslint/js and rustywind binaries in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1aaacf7748330aa0cb7435baff47e